### PR TITLE
fix: declare pi extension entry for npm installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Fixed
 - Declared the extension entry in `package.json` via `pi.extensions` so `pi install npm:pi-intercom` can discover and load the extension from the npm package.
 
+### Changed
+- Added `pi-package` package metadata and peer dependency declarations for Pi runtime packages used by the extension.
+
 ## [0.1.6] - 2026-04-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+- Declared the extension entry in `package.json` via `pi.extensions` so `pi install npm:pi-intercom` can discover and load the extension from the npm package.
+
 ## [0.1.6] - 2026-04-13
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -4,10 +4,17 @@
   "license": "MIT",
   "type": "module",
   "main": "index.ts",
+  "keywords": [
+    "pi-package"
+  ],
   "pi": {
     "extensions": [
       "./index.ts"
     ]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@sinclair/typebox": "*"
   },
   "dependencies": {
     "tsx": "^4.20.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "license": "MIT",
   "type": "module",
   "main": "index.ts",
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
   "dependencies": {
     "tsx": "^4.20.0"
   }


### PR DESCRIPTION
## Summary
- declare the extension entry in `package.json` via `pi.extensions` so pi can discover it after `pi install npm:pi-intercom`
- add matching changelog notes under `Unreleased`
- keep package metadata cleanup separate in its own follow-up commit

## Why
When pi installs an npm package, it discovers resources through the pi package manifest or convention directories like `extensions/`. This package had a root `index.ts`, but no `pi.extensions` entry, so npm installation could succeed while pi still failed to discover any extension to load.

This also explains why loading the repo locally by path works while the npm install flow does not: the explicit local-path loader falls back to `index.ts`, but installed package discovery does not.

Fixes #3

## Commits
1. `fix: declare pi extension entry for npm installs` — required bug fix + unreleased changelog entry
2. `chore: add pi package metadata` — optional package metadata cleanup + unreleased changelog entry

## Validation
- verified the package contents with `npm pack --dry-run`
