### PR TITLE
fix: auto-reply in pipe mode instead of aborting on incoming messages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -233,6 +233,20 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     const entry = { from, message, replyCommand, bodyText };
     void (async () => {
       if (!ctx.isIdle()) {
+        // Non-interactive (pipe) mode: cannot interrupt or start new turns.
+        // Best-effort auto-reply to incoming top-level messages (those without
+        // `replyTo`) so the sender isn't left hanging; reply messages are skipped.
+        if (!ctx.hasUI) {
+          if (client && !message.replyTo) {
+            try {
+              await client.send(from.id, {
+                text: "This agent is running in non-interactive (pipe) mode and cannot respond to messages while working. It will complete its current task and exit.",
+                replyTo: message.id,
+              });
+            } catch { /* best-effort */ }
+          }
+          return;
+        }
         const detached = await requestGracefulDetach();
         if (detached) {
           sendIncomingMessage(entry, "trigger");

--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "license": "MIT",
   "type": "module",
   "main": "index.ts",
+  "keywords": ["pi-package"],
+  "pi": {
+    "extensions": ["./index.ts"]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*",
+    "@sinclair/typebox": "*"
+  },
   "dependencies": {
     "tsx": "^4.20.0"
   }


### PR DESCRIPTION
## Problem

When a background (pipe mode) subagent receives an intercom message while busy streaming, the interrupt path in `handleIncomingMessage` calls `ctx.abort()`, which kills the agent's current turn. Pipe mode then exits in its `finally` block, and `session_shutdown` clears the pending message queue before the scheduled `flushInterruptedMessages` can fire. The message is lost, the subagent disconnects from the broker, and the sender's `ask` gets `Failed: Cancelled`.

### Root cause chain

1. `handleIncomingMessage` → `ctx.abort()` (interrupt path)
2. Agent turn ends → pipe mode's `finally` block fires
3. `session_shutdown` runs synchronously: clears `pendingInterruptedMessages`, disconnects client
4. `setTimeout(flushInterruptedMessages, 0)` fires too late — queue empty, client gone
5. Subagent exits. Sender's `waitForReply` never resolves → `Cancelled`

Interactive mode survives because it has a persistent event loop — after abort, it starts a new turn to process the message.

## Fix

Detect non-interactive mode (`ctx.hasUI === false`) before the interrupt path. When a pipe-mode agent is busy:
- For messages without `replyTo` (i.e., `ask` questions or plain `send`): auto-reply explaining the agent can't respond
- For messages with `replyTo` (replies to previous asks): silently skip

This way:
- The sender's `ask` gets a meaningful response instead of hanging
- The subagent continues its task uninterrupted
- No disconnection cascade from the broker

## Testing

1. Spawned a background `pi -p --no-session` with a multi-step task
2. Confirmed it registered with intercom (`intercom list` showed it)
3. From another pi instance, ran `intercom ask` targeting the subagent
4. Got the auto-reply: *"This agent is running in non-interactive (pipe) mode..."*
5. Confirmed the subagent continued running and completed its task
6. Previously this caused `Failed: Cancelled` and killed the subagent's intercom connection