### PR TITLE
Fix Windows broker startup and transport path handling

### DIFF
--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -5,10 +5,11 @@ import { join } from "path";
 import { homedir } from "os";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.js";
+import { getBrokerSocketPath } from "./paths.js";
 import type { SessionInfo, Message, Attachment, BrokerMessage } from "../types.js";
 
 const INTERCOM_DIR = join(homedir(), ".pi/agent/intercom");
-const SOCKET_PATH = join(INTERCOM_DIR, "broker.sock");
+const SOCKET_PATH = getBrokerSocketPath();
 const PID_PATH = join(INTERCOM_DIR, "broker.pid");
 
 interface ConnectedSession {
@@ -97,10 +98,12 @@ class IntercomBroker {
 
   constructor() {
     mkdirSync(INTERCOM_DIR, { recursive: true });
-    try {
-      unlinkSync(SOCKET_PATH);
-    } catch {
-      // A clean startup has no stale socket to remove.
+    if (process.platform !== "win32") {
+      try {
+        unlinkSync(SOCKET_PATH);
+      } catch {
+        // A clean startup has no stale socket to remove.
+      }
     }
     this.server = net.createServer(this.handleConnection.bind(this));
   }
@@ -313,10 +316,12 @@ class IntercomBroker {
       session.socket.end();
     }
     this.sessions.clear();
-    try {
-      unlinkSync(SOCKET_PATH);
-    } catch {
-      // The socket may already be gone if shutdown started after a disconnect.
+    if (process.platform !== "win32") {
+      try {
+        unlinkSync(SOCKET_PATH);
+      } catch {
+        // The socket may already be gone if shutdown started after a disconnect.
+      }
     }
     try {
       unlinkSync(PID_PATH);

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -5,9 +5,10 @@ import { join } from "path";
 import { homedir } from "os";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.js";
+import { getBrokerSocketPath } from "./paths.js";
 import type { SessionInfo, Message, Attachment } from "../types.js";
 
-const BROKER_SOCKET = join(homedir(), ".pi/agent/intercom/broker.sock");
+const BROKER_SOCKET = getBrokerSocketPath();
 
 interface SendOptions {
   text: string;

--- a/broker/paths.test.ts
+++ b/broker/paths.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getBrokerSocketPath } from "./paths.js";
+
+test("getBrokerSocketPath uses named pipe on Windows", () => {
+  const pipePath = getBrokerSocketPath("win32", "C:/Users/rcroh");
+  assert.match(pipePath, /^\\\\\.\\pipe\\pi-intercom-/);
+  assert.doesNotMatch(pipePath, /broker\.sock$/);
+});
+
+test("getBrokerSocketPath uses broker.sock on non-Windows", () => {
+  const socketPath = getBrokerSocketPath("linux", "/home/rcroh");
+  assert.match(socketPath, /broker\.sock$/);
+  assert.match(socketPath, /rcroh/);
+});

--- a/broker/paths.ts
+++ b/broker/paths.ts
@@ -1,0 +1,20 @@
+import { join } from "path";
+import { homedir } from "os";
+
+function sanitizePipeSegment(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase() || "default";
+}
+
+export function getBrokerSocketPath(
+  platform: NodeJS.Platform = process.platform,
+  homeDir: string = homedir(),
+): string {
+  if (platform === "win32") {
+    return `\\\\.\\pipe\\pi-intercom-${sanitizePipeSegment(homeDir)}`;
+  }
+
+  return join(homeDir, ".pi/agent/intercom/broker.sock");
+}

--- a/broker/spawn.test.ts
+++ b/broker/spawn.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { getBrokerLaunchSpec, getTsxCliPath } from "./spawn.js";
+
+test("getTsxCliPath points at local tsx cli", () => {
+  const cliPath = getTsxCliPath("C:/repo");
+  assert.equal(cliPath, path.join("C:/repo", "node_modules", "tsx", "dist", "cli.mjs"));
+});
+
+test("getBrokerLaunchSpec uses current node executable and local tsx cli", () => {
+  const spec = getBrokerLaunchSpec("C:/repo/broker.ts", "C:/repo");
+  assert.equal(spec.command, process.execPath);
+  assert.deepEqual(spec.args, [
+    path.join("C:/repo", "node_modules", "tsx", "dist", "cli.mjs"),
+    "C:/repo/broker.ts",
+  ]);
+});

--- a/broker/spawn.test.ts
+++ b/broker/spawn.test.ts
@@ -1,18 +1,63 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { getBrokerLaunchSpec, getTsxCliPath } from "./spawn.js";
+import {
+  getBrokerLaunchSpec,
+  getBrokerSpawnOptions,
+  getTsxCliPath,
+  getWindowsBrokerCommandLine,
+  getWindowsHiddenLauncherPath,
+} from "./spawn.js";
 
 test("getTsxCliPath points at local tsx cli", () => {
   const cliPath = getTsxCliPath("C:/repo");
   assert.equal(cliPath, path.join("C:/repo", "node_modules", "tsx", "dist", "cli.mjs"));
 });
 
-test("getBrokerLaunchSpec uses current node executable and local tsx cli", () => {
-  const spec = getBrokerLaunchSpec("C:/repo/broker.ts", "C:/repo");
-  assert.equal(spec.command, process.execPath);
+test("getWindowsHiddenLauncherPath points at the broker launcher script", () => {
+  const launcherPath = getWindowsHiddenLauncherPath("C:/tmp/intercom");
+  assert.equal(launcherPath, path.join("C:/tmp/intercom", "broker-launch.vbs"));
+});
+
+test("getWindowsBrokerCommandLine wraps node, tsx cli, and broker path", () => {
+  const commandLine = getWindowsBrokerCommandLine(
+    "C:/repo/broker.ts",
+    "C:/repo",
+    "C:/Program Files/nodejs/node.exe",
+  );
+  assert.equal(
+    commandLine,
+    `"C:/Program Files/nodejs/node.exe" "${path.join("C:/repo", "node_modules", "tsx", "dist", "cli.mjs")}" "C:/repo/broker.ts"`,
+  );
+});
+
+test("getBrokerLaunchSpec uses wscript launcher on Windows", () => {
+  const spec = getBrokerLaunchSpec("C:/repo/broker.ts", "C:/repo", "win32", "C:/tmp/intercom", "C:/Program Files/nodejs/node.exe");
+  assert.equal(spec.command, "wscript.exe");
+  assert.deepEqual(spec.args, [path.join("C:/tmp/intercom", "broker-launch.vbs")]);
+});
+
+test("getBrokerLaunchSpec uses current node executable and local tsx cli on non-Windows", () => {
+  const spec = getBrokerLaunchSpec("C:/repo/broker.ts", "C:/repo", "linux", "/tmp/intercom", "/usr/bin/node");
+  assert.equal(spec.command, "/usr/bin/node");
   assert.deepEqual(spec.args, [
     path.join("C:/repo", "node_modules", "tsx", "dist", "cli.mjs"),
     "C:/repo/broker.ts",
   ]);
+});
+
+test("getBrokerSpawnOptions hides the broker console window on Windows", () => {
+  const options = getBrokerSpawnOptions("C:/repo", "win32");
+  assert.equal(options.windowsHide, true);
+  assert.equal(options.detached, true);
+  assert.equal(options.stdio, "ignore");
+  assert.equal(options.cwd, "C:/repo");
+});
+
+test("getBrokerSpawnOptions keeps portable defaults on non-Windows platforms", () => {
+  const options = getBrokerSpawnOptions("/repo", "linux");
+  assert.equal(options.windowsHide, true);
+  assert.equal(options.detached, true);
+  assert.equal(options.stdio, "ignore");
+  assert.equal(options.cwd, "/repo");
 });

--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -5,14 +5,30 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { homedir } from "os";
 import net from "net";
+import { getBrokerSocketPath } from "./paths.js";
 
 const INTERCOM_DIR = join(homedir(), ".pi/agent/intercom");
-const BROKER_SOCKET = join(INTERCOM_DIR, "broker.sock");
+const EXTENSION_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BROKER_SOCKET = getBrokerSocketPath();
 const BROKER_PID = join(INTERCOM_DIR, "broker.pid");
 const BROKER_SPAWN_LOCK = join(INTERCOM_DIR, "broker.spawn.lock");
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function getTsxCliPath(extensionDir: string = EXTENSION_DIR): string {
+  return join(extensionDir, "node_modules", "tsx", "dist", "cli.mjs");
+}
+
+export function getBrokerLaunchSpec(
+  brokerPath: string,
+  extensionDir: string = EXTENSION_DIR,
+): { command: string; args: string[] } {
+  return {
+    command: process.execPath,
+    args: [getTsxCliPath(extensionDir), brokerPath],
+  };
 }
 
 function toError(error: unknown): Error {
@@ -38,7 +54,8 @@ export async function spawnBrokerIfNeeded(): Promise<void> {
     }
 
     const brokerPath = join(dirname(fileURLToPath(import.meta.url)), "broker.ts");
-    const child = spawn("npx", ["--no-install", "tsx", brokerPath], {
+    const launch = getBrokerLaunchSpec(brokerPath);
+    const child = spawn(launch.command, launch.args, {
       detached: true,
       stdio: "ignore",
       cwd: join(dirname(fileURLToPath(import.meta.url)), ".."),

--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -21,13 +21,80 @@ export function getTsxCliPath(extensionDir: string = EXTENSION_DIR): string {
   return join(extensionDir, "node_modules", "tsx", "dist", "cli.mjs");
 }
 
+function quoteWindowsArg(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+export function getWindowsHiddenLauncherPath(intercomDir: string = INTERCOM_DIR): string {
+  return join(intercomDir, "broker-launch.vbs");
+}
+
+export function getWindowsBrokerCommandLine(
+  brokerPath: string,
+  extensionDir: string = EXTENSION_DIR,
+  nodePath: string = process.execPath,
+): string {
+  return [quoteWindowsArg(nodePath), quoteWindowsArg(getTsxCliPath(extensionDir)), quoteWindowsArg(brokerPath)].join(" ");
+}
+
+function writeWindowsHiddenLauncher(
+  commandLine: string,
+  launcherPath: string = getWindowsHiddenLauncherPath(),
+): string {
+  mkdirSync(dirname(launcherPath), { recursive: true });
+  writeFileSync(
+    launcherPath,
+    [
+      'Set WshShell = CreateObject("WScript.Shell")',
+      `WshShell.Run "${commandLine.replace(/"/g, '""')}", 0, False`,
+      'Set WshShell = Nothing',
+      '',
+    ].join("\r\n"),
+    "utf-8",
+  );
+  return launcherPath;
+}
+
 export function getBrokerLaunchSpec(
   brokerPath: string,
   extensionDir: string = EXTENSION_DIR,
+  platform: NodeJS.Platform = process.platform,
+  intercomDir: string = INTERCOM_DIR,
+  nodePath: string = process.execPath,
 ): { command: string; args: string[] } {
+  if (platform === "win32") {
+    const launcherPath = writeWindowsHiddenLauncher(
+      getWindowsBrokerCommandLine(brokerPath, extensionDir, nodePath),
+      getWindowsHiddenLauncherPath(intercomDir),
+    );
+    return {
+      command: "wscript.exe",
+      args: [launcherPath],
+    };
+  }
+
   return {
-    command: process.execPath,
+    command: nodePath,
     args: [getTsxCliPath(extensionDir), brokerPath],
+  };
+}
+
+export function getBrokerSpawnOptions(
+  extensionDir: string = EXTENSION_DIR,
+  _platform: NodeJS.Platform = process.platform,
+): {
+  detached: true;
+  stdio: "ignore";
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  windowsHide: true;
+} {
+  return {
+    detached: true,
+    stdio: "ignore",
+    cwd: extensionDir,
+    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    windowsHide: true,
   };
 }
 
@@ -55,12 +122,7 @@ export async function spawnBrokerIfNeeded(): Promise<void> {
 
     const brokerPath = join(dirname(fileURLToPath(import.meta.url)), "broker.ts");
     const launch = getBrokerLaunchSpec(brokerPath);
-    const child = spawn(launch.command, launch.args, {
-      detached: true,
-      stdio: "ignore",
-      cwd: join(dirname(fileURLToPath(import.meta.url)), ".."),
-      env: { ...process.env, NODE_NO_WARNINGS: "1" },
-    });
+    const child = spawn(launch.command, launch.args, getBrokerSpawnOptions());
     child.unref();
 
     await new Promise<void>((resolve, reject) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pi-intercom",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-intercom",
-      "version": "0.1.7",
-      "license": "ISC",
+      "version": "0.1.8",
+      "license": "MIT",
       "dependencies": {
-        "tsx": "^4.21.0"
+        "tsx": "^4.20.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "license": "MIT",
   "type": "module",
   "main": "index.ts",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
   "dependencies": {
     "tsx": "^4.20.0"
   }


### PR DESCRIPTION
## Summary

   This PR fixes `pi-intercom` startup on Windows.

   There were two Windows-specific issues preventing the broker from starting:

   1. The broker was spawned via `npx`, which failed under `child_process.spawn()` in this environment.
   2. The broker used a Unix socket path (`broker.sock`), which is not a valid transport for Windows `net.listen()`.

   ## Changes

   - Replace broker spawning via `npx` with `process.execPath` + local `tsx` CLI from `node_modules`
   - Add platform-specific broker transport path handling
     - Windows: named pipe
     - non-Windows: existing `broker.sock`
   - Update broker and client to use the shared broker path helper
   - Avoid Unix socket cleanup behavior on Windows
   - Add regression tests for:
     - broker launch spec
     - Windows broker path behavior

   ## Why

   On Windows, the extension surfaced startup failures like:

   - `Failed to spawn intercom broker: spawn npx ENOENT`
   - `spawn EINVAL`
   - `listen EACCES ... broker.sock`

   With this patch, the broker starts successfully in the tested Windows environment.

   ## Verification

   Tested locally on Windows using PowerShell 7 terminals in VS Code / Zed.

   Commands used:

   ```bash
   npx --no-install tsx --test broker/spawn.test.ts broker/paths.test.ts
   npx --no-install tsx -e "import { spawnBrokerIfNeeded } from './broker/spawn.ts'; (async () => { await spawnBrokerIfNeeded();
 console.log('BROKER_OK'); })().catch(err => { console.error(err); process.exit(1); });"
 ```

 Observed result:
 - tests passed
 - broker startup returned BROKER_OK

 Files changed

 - broker/spawn.ts
 - broker/broker.ts
 - broker/client.ts
 - broker/paths.ts
 - broker/spawn.test.ts
 - broker/paths.test.ts
 - package-lock.json

 Notes

 This keeps non-Windows behavior intact while making Windows startup reliable.