### PR TITLE
feat(config): make broker command configurable

### DIFF
--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -70,6 +70,8 @@ function writeWindowsHiddenLauncher(
 
 export function getBrokerLaunchSpec(
   brokerPath: string,
+  brokerCommand: string,
+  brokerArgs: string[],
   extensionDir: string = EXTENSION_DIR,
   platform: NodeJS.Platform = process.platform,
   intercomDir: string = INTERCOM_DIR,
@@ -88,8 +90,8 @@ export function getBrokerLaunchSpec(
 
   return {
     kind: "direct",
-    command: "npx",
-    args: ["--no-install", "tsx", brokerPath],
+    command: brokerCommand,
+    args: [...brokerArgs, brokerPath],
   };
 }
 
@@ -113,7 +115,7 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-export async function spawnBrokerIfNeeded(): Promise<void> {
+export async function spawnBrokerIfNeeded(brokerCommand: string, brokerArgs: string[]): Promise<void> {
   mkdirSync(INTERCOM_DIR, { recursive: true });
 
   if (await isBrokerRunning()) {
@@ -132,7 +134,7 @@ export async function spawnBrokerIfNeeded(): Promise<void> {
     }
 
     const brokerPath = join(dirname(fileURLToPath(import.meta.url)), "broker.ts");
-    const launch = getBrokerLaunchSpec(brokerPath);
+    const launch = getBrokerLaunchSpec(brokerPath, brokerCommand, brokerArgs);
     if (launch.kind === "windows-launcher") {
       writeWindowsHiddenLauncher(launch.launcherCommandLine, launch.launcherPath);
     }

--- a/config.ts
+++ b/config.ts
@@ -3,6 +3,12 @@ import { join } from "path";
 import { homedir } from "os";
 
 export interface IntercomConfig {
+  /** Broker command used to spawn the broker process (e.g. "npx" or "bun") */
+  brokerCommand: string;
+
+  /** Arguments passed to the broker command before the broker script path */
+  brokerArgs: string[];
+
   /** Require confirmation before non-reply sends from interactive sessions */
   confirmSend: boolean;
 
@@ -19,6 +25,8 @@ export interface IntercomConfig {
 const CONFIG_PATH = join(homedir(), ".pi/agent/intercom/config.json");
 
 const defaults: IntercomConfig = {
+  brokerCommand: "npx",
+  brokerArgs: ["--no-install", "tsx"],
   confirmSend: false,
   enabled: true,
   replyHint: true,
@@ -38,6 +46,25 @@ export function loadConfig(): IntercomConfig {
 
     const parsedConfig = parsed as Record<string, unknown>;
     const config: IntercomConfig = { ...defaults };
+
+    if (Object.hasOwn(parsedConfig, "brokerCommand")) {
+      if (typeof parsedConfig.brokerCommand !== "string") {
+        throw new Error(`"brokerCommand" must be a string`);
+      }
+      config.brokerCommand = parsedConfig.brokerCommand as string;
+    }
+
+    if (Object.hasOwn(parsedConfig, "brokerArgs")) {
+      if (!Array.isArray(parsedConfig.brokerArgs)) {
+        throw new Error(`"brokerArgs" must be an array`);
+      }
+      for (const arg of parsedConfig.brokerArgs) {
+        if (typeof arg !== "string") {
+          throw new Error(`"brokerArgs" items must be strings`);
+        }
+      }
+      config.brokerArgs = parsedConfig.brokerArgs as string[];
+    }
 
     if (Object.hasOwn(parsedConfig, "confirmSend")) {
       if (typeof parsedConfig.confirmSend !== "boolean") {

--- a/index.ts
+++ b/index.ts
@@ -661,7 +661,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       client = nextClient;
       attachClientHandlers(nextClient);
       try {
-        await spawnBrokerIfNeeded();
+        await spawnBrokerIfNeeded(config.brokerCommand, config.brokerArgs);
         await nextClient.connect(buildRegistration());
         if (shuttingDown) {
           await nextClient.disconnect();


### PR DESCRIPTION
Allows users to specify a custom broker runtime (e.g. "bun" instead of "npx") and its arguments via config.