### PR TITLE
fix: use @earendil-works Pi runtime packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+- Switched Pi runtime imports and peer dependencies from the deprecated `@mariozechner/*` packages to `@earendil-works/*` so `pi install npm:pi-intercom` no longer pulls deprecated package warnings.
+
 ## [0.6.0] - 2026-05-03
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { randomUUID } from "crypto";
 import { Type } from "typebox";
-import { Text } from "@mariozechner/pi-tui";
+import { Text } from "@earendil-works/pi-tui";
 import { IntercomClient } from "./broker/client.ts";
 import { spawnBrokerIfNeeded } from "./broker/spawn.ts";
 import { SessionListOverlay } from "./ui/session-list.ts";

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     ]
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "dependencies": {
     "tsx": "^4.20.0",

--- a/test/inline-message.test.ts
+++ b/test/inline-message.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { visibleWidth } from "@mariozechner/pi-tui";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { InlineMessageComponent } from "../ui/inline-message.ts";
 import type { Message, SessionInfo } from "../types.ts";
 

--- a/ui/compose.ts
+++ b/ui/compose.ts
@@ -1,6 +1,6 @@
-import type { Component, TUI } from "@mariozechner/pi-tui";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import type { KeybindingsManager, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import type { IntercomClient } from "../broker/client.js";
 import type { SessionInfo } from "../types.js";
 

--- a/ui/inline-message.ts
+++ b/ui/inline-message.ts
@@ -1,6 +1,6 @@
-import type { Component } from "@mariozechner/pi-tui";
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
-import type { Theme } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { SessionInfo, Message } from "../types.js";
 
 export class InlineMessageComponent implements Component {

--- a/ui/session-list.ts
+++ b/ui/session-list.ts
@@ -1,6 +1,6 @@
-import type { Component } from "@mariozechner/pi-tui";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import type { KeybindingsManager, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import type { SessionInfo } from "../types.js";
 
 function middleTruncate(text: string, maxWidth: number): string {


### PR DESCRIPTION
## Summary
- switch runtime imports from deprecated `@mariozechner/*` packages to `@earendil-works/*`
- update peer dependencies so `pi install npm:pi-intercom` no longer auto-installs the deprecated Pi packages
- add an unreleased changelog note for the install warning cleanup

## Validation
- `npm test`
- `npm pack --pack-destination .tmp-pack && npm install ./pi-intercom-0.6.0.tgz` in a clean temp project to confirm the deprecated `@mariozechner/*` warnings are gone

Note: `node-domexception` still warns during install because it currently comes transitively from `@earendil-works/pi-coding-agent` via `@google/genai`, not from pi-intercom itself.