### PR TITLE
Add optional fork handler runtime integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,13 @@ Create `~/.pi/agent/intercom/config.json`:
   "confirmSend": false,
   "enabled": true,
   "replyHint": true,
-  "status": "researching"
+  "status": "researching",
+  "inboundForkHandlers": {
+    "enabled": true,
+    "when": "always",
+    "notify": "ack-and-summary",
+    "triggerParentOnSummary": false
+  }
 }
 ```
 
@@ -380,6 +386,15 @@ Create `~/.pi/agent/intercom/config.json`:
 | `enabled` | true | Enable/disable intercom entirely |
 | `replyHint` | true | Include reply instruction in incoming messages |
 | `status` | — | Optional custom status suffix shown after the automatic lifecycle status, for example `thinking · researching` |
+| `inboundForkHandlers.enabled` | true | Route inbound messages to background sibling Pi handlers instead of interrupting/queuing in the parent; set false to opt out |
+| `inboundForkHandlers.when` | `"always"` | Fork all inbound messages by default; set `"busy"` to fork only while the parent is busy |
+| `inboundForkHandlers.notify` | `"ack-and-summary"` | Parent notification mode: `"ack-and-summary"`, `"summary"`, or `"none"` |
+| `inboundForkHandlers.piCommand` | — | Optional Pi executable override for handler launch; `PI_INTERCOM_PI_BIN` also works |
+| `inboundForkHandlers.triggerParentOnSummary` | false | Trigger a parent turn when the handler summary arrives instead of display-only delivery |
+
+Inbound fork handlers are delegated triage sessions. They receive the inbound message capsule, may answer directly when safe and derivable, and should escalate only for destructive actions, ambiguous user preference, external side effects, security/privacy/cost risk, conflict with parent work, or low confidence. For `ask` messages, handlers are instructed to reply with `intercom.send` plus the original `replyTo` id when safe so the sender is unblocked without waking the parent. Handler sessions advertise a `fork-handler:<id>` status tag, and messages from those sessions bypass default fork routing so true parent escalations reach the parent instead of spawning another handler. Local subagent result/control relays also use this path when possible and otherwise fall back to display-only delivery rather than starting a parent turn.
+
+Use `/intercom-handlers [running|complete|failed|all]` to inspect persisted handler runs under `~/.local/state/pi-intercom/handlers/`.
 
 For example, if you have Bun installed and want it to start the broker directly, use:
 

--- a/config.ts
+++ b/config.ts
@@ -2,6 +2,23 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
+export interface InboundForkHandlersConfig {
+  /** Route inbound intercom messages to background fork handlers (default: true) */
+  enabled: boolean;
+
+  /** When to fork: only while parent is busy, or for all inbound messages */
+  when: "busy" | "always";
+
+  /** Parent notification policy for launched handlers */
+  notify: "ack-and-summary" | "summary" | "none";
+
+  /** Optional Pi executable override for handler launch */
+  piCommand?: string;
+
+  /** Trigger a parent turn when the handler summary arrives (default: false) */
+  triggerParentOnSummary: boolean;
+}
+
 export interface IntercomConfig {
   /** Broker command used to spawn the broker process (e.g. "npx" or "bun") */
   brokerCommand: string;
@@ -20,6 +37,9 @@ export interface IntercomConfig {
   
   /** Show reply hint in incoming messages (default: true) */
   replyHint: boolean;
+
+  /** Optional inbound background fork-handler routing */
+  inboundForkHandlers: InboundForkHandlersConfig;
 }
 
 const CONFIG_PATH = join(homedir(), ".pi/agent/intercom/config.json");
@@ -30,6 +50,12 @@ const defaults: IntercomConfig = {
   confirmSend: false,
   enabled: true,
   replyHint: true,
+  inboundForkHandlers: {
+    enabled: true,
+    when: "always",
+    notify: "ack-and-summary",
+    triggerParentOnSummary: false,
+  },
 };
 
 export function loadConfig(): IntercomConfig {
@@ -98,6 +124,35 @@ export function loadConfig(): IntercomConfig {
         throw new Error(`"status" must be a string`);
       }
       config.status = parsedConfig.status;
+    }
+
+    if (Object.hasOwn(parsedConfig, "inboundForkHandlers")) {
+      if (typeof parsedConfig.inboundForkHandlers !== "object" || parsedConfig.inboundForkHandlers === null || Array.isArray(parsedConfig.inboundForkHandlers)) {
+        throw new Error(`"inboundForkHandlers" must be an object`);
+      }
+      const forkConfig = parsedConfig.inboundForkHandlers as Record<string, unknown>;
+      config.inboundForkHandlers = { ...defaults.inboundForkHandlers };
+      if (Object.hasOwn(forkConfig, "enabled")) {
+        if (typeof forkConfig.enabled !== "boolean") throw new Error(`"inboundForkHandlers.enabled" must be a boolean`);
+        config.inboundForkHandlers.enabled = forkConfig.enabled;
+      }
+      if (Object.hasOwn(forkConfig, "when")) {
+        if (forkConfig.when !== "busy" && forkConfig.when !== "always") throw new Error(`"inboundForkHandlers.when" must be "busy" or "always"`);
+        config.inboundForkHandlers.when = forkConfig.when;
+      }
+      if (Object.hasOwn(forkConfig, "notify")) {
+        if (forkConfig.notify !== "ack-and-summary" && forkConfig.notify !== "summary" && forkConfig.notify !== "none") throw new Error(`"inboundForkHandlers.notify" must be "ack-and-summary", "summary", or "none"`);
+        config.inboundForkHandlers.notify = forkConfig.notify;
+      }
+      if (Object.hasOwn(forkConfig, "piCommand")) {
+        if (typeof forkConfig.piCommand !== "string") throw new Error(`"inboundForkHandlers.piCommand" must be a string`);
+        const piCommand = forkConfig.piCommand.trim();
+        if (piCommand) config.inboundForkHandlers.piCommand = piCommand;
+      }
+      if (Object.hasOwn(forkConfig, "triggerParentOnSummary")) {
+        if (typeof forkConfig.triggerParentOnSummary !== "boolean") throw new Error(`"inboundForkHandlers.triggerParentOnSummary" must be a boolean`);
+        config.inboundForkHandlers.triggerParentOnSummary = forkConfig.triggerParentOnSummary;
+      }
     }
 
     return config;

--- a/fork-handler.test.ts
+++ b/fork-handler.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildIntercomForkHandlerPrompt, buildIntercomForkHandlerSystemPrompt, type IntercomForkHandlerRun, type InboundForkMessageEntry } from "./fork-handler.ts";
+
+function makeRun(): IntercomForkHandlerRun {
+  return {
+    id: "icfh_test",
+    eventId: "intercom_msg-1",
+    messageId: "msg-1",
+    from: "worker",
+    status: "starting",
+    cwd: "/tmp/project",
+    dir: "/tmp/pi-intercom/handlers/icfh_test",
+    eventPath: "/tmp/pi-intercom/handlers/icfh_test/event.json",
+    promptPath: "/tmp/pi-intercom/handlers/icfh_test/prompt.md",
+    stdoutPath: "/tmp/pi-intercom/handlers/icfh_test/stdout.log",
+    stderrPath: "/tmp/pi-intercom/handlers/icfh_test/stderr.log",
+    sessionDir: "/tmp/pi-intercom/handlers/icfh_test/sessions",
+    startedAt: 1,
+  };
+}
+
+function makeEntry(expectsReply: boolean): InboundForkMessageEntry {
+  return {
+    from: {
+      id: "session-worker",
+      name: "worker",
+      cwd: "/tmp/project",
+      model: "test-model",
+      pid: 123,
+      startedAt: 1,
+      lastActivity: 2,
+      status: "thinking",
+    },
+    message: {
+      id: "msg-1",
+      timestamp: 2,
+      expectsReply,
+      content: { text: expectsReply ? "Can I proceed?" : "FYI: build finished" },
+    },
+    replyCommand: expectsReply ? "intercom({ action: \"reply\", message: \"...\" })" : undefined,
+    bodyText: expectsReply ? "Can I proceed?" : "FYI: build finished",
+  };
+}
+
+test("ask fork handler prompt tells handler to answer with replyTo and delegated authority", () => {
+  const prompt = buildIntercomForkHandlerPrompt(makeEntry(true), makeRun(), JSON.stringify({ type: "intercom.ask" }, null, 2));
+  assert.match(prompt, /sender is blocked waiting/i);
+  assert.match(prompt, /replyTo: "msg-1"/);
+  assert.match(prompt, /delegated authority/i);
+  assert.match(prompt, /Escalate only for destructive actions/i);
+});
+
+test("send fork handler prompt treats non-blocking messages as async summaries", () => {
+  const prompt = buildIntercomForkHandlerPrompt(makeEntry(false), makeRun(), JSON.stringify({ type: "intercom.message" }, null, 2));
+  assert.match(prompt, /non-blocking intercom send/i);
+  assert.match(prompt, /summarize only what matters/i);
+});
+
+test("system prompt constrains fork handler to the intercom event capsule", () => {
+  const prompt = buildIntercomForkHandlerSystemPrompt(makeRun());
+  assert.match(prompt, /only task is to handle the inbound intercom event capsule/i);
+  assert.match(prompt, /Do not continue unrelated inherited parent work/i);
+  assert.match(prompt, /answer directly with intercom.send \+ replyTo/i);
+});

--- a/fork-handler.ts
+++ b/fork-handler.ts
@@ -1,0 +1,352 @@
+import * as fsp from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { buildForkHandlerEnv, buildForkRunPaths, buildPiForkArgs, getForkHandlersFile, launchDetachedFork, readOptionalText, truncateText, writeJsonAtomic } from "./fork-runtime.ts";
+import type { Message, SessionInfo } from "./types.ts";
+
+const HANDLER_MESSAGE_TYPE = "intercom_fork_handler";
+const HANDLERS_FILE = getForkHandlersFile("intercom");
+const HANDLER_SUMMARY_LIMIT_BYTES = 24 * 1024;
+
+export type InboundForkWhen = "busy" | "always";
+export type InboundForkNotify = "ack-and-summary" | "summary" | "none";
+
+export interface InboundForkHandlersConfig {
+  enabled: boolean;
+  when: InboundForkWhen;
+  notify: InboundForkNotify;
+  piCommand?: string;
+  triggerParentOnSummary: boolean;
+}
+
+export interface InboundForkMessageEntry {
+  from: SessionInfo;
+  message: Message;
+  replyCommand?: string;
+  bodyText: string;
+}
+
+export interface IntercomForkHandlerRun {
+  id: string;
+  eventId: string;
+  messageId: string;
+  from: string;
+  status: "starting" | "running" | "complete" | "failed";
+  pid?: number;
+  cwd: string;
+  parentSessionFile?: string;
+  forkSessionFile?: string;
+  parentSessionId?: string;
+  parentSessionName?: string;
+  dir: string;
+  eventPath: string;
+  promptPath: string;
+  stdoutPath: string;
+  stderrPath: string;
+  sessionDir: string;
+  startedAt: number;
+  endedAt?: number;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  summary?: string;
+  error?: string;
+}
+
+let handlerRuns: IntercomForkHandlerRun[] = [];
+
+async function loadHandlers(): Promise<void> {
+  try {
+    const raw = await fsp.readFile(HANDLERS_FILE, "utf8");
+    const parsed = JSON.parse(raw) as { runs?: IntercomForkHandlerRun[] };
+    handlerRuns = Array.isArray(parsed.runs) ? parsed.runs : [];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      handlerRuns = [];
+      return;
+    }
+    throw error;
+  }
+}
+
+async function saveHandlers(): Promise<void> {
+  handlerRuns = handlerRuns.slice(-200);
+  await writeJsonAtomic(HANDLERS_FILE, { runs: handlerRuns });
+}
+
+function shortId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 12) || randomBytes(3).toString("hex");
+}
+
+function makeHandlerId(message: Message): string {
+  return `icfh_${Date.now().toString(36)}_${shortId(message.id)}_${randomBytes(2).toString("hex")}`;
+}
+
+function getSessionFile(ctx: ExtensionContext): string | undefined {
+  const manager = ctx.sessionManager as unknown as { getSessionFile?: () => string | undefined; getSessionId?: () => string | undefined };
+  try {
+    return manager.getSessionFile?.();
+  } catch {
+    return undefined;
+  }
+}
+
+function getSessionId(ctx: ExtensionContext): string | undefined {
+  const manager = ctx.sessionManager as unknown as { getSessionId?: () => string | undefined };
+  try {
+    return manager.getSessionId?.();
+  } catch {
+    return undefined;
+  }
+}
+
+function getParentSessionName(pi: ExtensionAPI): string | undefined {
+  try {
+    return pi.getSessionName?.();
+  } catch {
+    return undefined;
+  }
+}
+
+function buildEventPayload(entry: InboundForkMessageEntry, run: IntercomForkHandlerRun, ctx: ExtensionContext, pi: ExtensionAPI) {
+  return {
+    version: 1,
+    type: entry.message.expectsReply ? "intercom.ask" : "intercom.message",
+    id: run.eventId,
+    source: "pi-intercom",
+    createdAt: run.startedAt,
+    cwd: ctx.cwd ?? process.cwd(),
+    parentSessionFile: run.parentSessionFile,
+    parentSessionId: run.parentSessionId,
+    parentSessionName: run.parentSessionName,
+    parentIntercomTarget: getParentSessionName(pi),
+    payload: {
+      messageId: entry.message.id,
+      replyTo: entry.message.replyTo,
+      expectsReply: entry.message.expectsReply === true,
+      from: entry.from,
+      bodyText: entry.bodyText,
+      content: entry.message.content,
+      timestamp: entry.message.timestamp,
+    },
+    authority: {
+      mode: "delegated",
+      mayAnswerWhenDerivable: true,
+      escalateOn: [
+        "destructive-action",
+        "ambiguous-user-preference",
+        "external-side-effect",
+        "security-privacy-cost-risk",
+        "parent-work-conflict",
+        "low-confidence",
+      ],
+    },
+  };
+}
+
+export function buildIntercomForkHandlerPrompt(entry: InboundForkMessageEntry, run: IntercomForkHandlerRun, eventJson: string): string {
+  const senderTarget = entry.from.name || entry.from.id;
+  const replyGuidance = entry.message.expectsReply
+    ? [
+      "The sender is blocked waiting for an answer.",
+      `If the answer is safe and derivable, reply directly with: intercom({ action: "send", to: ${JSON.stringify(senderTarget)}, message: "...", replyTo: ${JSON.stringify(entry.message.id)} })`,
+      "If you cannot safely answer, escalate to the parent with the smallest concrete question; do not do unrelated work while the sender is waiting.",
+    ]
+    : [
+      "This is a non-blocking intercom send. Handle it asynchronously and summarize only what matters.",
+      `If useful, respond with intercom({ action: "send", to: ${JSON.stringify(senderTarget)}, message: "..." }).`,
+    ];
+  return [
+    "You are a background pi-intercom handler running in a sibling Pi session.",
+    "The parent chat is busy and should stay undistracted unless a real decision is needed.",
+    "Handle only the inbound intercom event capsule supplied here; do not continue unrelated inherited parent work.",
+    "",
+    "Delegated authority:",
+    "- Answer or act directly when the response is derivable from the inbound message, inherited context, repo files, local artifacts, or prior user instructions.",
+    "- Escalate only for destructive actions, ambiguous user preference, external side effects, security/privacy/cost risk, conflict with parent work, or low confidence.",
+    "- Use intercom.send for non-blocking notices. Use intercom.ask only for true blocking parent decisions.",
+    "- Keep any parent escalation brief and include the handler id.",
+    "",
+    ...replyGuidance,
+    "",
+    `Handler id: ${run.id}`,
+    `Event JSON path: ${run.eventPath}`,
+    "",
+    "Intercom event payload:",
+    "```json",
+    eventJson,
+    "```",
+    "",
+    "Final response: provide a concise audit summary of what you did, what you replied/escalated, and whether parent follow-up is needed.",
+  ].join("\n");
+}
+
+export function buildIntercomForkHandlerSystemPrompt(run: IntercomForkHandlerRun): string {
+  return [
+    "You are a background pi-intercom handler in a sibling Pi process.",
+    "Your only task is to handle the inbound intercom event capsule supplied in the latest user message.",
+    "Do not continue unrelated inherited parent work. Treat inherited conversation as context only.",
+    "You have delegated authority to answer or act when safe and derivable.",
+    "Escalate only for destructive actions, ambiguous user preference, external side effects, security/privacy/cost risk, conflict with parent work, or low confidence.",
+    "For intercom asks, answer directly with intercom.send + replyTo when safe; otherwise escalate quickly.",
+    `Handler id: ${run.id}`,
+  ].join("\n");
+}
+
+function buildHandlerArgs(run: IntercomForkHandlerRun): string[] {
+  return buildPiForkArgs({
+    sessionDir: run.sessionDir,
+    systemPrompt: buildIntercomForkHandlerSystemPrompt(run),
+    promptPath: run.promptPath,
+    forkFile: run.forkSessionFile || run.parentSessionFile,
+  });
+}
+
+function formatAck(run: IntercomForkHandlerRun, entry: InboundForkMessageEntry): string {
+  const sender = entry.from.name || entry.from.id.slice(0, 8);
+  return [
+    `pi-intercom received ${entry.message.expectsReply ? "an ask" : "a message"} from ${sender}.`,
+    `Launched background fork handler ${run.id}${run.pid ? ` (pid ${run.pid})` : ""}.`,
+    `Handler dir: ${run.dir}`,
+  ].join("\n");
+}
+
+function formatSummary(run: IntercomForkHandlerRun): string {
+  const status = run.status === "complete" ? "completed" : "failed";
+  const output = run.summary?.trim() || run.error || "(no handler output)";
+  return [
+    `pi-intercom fork handler ${status}: ${run.id}`,
+    `From: ${run.from}`,
+    `Message: ${run.messageId}`,
+    `Exit: ${run.exitCode ?? "signal " + (run.signal ?? "unknown")}`,
+    `Output: ${run.stdoutPath}`,
+    `Errors: ${run.stderrPath}`,
+    "",
+    truncateText(output, HANDLER_SUMMARY_LIMIT_BYTES),
+  ].join("\n");
+}
+
+async function markHandlerFinished(pi: ExtensionAPI, runId: string, code: number | null, signal: NodeJS.Signals | null, notify: InboundForkNotify, triggerParent: boolean): Promise<void> {
+  await loadHandlers();
+  const run = handlerRuns.find((candidate) => candidate.id === runId);
+  if (!run) return;
+  run.endedAt = Date.now();
+  run.exitCode = code;
+  run.signal = signal;
+  const stdout = await readOptionalText(run.stdoutPath);
+  const stderr = await readOptionalText(run.stderrPath);
+  run.summary = truncateText(stdout.trim() || stderr.trim(), HANDLER_SUMMARY_LIMIT_BYTES);
+  run.status = code === 0 ? "complete" : "failed";
+  if (code !== 0) run.error = stderr.trim() || `handler exited with ${code ?? signal ?? "unknown status"}`;
+  await saveHandlers();
+  try {
+    pi.appendEntry?.("intercom_fork_handler_finished", { id: run.id, status: run.status, messageId: run.messageId, exitCode: code, signal, endedAt: run.endedAt });
+  } catch {
+    // Best effort audit trail.
+  }
+  if (notify === "summary" || notify === "ack-and-summary") {
+    pi.sendMessage(
+      {
+        customType: HANDLER_MESSAGE_TYPE,
+        content: formatSummary(run),
+        display: true,
+        details: { id: run.id, messageId: run.messageId, status: run.status, exitCode: code, signal },
+      },
+      { triggerTurn: triggerParent },
+    );
+  }
+}
+
+export async function launchIntercomForkHandler(pi: ExtensionAPI, ctx: ExtensionContext, entry: InboundForkMessageEntry, config: InboundForkHandlersConfig): Promise<boolean> {
+  await loadHandlers();
+  const id = makeHandlerId(entry.message);
+  const paths = buildForkRunPaths("intercom", id);
+  const run: IntercomForkHandlerRun = {
+    ...paths,
+    eventId: `intercom_${entry.message.id}`,
+    messageId: entry.message.id,
+    from: entry.from.name || entry.from.id,
+    status: "starting",
+    cwd: ctx.cwd ?? process.cwd(),
+    ...(getSessionFile(ctx) ? { parentSessionFile: getSessionFile(ctx) } : {}),
+    ...(getSessionId(ctx) ? { parentSessionId: getSessionId(ctx) } : {}),
+    ...(getParentSessionName(pi) ? { parentSessionName: getParentSessionName(pi) } : {}),
+    startedAt: Date.now(),
+  };
+  const eventJson = JSON.stringify(buildEventPayload(entry, run, ctx, pi), null, 2);
+  await fsp.mkdir(run.sessionDir, { recursive: true });
+  if (run.parentSessionFile) {
+    const snapshotPath = `${run.dir}/parent-session-snapshot.jsonl`;
+    try {
+      await fsp.copyFile(run.parentSessionFile, snapshotPath);
+      run.forkSessionFile = snapshotPath;
+    } catch {
+      // Best effort. If snapshotting fails, fall back to the original session file.
+    }
+  }
+  await fsp.writeFile(run.eventPath, `${eventJson}\n`, "utf8");
+  await fsp.writeFile(run.promptPath, buildIntercomForkHandlerPrompt(entry, run, eventJson), "utf8");
+  handlerRuns.push(run);
+  await saveHandlers();
+
+  const command = config.piCommand || process.env.PI_INTERCOM_PI_BIN || "pi";
+  const args = buildHandlerArgs(run);
+  try {
+    const launch = await launchDetachedFork({
+      command,
+      args,
+      cwd: run.cwd,
+      stdoutPath: run.stdoutPath,
+      stderrPath: run.stderrPath,
+      env: buildForkHandlerEnv("intercom", run.id, {
+        ...process.env,
+        ...(run.parentSessionFile ? { PI_INTERCOM_PARENT_SESSION_FILE: run.parentSessionFile } : {}),
+      }),
+      onClose: (code, signal) => {
+        void markHandlerFinished(pi, run.id, code, signal, config.notify, config.triggerParentOnSummary).catch((error) => {
+          console.error("[pi-intercom] Failed to finish fork handler", error);
+        });
+      },
+    });
+    if (!launch.ok) {
+      await loadHandlers();
+      const failed = handlerRuns.find((candidate) => candidate.id === run.id) ?? run;
+      failed.status = "failed";
+      failed.endedAt = Date.now();
+      failed.error = launch.error instanceof Error ? launch.error.message : String(launch.error);
+      if (!handlerRuns.some((candidate) => candidate.id === run.id)) handlerRuns.push(failed);
+      await saveHandlers();
+      console.error("[pi-intercom] Failed to launch fork handler", launch.error);
+      return false;
+    }
+
+    run.pid = launch.pid;
+    run.status = "running";
+    await saveHandlers();
+    if (config.notify === "ack-and-summary") {
+      pi.sendMessage(
+        {
+          customType: HANDLER_MESSAGE_TYPE,
+          content: formatAck(run, entry),
+          display: true,
+          details: { id: run.id, messageId: entry.message.id, status: "running" },
+        },
+        { triggerTurn: false },
+      );
+    }
+    return true;
+  } catch (error) {
+    run.status = "failed";
+    run.endedAt = Date.now();
+    run.error = error instanceof Error ? error.message : String(error);
+    await saveHandlers();
+    console.error("[pi-intercom] Failed to launch fork handler", error);
+    return false;
+  }
+}
+
+export async function listIntercomForkHandlers(status: "running" | "complete" | "failed" | "all" = "all"): Promise<IntercomForkHandlerRun[]> {
+  await loadHandlers();
+  return handlerRuns
+    .filter((run) => status === "all" || run.status === status)
+    .sort((a, b) => b.startedAt - a.startedAt);
+}

--- a/fork-routing.test.ts
+++ b/fork-routing.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildIntercomStatus, getForkHandlerIdentity, isForkHandlerSession } from "./fork-routing.ts";
+
+test("buildIntercomStatus tags intercom fork handler sessions", () => {
+  assert.equal(
+    buildIntercomStatus("thinking", "reviewing", {
+      PI_INTERCOM_FORK_HANDLER: "1",
+      PI_INTERCOM_FORK_HANDLER_RUN_ID: "icfh_123",
+    }),
+    "thinking · reviewing · fork-handler:intercom:icfh_123",
+  );
+});
+
+test("buildIntercomStatus tags return_on and subagent fork handler sessions", () => {
+  assert.equal(
+    buildIntercomStatus("idle", undefined, {
+      PI_RETURN_ON_HANDLER: "1",
+      PI_RETURN_ON_HANDLER_RUN_ID: "roh_abc",
+    }),
+    "idle · fork-handler:return-on:roh_abc",
+  );
+  assert.equal(
+    buildIntercomStatus("tool:bash", undefined, {
+      PI_SUBAGENT_BACKGROUND_HANDLER: "1",
+      PI_SUBAGENT_BACKGROUND_HANDLER_RUN_ID: "sbf_def",
+    }),
+    "tool:bash · fork-handler:subagent:sbf_def",
+  );
+});
+
+test("getForkHandlerIdentity gives visible fork session names", () => {
+  assert.deepEqual(
+    getForkHandlerIdentity({ PI_SUBAGENT_BACKGROUND_HANDLER: "1", PI_SUBAGENT_BACKGROUND_HANDLER_RUN_ID: "sbf_mp7m9yxl_jqn3ap_async-step-complete" }),
+    {
+      kind: "subagent",
+      runId: "sbf_mp7m9yxl_jqn3ap_async-step-complete",
+      statusTag: "fork-handler:subagent:sbf_mp7m9yxl_jqn3ap_async-step-complete",
+      sessionName: "fork-subagent-mp7m9yxl-jqn3ap",
+    },
+  );
+});
+
+test("isForkHandlerSession detects fork handler status tags", () => {
+  assert.equal(isForkHandlerSession({ status: "thinking · fork-handler:intercom:icfh_123" }), true);
+  assert.equal(isForkHandlerSession({ status: "idle · fork-handler:return-on:roh_abc" }), true);
+  assert.equal(isForkHandlerSession({ status: "idle · researching" }), false);
+  assert.equal(isForkHandlerSession({}), false);
+});

--- a/fork-routing.ts
+++ b/fork-routing.ts
@@ -1,0 +1,19 @@
+import { getForkHandlerIdentity, type ForkHandlerIdentity, type ForkHandlerKind } from "./fork-runtime.ts";
+import type { SessionInfo } from "./types.ts";
+
+export const INTERCOM_FORK_HANDLER_STATUS_TAG = "fork-handler";
+export { getForkHandlerIdentity, type ForkHandlerIdentity, type ForkHandlerKind };
+
+export function buildIntercomStatus(lifecycleStatus: string, customStatus?: string, env: NodeJS.ProcessEnv = process.env): string {
+  const suffixes: string[] = [];
+  const trimmedCustomStatus = customStatus?.trim();
+  if (trimmedCustomStatus) suffixes.push(trimmedCustomStatus);
+  const forkHandler = getForkHandlerIdentity(env);
+  if (forkHandler) suffixes.push(forkHandler.statusTag);
+  return suffixes.length ? `${lifecycleStatus} · ${suffixes.join(" · ")}` : lifecycleStatus;
+}
+
+export function isForkHandlerSession(session: Pick<SessionInfo, "status">): boolean {
+  const status = session.status?.toLowerCase() ?? "";
+  return /(?:^|[\s·])fork-handler(?::|$|[\s·])/.test(status);
+}

--- a/fork-runtime-fallback.ts
+++ b/fork-runtime-fallback.ts
@@ -1,0 +1,106 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+
+export type ForkSource = "intercom" | "return_on" | "subagents";
+export type ForkHandlerKind = "intercom" | "return-on" | "subagent";
+export interface ForkHandlerIdentity { kind: ForkHandlerKind; runId?: string; statusTag: string; sessionName: string }
+
+const SOURCE_STATE_DIR: Record<ForkSource, string> = { intercom: "pi-intercom", return_on: "pi-return-on", subagents: "pi-subagents" };
+const SOURCE_ENV: Record<ForkSource, { flag: string; runId: string }> = {
+  intercom: { flag: "PI_INTERCOM_FORK_HANDLER", runId: "PI_INTERCOM_FORK_HANDLER_RUN_ID" },
+  return_on: { flag: "PI_RETURN_ON_HANDLER", runId: "PI_RETURN_ON_HANDLER_RUN_ID" },
+  subagents: { flag: "PI_SUBAGENT_BACKGROUND_HANDLER", runId: "PI_SUBAGENT_BACKGROUND_HANDLER_RUN_ID" },
+};
+
+function shortForkRunId(runId: string | undefined): string {
+  const cleaned = runId?.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "") ?? "";
+  const withoutPrefix = cleaned.replace(/^(?:icfh|roh|sbf)-?/i, "");
+  const parts = withoutPrefix.split("-").filter(Boolean);
+  const compact = parts.length >= 2 ? parts.slice(0, 2).join("-") : withoutPrefix;
+  return (compact || "handler").slice(0, 24);
+}
+
+export function forkHandlerKind(source: ForkSource): ForkHandlerKind {
+  if (source === "return_on") return "return-on";
+  if (source === "subagents") return "subagent";
+  return "intercom";
+}
+
+export function buildForkIntercomIdentity(source: ForkSource, runId?: string): ForkHandlerIdentity {
+  const kind = forkHandlerKind(source);
+  return { kind, ...(runId ? { runId } : {}), statusTag: runId ? `fork-handler:${kind}:${runId}` : `fork-handler:${kind}`, sessionName: `fork-${kind}-${shortForkRunId(runId)}` };
+}
+
+export function getForkHandlerIdentity(env: NodeJS.ProcessEnv = process.env): ForkHandlerIdentity | undefined {
+  for (const source of ["intercom", "return_on", "subagents"] as const) {
+    const keys = SOURCE_ENV[source];
+    if (env[keys.flag] !== "1") continue;
+    return buildForkIntercomIdentity(source, env[keys.runId]?.trim() || undefined);
+  }
+  return undefined;
+}
+
+export function buildForkHandlerEnv(source: ForkSource, runId: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const keys = SOURCE_ENV[source];
+  return { ...extra, [keys.flag]: "1", [keys.runId]: runId };
+}
+
+export function getForkStateDir(source: ForkSource, homeDir = os.homedir()): string {
+  return path.join(homeDir, ".local", "state", SOURCE_STATE_DIR[source]);
+}
+export function getForkHandlersDir(source: ForkSource, homeDir = os.homedir()): string {
+  return path.join(getForkStateDir(source, homeDir), "handlers");
+}
+export function getForkHandlersFile(source: ForkSource, homeDir = os.homedir()): string {
+  return path.join(getForkStateDir(source, homeDir), "handlers.json");
+}
+export function buildForkRunPaths(source: ForkSource, id: string, homeDir = os.homedir()) {
+  const dir = path.join(getForkHandlersDir(source, homeDir), id);
+  return { id, dir, eventPath: path.join(dir, "event.json"), promptPath: path.join(dir, "prompt.md"), stdoutPath: path.join(dir, "stdout.log"), stderrPath: path.join(dir, "stderr.log"), sessionDir: path.join(dir, "sessions") };
+}
+export function buildPiForkArgs(options: { sessionDir: string; systemPrompt: string; promptPath: string; forkFile?: string }): string[] {
+  const args = ["-p", "--session-dir", options.sessionDir, "--append-system-prompt", options.systemPrompt];
+  if (options.forkFile) args.push("--fork", options.forkFile);
+  args.push(`@${options.promptPath}`);
+  return args;
+}
+export async function readOptionalText(filePath: string): Promise<string> {
+  try { return await fsp.readFile(filePath, "utf8"); } catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return ""; throw error; }
+}
+export function truncateText(value: string, limitBytes: number): string {
+  const buf = Buffer.from(value);
+  return buf.length <= limitBytes ? value : `${buf.subarray(0, limitBytes).toString("utf8")}\n[truncated ${buf.length - limitBytes} bytes]`;
+}
+export async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await fsp.rename(tmp, filePath);
+}
+function closeFdBestEffort(fd: number | undefined): void { if (fd !== undefined) { try { fs.closeSync(fd); } catch {} } }
+export async function launchDetachedFork(options: { command: string; args: string[]; cwd: string; stdoutPath: string; stderrPath: string; env?: NodeJS.ProcessEnv; onClose?: (code: number | null, signal: NodeJS.Signals | null) => void }) {
+  let stdoutFd: number | undefined;
+  let stderrFd: number | undefined;
+  try {
+    stdoutFd = fs.openSync(options.stdoutPath, "a");
+    stderrFd = fs.openSync(options.stderrPath, "a");
+    const child = spawn(options.command, options.args, { cwd: options.cwd, detached: true, env: options.env ?? process.env, stdio: ["ignore", stdoutFd, stderrFd] });
+    closeFdBestEffort(stdoutFd); closeFdBestEffort(stderrFd); stdoutFd = undefined; stderrFd = undefined;
+    child.unref();
+    let launchError: unknown;
+    const spawned = await new Promise<boolean>((resolve) => {
+      const onSpawn = () => { child.off("error", onError); resolve(true); };
+      const onError = (error: Error) => { launchError = error; child.off("spawn", onSpawn); resolve(false); };
+      child.once("spawn", onSpawn); child.once("error", onError);
+    });
+    if (!spawned) return { ok: false as const, error: launchError };
+    if (options.onClose) child.once("close", options.onClose);
+    return { ok: true as const, pid: child.pid };
+  } catch (error) {
+    closeFdBestEffort(stdoutFd); closeFdBestEffort(stderrFd);
+    return { ok: false as const, error };
+  }
+}

--- a/fork-runtime.ts
+++ b/fork-runtime.ts
@@ -1,0 +1,20 @@
+import * as fallback from "./fork-runtime-fallback.ts";
+
+const runtimeModule = "pi-forks/runtime";
+const runtime = await import(runtimeModule)
+  .then((module) => module as typeof fallback)
+  .catch(() => fallback);
+
+export type ForkHandlerIdentity = fallback.ForkHandlerIdentity;
+export type ForkHandlerKind = fallback.ForkHandlerKind;
+export type ForkSource = fallback.ForkSource;
+
+export const buildForkHandlerEnv = runtime.buildForkHandlerEnv;
+export const buildForkRunPaths = runtime.buildForkRunPaths;
+export const buildPiForkArgs = runtime.buildPiForkArgs;
+export const getForkHandlerIdentity = runtime.getForkHandlerIdentity;
+export const getForkHandlersFile = runtime.getForkHandlersFile;
+export const launchDetachedFork = runtime.launchDetachedFork;
+export const readOptionalText = runtime.readOptionalText;
+export const truncateText = runtime.truncateText;
+export const writeJsonAtomic = runtime.writeJsonAtomic;

--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,10 @@ import { SessionListOverlay } from "./ui/session-list.ts";
 import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
 import { InlineMessageComponent } from "./ui/inline-message.ts";
 import { loadConfig, type IntercomConfig } from "./config.ts";
+import { buildIntercomStatus, getForkHandlerIdentity, isForkHandlerSession } from "./fork-routing.ts";
 import type { SessionInfo, Message, Attachment } from "./types.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
+import { launchIntercomForkHandler, listIntercomForkHandlers } from "./fork-handler.ts";
 
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
@@ -381,6 +383,15 @@ function buildPresenceIdentity(pi: ExtensionAPI, sessionId: string): { name: str
     name: resolveIntercomPresenceName(pi.getSessionName(), sessionId),
   };
 }
+function applyForkHandlerSessionName(pi: ExtensionAPI): void {
+  const forkHandler = getForkHandlerIdentity();
+  if (!forkHandler) return;
+  try {
+    pi.setSessionName?.(forkHandler.sessionName);
+  } catch {
+    // Best effort only; presence status still advertises fork-handler identity.
+  }
+}
 function formatSessionLabel(session: SessionInfo, duplicates: Set<string>): string {
   if (!session.name) {
     return session.id;
@@ -410,6 +421,7 @@ function firstTextContent(result: { content?: Array<{ type: string; text?: strin
   return result.content?.find((item) => item.type === "text" && typeof item.text === "string")?.text?.replace(/\*\*/g, "") ?? "";
 }
 export default function piIntercomExtension(pi: ExtensionAPI) {
+  applyForkHandlerSessionName(pi);
   let client: IntercomClient | null = null;
   const config: IntercomConfig = loadConfig();
   let runtimeContext: ExtensionContext | null = null;
@@ -530,7 +542,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   function currentStatus(): string {
     const activeToolName = activeTools.values().next().value;
     const lifecycleStatus = activeToolName ? `tool:${activeToolName}` : agentRunning ? "thinking" : "idle";
-    return config.status ? `${lifecycleStatus} · ${config.status}` : lifecycleStatus;
+    return buildIntercomStatus(lifecycleStatus, config.status);
   }
   function buildRegistration(): Omit<SessionInfo, "id"> {
     const liveContext = getLiveContext();
@@ -636,6 +648,26 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     pendingIdleMessages.push(entry);
     scheduleInboundFlush();
   }
+  async function maybeLaunchInboundForkHandler(ctx: ExtensionContext, entry: InboundMessageEntry, parentIsBusy: boolean): Promise<boolean> {
+    if (process.env.PI_INTERCOM_FORK_HANDLER === "1") return false;
+    if (!config.inboundForkHandlers.enabled) return false;
+    if (config.inboundForkHandlers.when === "busy" && !parentIsBusy) return false;
+    try {
+      const launched = await launchIntercomForkHandler(pi, ctx, entry, config.inboundForkHandlers);
+      if (launched) {
+        pi.appendEntry("intercom_fork_handler_started", {
+          messageId: entry.message.id,
+          from: entry.from.name || entry.from.id,
+          expectsReply: entry.message.expectsReply === true,
+          timestamp: Date.now(),
+        });
+      }
+      return launched;
+    } catch (error) {
+      console.error("[pi-intercom] Failed to route inbound message to fork handler:", error);
+      return false;
+    }
+  }
   function handleIncomingMessage(ctx: ExtensionContext, from: SessionInfo, message: Message): void {
     const messageGeneration = runtimeGeneration;
     const liveContext = getLiveContext(ctx, messageGeneration);
@@ -661,12 +693,21 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       : undefined;
     replyTracker.recordIncomingMessage(from, message);
     const entry = { from, message, replyCommand, bodyText };
+    const fromForkHandler = isForkHandlerSession(from);
     void (async () => {
       const activeContext = getLiveContext(liveContext, messageGeneration);
       if (!activeContext) {
         return;
       }
-      if (!activeContext.isIdle()) {
+      const parentIsBusy = !activeContext.isIdle();
+      if (parentIsBusy) {
+        if (fromForkHandler) {
+          sendIncomingMessage(entry, "trigger", messageGeneration);
+          return;
+        }
+        if (await maybeLaunchInboundForkHandler(activeContext, entry, true)) {
+          return;
+        }
         if (!activeContext.hasUI) {
           const activeClient = client;
           if (!message.replyTo && activeClient?.isConnected()) {
@@ -688,6 +729,9 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         return;
       }
       if (getLiveContext(liveContext, messageGeneration)) {
+        if (!fromForkHandler && await maybeLaunchInboundForkHandler(activeContext, entry, false)) {
+          return;
+        }
         sendIncomingMessage(entry, "trigger", messageGeneration);
       }
     })();
@@ -796,9 +840,9 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     return byName[0]?.id ?? null;
   }
-  function deliverLocalSubagentRelayMessage(sender: "subagent-control" | "subagent-result", status: string, messageText: string): void {
+  async function deliverLocalSubagentRelayMessage(sender: "subagent-control" | "subagent-result", status: string, messageText: string): Promise<void> {
     const now = Date.now();
-    sendIncomingMessage({
+    const entry: InboundMessageEntry = {
       from: {
         id: sender,
         name: sender,
@@ -815,7 +859,20 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         content: { text: messageText },
       },
       bodyText: messageText,
-    }, "trigger");
+    };
+    const ctx = getLiveContext();
+    if (ctx) {
+      let parentIsBusy = true;
+      try {
+        parentIsBusy = !ctx.isIdle();
+      } catch {
+        parentIsBusy = true;
+      }
+      if (await maybeLaunchInboundForkHandler(ctx, entry, parentIsBusy)) {
+        return;
+      }
+    }
+    sendIncomingMessage(entry, "followUp");
   }
   function recordSubagentDeliveryError(entryType: string, to: string, message: string, error: unknown): void {
     pi.appendEntry(entryType, {
@@ -849,7 +906,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         return;
       }
       if (currentSessionTargetMatches(parsed.to)) {
-        deliverLocalSubagentRelayMessage(options.sender, options.status, parsed.message);
+        await deliverLocalSubagentRelayMessage(options.sender, options.status, parsed.message);
         if (options.acknowledge) emitResultDelivery(parsed.requestId, true);
         return;
       }
@@ -870,7 +927,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         return;
       }
       if (currentSessionTargetMatches(parsed.to, target, activeClient)) {
-        deliverLocalSubagentRelayMessage(options.sender, options.status, parsed.message);
+        await deliverLocalSubagentRelayMessage(options.sender, options.status, parsed.message);
         if (options.acknowledge) emitResultDelivery(parsed.requestId, true);
         return;
       }
@@ -908,6 +965,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     });
   });
   pi.on("session_start", (_event, ctx) => {
+    applyForkHandlerSessionName(pi);
     if (!config.enabled) {
       return;
     }
@@ -1317,6 +1375,11 @@ Usage:
   intercom({ action: "status" })                  → Show connection status`,
     promptSnippet:
       "Use to coordinate with other local pi sessions: list peers, send updates, ask for help, or check intercom connectivity.",
+    promptGuidelines: [
+      "intercom({action:'send'}) is non-blocking and returns immediately; intercom({action:'ask'}) blocks the current turn for up to 10 minutes waiting for a reply.",
+      "Only use action:'ask' when you actually need a human/sibling decision before continuing. For polling external state (file appears, process exits, port opens, URL becomes ready), use return_on instead so the turn can end and resume on the signal.",
+      "If you only need to notify a sibling and then keep working, use action:'send' and (if needed) register a return_on watcher on whatever artifact the sibling produces.",
+    ],
 
     parameters: Type.Object({
       action: Type.String({
@@ -1769,6 +1832,19 @@ Usage:
   pi.registerCommand("intercom", {
     description: "Open session intercom overlay",
     handler: async (_args, ctx) => openIntercomOverlay(ctx),
+  });
+
+  pi.registerCommand("intercom-handlers", {
+    description: "List inbound intercom fork handlers: /intercom-handlers [running|complete|failed|all]",
+    handler: async (args, ctx) => {
+      const arg = args.trim();
+      const status: "running" | "complete" | "failed" | "all" = arg === "running" || arg === "complete" || arg === "failed" ? arg : "all";
+      const runs = await listIntercomForkHandlers(status);
+      const lines = runs.length === 0
+        ? ["No intercom fork handlers."]
+        : runs.map((run) => `- ${run.id} · ${run.status} · from ${run.from} · message ${run.messageId} · ${run.dir}`);
+      ctx.ui.notify(lines.join("\n"), "info");
+    },
   });
 
   pi.registerShortcut("alt+m", {

--- a/package.json
+++ b/package.json
@@ -8,13 +8,17 @@
     "index.ts",
     "types.ts",
     "config.ts",
+    "fork-handler.ts",
+    "fork-routing.ts",
+    "fork-runtime.ts",
+    "fork-runtime-fallback.ts",
     "reply-tracker.ts",
     "broker/**/*.ts",
     "ui/**/*.ts",
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts"
+    "test": "tsx --test broker/paths.test.ts broker/spawn.test.ts fork-handler.test.ts fork-routing.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts"
   },
   "keywords": [
     "pi-package"
@@ -29,10 +33,19 @@
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*"
+    "@mariozechner/pi-tui": "*",
+    "pi-forks": "^0.1.0"
+  },
+  "peerDependenciesMeta": {
+    "pi-forks": {
+      "optional": true
+    }
   },
   "dependencies": {
     "tsx": "^4.20.0",
     "typebox": "^1.1.24"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
This squashes the dataforxyz local fork-handler work onto current upstream main.\n\nHighlights:\n- add inbound intercom fork handler delivery\n- name/tag fork handler sessions consistently for discovery\n- expose optional pi-forks runtime integration with a local fallback\n- add prompt guidance to avoid polling/direct waits\n\nValidation note: focused fork-handler/fork-routing tests passed in the dataforxyz branch before rebasing. On this clean branch, test execution in a temporary worktree was blocked by missing local peer/dependency installs.