### PR TITLE
feat: add /intercom-name to sync presence after session rename

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -559,7 +559,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     if (!client || !currentSessionId || !getLiveContext()) {
       return;
     }
-    client.updatePresence({ status: currentStatus() });
+    client.updatePresence({ ...buildPresenceIdentity(pi, currentSessionId), status: currentStatus() });
   }
   function currentSessionTargetMatches(to: string, resolvedTo?: string | null, activeClient?: IntercomClient): boolean {
     const targets = new Set<string>();
@@ -1018,6 +1018,24 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         status: currentStatus(),
       });
     }
+  });
+
+
+  pi.registerCommand("intercom-name", {
+    description: "Set the pi session name and immediately sync pi-intercom presence (usage: /intercom-name <name>)",
+    handler: async (args, ctx) => {
+      const name = args.trim();
+      if (!name) {
+        const current = pi.getSessionName();
+        ctx.ui.notify(current ? `Intercom session name: ${current}` : "Usage: /intercom-name <name>", "info");
+        return;
+      }
+
+      pi.setSessionName(name);
+      currentSessionId = ctx.sessionManager.getSessionId();
+      syncPresenceIdentity(currentSessionId);
+      ctx.ui.notify(`Intercom session name synced: ${name}`, "info");
+    },
   });
 
   pi.registerMessageRenderer("intercom_message", (message, _options, theme) => {


### PR DESCRIPTION
## Summary
- add /intercom-name to set the Pi session name and immediately sync intercom presence
- include the current presence identity when publishing status updates so renamed sessions do not remain stale

## Motivation
Pi's /name command updates the Pi session display name, but pi-intercom keeps a separate presence record in the broker. Until another intercom-related sync happens, other sessions can still see the old fallback name (for example subagent-chat-xxxx). This provides an explicit command for immediate sync and makes regular status updates carry the latest name as a fallback.

## Test
- npm test