### PR TITLE
fix: non-interactive busy sessions no longer auto-reply to ask messages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -669,7 +669,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       if (!activeContext.isIdle()) {
         if (!activeContext.hasUI) {
           const activeClient = client;
-          if (!message.replyTo && activeClient?.isConnected()) {
+          if (!message.replyTo && !message.expectsReply && activeClient?.isConnected()) {
             try {
               const result = await activeClient.send(from.id, {
                 text: "This agent is running in non-interactive mode and cannot respond to intercom messages while it is working. It will continue its current task and exit when done.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-intercom",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "MIT",
   "type": "module",
   "main": "index.ts",

--- a/reply-tracker.test.ts
+++ b/reply-tracker.test.ts
@@ -75,3 +75,96 @@ test("reply removes pending ask after successful reply", () => {
 
   assert.deepEqual(tracker.listPending(1001), []);
 });
+
+// --- Fix 2: Long timeout for deployment chains ---
+
+test("pending ask survives past 10 minutes with default timeout (60 min)", () => {
+  // Deployment chains routinely take 30-60+ minutes.
+  // BUG: The OLD default was 10 min — deployment asks expired mid-chain.
+  // FIX: Default timeout increased to 60 minutes.
+  // This test must pass with the NEW default (60 min) and fail with the OLD (10 min).
+  const tracker = new ReplyTracker(); // Use default timeout
+
+  tracker.recordIncomingMessage(
+    createSession("orchestrator-id", "orchestrator"),
+    createMessage("ask-deploy", "Deploy to prod?"),
+    1000,
+  );
+
+  // After 30 minutes (typical deployment duration), ask should still be pending
+  const thirtyMinLater = 1000 + 30 * 60 * 1000;
+  assert.equal(tracker.resolveReplyTarget({}, thirtyMinLater).message.id, "ask-deploy");
+});
+
+test("pending ask expires after 60 minutes with new default timeout", () => {
+  const SIXTY_MIN = 60 * 60 * 1000;
+  const tracker = new ReplyTracker(SIXTY_MIN);
+
+  tracker.recordIncomingMessage(
+    createSession("orchestrator-id", "orchestrator"),
+    createMessage("ask-deploy", "Deploy to prod?"),
+    1000,
+  );
+
+  // After 61 minutes, should be expired
+  const sixtyOneMinLater = 1000 + 61 * 60 * 1000;
+  assert.throws(
+    () => tracker.resolveReplyTarget({}, sixtyOneMinLater),
+    /No active intercom context to reply to/,
+  );
+});
+
+test("pending ask survives endTurn and can be replied later from pendingAsks", () => {
+  // Scenario: ask triggers a turn, agent processes but doesn't reply in that turn,
+  // turn ends, agent replies in a later turn from pendingAsks
+  const tracker = new ReplyTracker(60 * 60 * 1000);
+  const from = createSession("orchestrator-id", "orchestrator");
+  const message = createMessage("ask-1", "Deploy?");
+
+  const context = tracker.recordIncomingMessage(from, message, 1000);
+  tracker.queueTurnContext(context);
+  tracker.beginTurn(1001);
+
+  // Agent processes but doesn't reply — turn ends
+  tracker.endTurn();
+
+  // Later, agent wants to reply — should find it in pendingAsks
+  assert.equal(tracker.resolveReplyTarget({}, 2000).message.id, "ask-1");
+});
+
+test("markReplied removes from pendingAsks so auto-replied asks cannot be manually replied", () => {
+  // This test documents the BUG: if markReplied is called by the auto-reply
+  // for expectsReply messages, the agent later can't reply.
+  // The fix is in index.ts (not here) — this test just verifies the tracker behavior
+  // that when markReplied IS called, the ask is gone.
+  const tracker = new ReplyTracker(60 * 60 * 1000);
+  tracker.recordIncomingMessage(
+    createSession("orchestrator-id", "orchestrator"),
+    createMessage("ask-1", "Deploy?"),
+    1000,
+  );
+
+  // Simulate auto-reply calling markReplied (the bug in index.ts)
+  tracker.markReplied("ask-1");
+
+  // Now agent tries to reply — should fail
+  assert.throws(
+    () => tracker.resolveReplyTarget({}, 1002),
+    /No active intercom context to reply to/,
+  );
+});
+
+test("send message (expectsReply=false) is NOT added to pendingAsks", () => {
+  const tracker = new ReplyTracker();
+  tracker.recordIncomingMessage(
+    createSession("orchestrator-id", "orchestrator"),
+    createMessage("msg-1", "Status update", false), // expectsReply=false (send, not ask)
+    1000,
+  );
+
+  // Cannot reply to a send message
+  assert.throws(
+    () => tracker.resolveReplyTarget({}, 1001),
+    /No active intercom context to reply to/,
+  );
+});

--- a/reply-tracker.ts
+++ b/reply-tracker.ts
@@ -19,7 +19,7 @@ export class ReplyTracker {
   private readonly pendingTurnContexts: IntercomContext[] = [];
   private currentTurnContext: IntercomContext | null = null;
 
-  constructor(private readonly askTimeoutMs = 10 * 60 * 1000) {}
+  constructor(private readonly askTimeoutMs = 60 * 60 * 1000) {}
 
   recordIncomingMessage(from: SessionInfo, message: Message, receivedAt = Date.now()): IntercomContext {
     const context = { from, message, receivedAt };


### PR DESCRIPTION
## Bug

When a non-interactive (headless) busy session receives an `ask` message, the auto-reply logic at `index.ts:672` sends a "cannot respond" message AND calls `markReplied()`, removing the ask from `pendingAsks`. When the agent later tries `intercom({ action: "reply" })`, it gets:

```
✗ Failed to reply: No active intercom context to reply to
```

This is the root cause of reply failures in deployment chain sessions.

## Root Cause Analysis

Two issues compound:

### 1. Auto-reply consumes ask messages (CRITICAL)

The guard at `index.ts:672` only checked `!message.replyTo`, but `ask` messages also have no `replyTo` (they are fresh questions). So the auto-reply fires for both `send` AND `ask` messages in non-interactive busy sessions.

Code path:
1. `ask` arrives → `recordIncomingMessage()` adds to `pendingAsks` (because `expectsReply=true`)
2. Session is busy + non-interactive → enters auto-reply block
3. `!message.replyTo` = true → guard passes → sends "cannot respond" + `markReplied()` → **removes from pendingAsks**
4. Agent later tries `reply` → `pendingAsks` empty → error

### 2. 10-minute timeout expires asks during deployment chains

`askTimeoutMs` defaulted to 10 minutes. Deployment chains routinely take 30-60+ minutes. Pending asks expire mid-deploy.

## Fix

### Fix 1 (critical): `index.ts` line 672

```diff
- if (!message.replyTo && activeClient?.isConnected()) {
+ if (!message.replyTo && !message.expectsReply && activeClient?.isConnected()) {
```

Now only `send` messages (fire-and-forget) get auto-replied. `ask` messages (which expect a reply) are preserved in `pendingAsks` for the agent to reply later.

**Side effects verified:**
- `send` messages: `!expectsReply` = true → auto-reply still happens → no regression
- `reply` messages: `!replyTo` = false → guard never reached → no regression
- Interactive sessions: guard is inside `if (!hasUI)` → never reached → no regression

### Fix 2 (reliability): `reply-tracker.ts` line 22

```diff
- constructor(private readonly askTimeoutMs = 10 * 60 * 1000) {}
+ constructor(private readonly askTimeoutMs = 60 * 60 * 1000) {}
```

## Tests

5 new tests in `reply-tracker.test.ts`:

| Test | Validates |
|------|-----------|
| `pending ask survives past 10 minutes with default timeout (60 min)` | Default is now 60 min (fails with old 10 min) |
| `pending ask expires after 60 minutes with new default timeout` | Expiry at 61 min still works |
| `pending ask survives endTurn and can be replied later from pendingAsks` | Ask persists across turns |
| `markReplied removes from pendingAsks` | Documents the bug mechanism |
| `send message (expectsReply=false) is NOT added to pendingAsks` | No side-effect for sends |

All 11 tests pass (6 existing + 5 new).

## Note

The sender-side `waitForReply` timeout (10 min, `index.ts:442`) is not updated. For deployment chains >10 min, the sender times out before the receiver's ask expires. This is not a regression but may warrant a follow-up.