### PR TITLE
Prevent intercom ask reply waiter race

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1490,6 +1490,13 @@ Usage:
                 details: { error: true },
               };
             }
+            if (replyWaiter) {
+              return {
+                content: [{ type: "text", text: "Already waiting for a reply" }],
+                isError: true,
+                details: { error: true },
+              };
+            }
             if (sendTo === connectedClient.sessionId) {
               return {
                 content: [{ type: "text", text: "Cannot message the current session" }],
@@ -1499,6 +1506,7 @@ Usage:
             }
             const questionId = randomUUID();
             replyPromise = waitForReply(sendTo, questionId, _signal);
+            replyPromise.catch(() => undefined);
             const sendResult = await connectedClient.send(sendTo, {
               messageId: questionId,
               text: message,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts"
+    "test": "tsx --test broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts wait-for-reply-unhandled.test.mjs"
   },
   "keywords": [
     "pi-package"

--- a/wait-for-reply-unhandled.test.mjs
+++ b/wait-for-reply-unhandled.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+test("reply-waiting ask paths attach rejection handlers immediately", () => {
+  const source = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+  const lines = source.split("\n");
+  const waitAssignments = lines
+    .map((line, index) => ({ line: line.trim(), lineNumber: index + 1 }))
+    .filter(({ line }) => line === "replyPromise = waitForReply(sendTo, questionId, signal);" ||
+      line === "replyPromise = waitForReply(sendTo, questionId, _signal);");
+
+  assert.ok(waitAssignments.length > 0, "expected at least one reply waiter assignment");
+
+  for (const assignment of waitAssignments) {
+    const nextLine = lines[assignment.lineNumber]?.trim();
+    assert.equal(
+      nextLine,
+      "replyPromise.catch(() => undefined);",
+      `line ${assignment.lineNumber} must attach a rejection handler before any await`,
+    );
+  }
+});
+
+test("regular ask rechecks reply waiter after target resolution", () => {
+  const source = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+  const start = source.indexOf('case "ask": {', source.indexOf('name: "intercom"'));
+  assert.notEqual(start, -1, "expected regular intercom ask case");
+  const end = source.indexOf('case "reply": {', start);
+  const askCase = source.slice(start, end);
+  const resolveIndex = askCase.indexOf("const sendTo = await resolveSessionTarget(connectedClient, to) ?? to;");
+  const questionIndex = askCase.indexOf("const questionId = randomUUID();", resolveIndex);
+  assert.ok(resolveIndex > -1, "expected async target resolution");
+  assert.ok(questionIndex > resolveIndex, "expected question id after target resolution");
+
+  const between = askCase.slice(resolveIndex, questionIndex);
+  assert.ok(
+    between.includes("if (replyWaiter) {") &&
+      between.includes("Already waiting for a reply") &&
+      between.includes("return"),
+    "ask must recheck replyWaiter after await and before sending",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes a race where concurrent reply-waiting `intercom({ action: "ask" })` tool calls can crash Pi with `Error: Already waiting for a reply`.

## Root Cause

`pi-agent-core` may execute same-turn tool calls concurrently. `pi-intercom` uses a single `replyWaiter`, so concurrent `ask` calls need to fail cleanly before sending.

The regular `intercom` `ask` path checked `replyWaiter` before awaiting `resolveSessionTarget(...)`, but did not recheck after that await. A parallel ask can install `replyWaiter` during that window. The later call then reaches `waitForReply(...)`, receives an already-rejected promise, and did not attach a rejection handler immediately.

## Changes

- Recheck `replyWaiter` after target resolution and before generating/sending the question.
- Attach `replyPromise.catch(() => undefined)` immediately after `waitForReply(...)`, matching the safer supervisor-contact path.
- Add a regression test covering immediate rejection-handler attachment and the post-resolution `replyWaiter` guard.
- Wire the regression test into `npm test`.

## Validation

```text
node --test wait-for-reply-unhandled.test.mjs
# 2/2 passing

npm test
# 38/38 passing
```

Related issue: #29