### PR TITLE
Update peer deps and imports from @mariozechner to @earendil-works

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { randomUUID } from "crypto";
 import { Type } from "typebox";
-import { Text } from "@mariozechner/pi-tui";
+import { Text } from "@earendil-works/pi-tui";
 import { IntercomClient } from "./broker/client.ts";
 import { spawnBrokerIfNeeded } from "./broker/spawn.ts";
 import { SessionListOverlay } from "./ui/session-list.ts";

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     ]
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "dependencies": {
     "tsx": "^4.20.0",

--- a/test/inline-message.test.ts
+++ b/test/inline-message.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { visibleWidth } from "@mariozechner/pi-tui";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { InlineMessageComponent } from "../ui/inline-message.ts";
 import type { Message, SessionInfo } from "../types.ts";
 

--- a/ui/compose.ts
+++ b/ui/compose.ts
@@ -1,6 +1,6 @@
-import type { Component, TUI } from "@mariozechner/pi-tui";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import type { KeybindingsManager, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import type { IntercomClient } from "../broker/client.js";
 import type { SessionInfo } from "../types.js";
 

--- a/ui/inline-message.ts
+++ b/ui/inline-message.ts
@@ -1,6 +1,6 @@
-import type { Component } from "@mariozechner/pi-tui";
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
-import type { Theme } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { SessionInfo, Message } from "../types.js";
 
 export class InlineMessageComponent implements Component {

--- a/ui/session-list.ts
+++ b/ui/session-list.ts
@@ -1,6 +1,6 @@
-import type { Component } from "@mariozechner/pi-tui";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import type { KeybindingsManager, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
 import type { SessionInfo } from "../types.js";
 
 function middleTruncate(text: string, maxWidth: number): string {


### PR DESCRIPTION
The `@mariozechner/pi-coding-agent` and `@mariozechner/pi-tui` packages have been deprecated and replaced by `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`. The old packages emit npm deprecation warnings on every install, and in npm 11.x the peer-dep resolution of the old packages can trigger `ERR_INVALID_ARG_TYPE: The "from" argument must be of type string. Received undefined` during install/update operations.

This PR makes a purely mechanical rename across all source files and `package.json`. The API surface is identical between the old and new packages — exports like `ExtensionAPI`, `ExtensionContext`, `Component`, `TUI`, `Theme`, `KeybindingsManager`, `truncateToWidth`, `visibleWidth`, `wrapTextWithAnsi`, and `Text` are all available with the same signatures.

### Changes
- **package.json**: `peerDependencies` updated to `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`
- **index.ts**: import path updated
- **ui/compose.ts**: import paths updated
- **ui/session-list.ts**: import paths updated
- **ui/inline-message.ts**: import paths updated
- **test/inline-message.test.ts**: import path updated

Closes the peer-dep deprecation warnings and prevents npm 11.x install/update errors for users of pi-intercom.