### PR TITLE
fix: route contact_supervisor by stable session id (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,14 +220,19 @@ This workflow requires [`pi-subagents`](https://github.com/nicobailon/pi-subagen
 
 ### When the Tool Appears
 
-`contact_supervisor` only registers when `pi-subagents` sets all of these environment variables:
+`contact_supervisor` registers when `pi-subagents` sets the run metadata plus a supervisor route target:
 
 - `PI_SUBAGENT_ORCHESTRATOR_TARGET` — the supervisor session name or ID
+- `PI_SUBAGENT_ORCHESTRATOR_SESSION_ID` — optional stable broker session ID for the supervisor; preferred for routing when names collide
 - `PI_SUBAGENT_RUN_ID` — the run identifier
 - `PI_SUBAGENT_CHILD_AGENT` — the agent type
 - `PI_SUBAGENT_CHILD_INDEX` — the child index within the run
 
-If any are missing, the session falls back to the regular `intercom` tool.
+`PI_SUBAGENT_ORCHESTRATOR_TARGET` is used for display and backwards-compatible name routing. When `PI_SUBAGENT_ORCHESTRATOR_SESSION_ID` is present, `contact_supervisor` routes to that exact broker session first, so duplicate display names do not make supervisor messages ambiguous. If that broker session ID is no longer connected, the tool falls back to `PI_SUBAGENT_ORCHESTRATOR_TARGET`.
+
+For bridge implementations that inherit the parent process environment, pi-intercom also publishes the current broker session ID as `PI_INTERCOM_SESSION_ID`. A child can use that inherited value as its supervisor session ID when an explicit `PI_SUBAGENT_ORCHESTRATOR_SESSION_ID` is not set.
+
+If run metadata or all supervisor route targets are missing, the session falls back to the regular `intercom` tool.
 
 ### Three Reasons
 

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,9 @@ const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delive
 const INBOUND_FLUSH_DELAY_MS = 200;
 const INBOUND_IDLE_RETRY_MS = 500;
 const DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX = "subagent-chat";
+const INTERCOM_SESSION_ID_ENV = "PI_INTERCOM_SESSION_ID";
 const SUBAGENT_ORCHESTRATOR_TARGET_ENV = "PI_SUBAGENT_ORCHESTRATOR_TARGET";
+const SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV = "PI_SUBAGENT_ORCHESTRATOR_SESSION_ID";
 const SUBAGENT_RUN_ID_ENV = "PI_SUBAGENT_RUN_ID";
 const SUBAGENT_CHILD_AGENT_ENV = "PI_SUBAGENT_CHILD_AGENT";
 const SUBAGENT_CHILD_INDEX_ENV = "PI_SUBAGENT_CHILD_INDEX";
@@ -25,6 +27,7 @@ const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
 
 interface ChildOrchestratorMetadata {
   orchestratorTarget: string;
+  orchestratorSessionId?: string;
   runId: string;
   agent: string;
   index: string;
@@ -78,21 +81,30 @@ function formatAttachments(attachments: Attachment[]): string {
 }
 function readChildOrchestratorMetadata(): ChildOrchestratorMetadata | null {
   const orchestratorTarget = process.env[SUBAGENT_ORCHESTRATOR_TARGET_ENV]?.trim();
+  const explicitOrchestratorSessionId = process.env[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV]?.trim();
+  const inheritedOrchestratorSessionId = process.env[INTERCOM_SESSION_ID_ENV]?.trim();
+  const orchestratorSessionId = explicitOrchestratorSessionId || inheritedOrchestratorSessionId;
   const runId = process.env[SUBAGENT_RUN_ID_ENV]?.trim();
   const agent = process.env[SUBAGENT_CHILD_AGENT_ENV]?.trim();
   const index = process.env[SUBAGENT_CHILD_INDEX_ENV]?.trim();
-  if (!orchestratorTarget || !runId || !agent || !index) {
+  if (!(orchestratorTarget || orchestratorSessionId) || !runId || !agent || !index) {
     return null;
   }
   const sessionName = process.env[SUBAGENT_INTERCOM_SESSION_NAME_ENV]?.trim();
   return {
-    orchestratorTarget,
+    orchestratorTarget: orchestratorTarget || orchestratorSessionId!,
+    ...(orchestratorSessionId ? { orchestratorSessionId } : {}),
     runId,
     agent,
     index,
     ...(sessionName ? { sessionName } : {}),
   };
 }
+
+function supervisorRoutingTarget(metadata: ChildOrchestratorMetadata): string {
+  return metadata.orchestratorSessionId ?? metadata.orchestratorTarget;
+}
+
 function formatChildOrchestratorMessage(kind: "ask" | "update" | "interview", metadata: ChildOrchestratorMetadata, message: string): string {
   const heading = kind === "ask"
     ? "Subagent needs a supervisor decision."
@@ -414,6 +426,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   const config: IntercomConfig = loadConfig();
   let runtimeContext: ExtensionContext | null = null;
   let currentSessionId: string | null = null;
+  let publishedIntercomSessionId: string | null = null;
+  let previousIntercomSessionIdEnv: string | undefined;
   let currentModel = "unknown";
   let sessionStartedAt: number | null = null;
   let reconnectTimer: NodeJS.Timeout | null = null;
@@ -531,6 +545,27 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     const activeToolName = activeTools.values().next().value;
     const lifecycleStatus = activeToolName ? `tool:${activeToolName}` : agentRunning ? "thinking" : "idle";
     return config.status ? `${lifecycleStatus} · ${config.status}` : lifecycleStatus;
+  }
+  function publishIntercomSessionId(sessionId: string | null): void {
+    if (!sessionId) {
+      return;
+    }
+    if (publishedIntercomSessionId === null) {
+      previousIntercomSessionIdEnv = process.env[INTERCOM_SESSION_ID_ENV];
+    }
+    process.env[INTERCOM_SESSION_ID_ENV] = sessionId;
+    publishedIntercomSessionId = sessionId;
+  }
+  function clearPublishedIntercomSessionId(): void {
+    if (publishedIntercomSessionId && process.env[INTERCOM_SESSION_ID_ENV] === publishedIntercomSessionId) {
+      if (previousIntercomSessionIdEnv === undefined) {
+        delete process.env[INTERCOM_SESSION_ID_ENV];
+      } else {
+        process.env[INTERCOM_SESSION_ID_ENV] = previousIntercomSessionIdEnv;
+      }
+    }
+    publishedIntercomSessionId = null;
+    previousIntercomSessionIdEnv = undefined;
   }
   function buildRegistration(): Omit<SessionInfo, "id"> {
     const liveContext = getLiveContext();
@@ -706,6 +741,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       }
       rejectReplyWaiter(new Error(`Disconnected while waiting for reply: ${error.message}`, { cause: error }));
       client = null;
+      clearPublishedIntercomSessionId();
       if (!shuttingDown && !disposed) {
         clearReconnectTimer();
         scheduleReconnect();
@@ -739,6 +775,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       throw new Error("Intercom shutting down");
     }
     if (client && client.isConnected()) {
+      publishIntercomSessionId(client.sessionId);
       return client;
     }
     const contextAtStart = getLiveContext();
@@ -762,6 +799,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
           throw new Error("Intercom runtime no longer active");
         }
         client = nextClient;
+        publishIntercomSessionId(nextClient.sessionId);
         reconnectAttempt = 0;
         return nextClient;
       } catch (error) {
@@ -795,6 +833,20 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       throw new Error(`Multiple sessions named "${nameOrId}" are connected. Use the session ID instead.`);
     }
     return byName[0]?.id ?? null;
+  }
+  async function resolveSupervisorTarget(activeClient: IntercomClient, metadata: ChildOrchestratorMetadata): Promise<string> {
+    if (metadata.orchestratorSessionId) {
+      const bySessionId = await resolveSessionTarget(activeClient, metadata.orchestratorSessionId);
+      if (bySessionId) {
+        return bySessionId;
+      }
+      if (metadata.orchestratorTarget !== metadata.orchestratorSessionId) {
+        return await resolveSessionTarget(activeClient, metadata.orchestratorTarget) ?? metadata.orchestratorTarget;
+      }
+    }
+
+    const routeTarget = supervisorRoutingTarget(metadata);
+    return await resolveSessionTarget(activeClient, routeTarget) ?? routeTarget;
   }
   function deliverLocalSubagentRelayMessage(sender: "subagent-control" | "subagent-result", status: string, messageText: string): void {
     const now = Date.now();
@@ -956,6 +1008,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       await client.disconnect();
       client = null;
     }
+    clearPublishedIntercomSessionId();
     runtimeContext = null;
     currentSessionId = null;
     sessionStartedAt = null;
@@ -1111,10 +1164,13 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         const metadata = childOrchestratorMetadata;
         let sendTo: string;
         try {
-          sendTo = await resolveSessionTarget(connectedClient, metadata.orchestratorTarget) ?? metadata.orchestratorTarget;
+          sendTo = await resolveSupervisorTarget(connectedClient, metadata);
         } catch (error) {
+          const stableIdHint = metadata.orchestratorSessionId
+            ? ""
+            : ` Ensure ${SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV} or ${INTERCOM_SESSION_ID_ENV} is available for stable supervisor routing.`;
           return {
-            content: [{ type: "text", text: `Failed to resolve supervisor target: ${getErrorMessage(error)}` }],
+            content: [{ type: "text", text: `Failed to resolve supervisor target: ${getErrorMessage(error)}${stableIdHint}` }],
             isError: true,
             details: { error: true },
           };

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -10,7 +10,9 @@ import type { Message, SessionInfo } from "./types.ts";
 
 const repoDir = process.cwd();
 const childEnvKeys = [
+  "PI_INTERCOM_SESSION_ID",
   "PI_SUBAGENT_ORCHESTRATOR_TARGET",
+  "PI_SUBAGENT_ORCHESTRATOR_SESSION_ID",
   "PI_SUBAGENT_RUN_ID",
   "PI_SUBAGENT_CHILD_AGENT",
   "PI_SUBAGENT_CHILD_INDEX",
@@ -57,8 +59,23 @@ async function waitForBrokerReady(broker: ChildProcessWithoutNullStreams): Promi
   await ready;
 }
 
+async function connectTestClient(name: string): Promise<InstanceType<typeof IntercomClient>> {
+  const client = new IntercomClient();
+  await client.connect({
+    name,
+    cwd: repoDir,
+    model: "test-model",
+    pid: process.pid,
+    startedAt: Date.now(),
+    lastActivity: Date.now(),
+  });
+  return client;
+}
+
 async function withChildOrchestratorEnv<T>(metadata: {
   orchestratorTarget?: string;
+  orchestratorSessionId?: string;
+  inheritedIntercomSessionId?: string;
   runId?: string;
   agent?: string;
   index?: string;
@@ -69,7 +86,9 @@ async function withChildOrchestratorEnv<T>(metadata: {
     previous.set(key, process.env[key]);
     delete process.env[key];
   }
+  if (metadata.inheritedIntercomSessionId !== undefined) process.env.PI_INTERCOM_SESSION_ID = metadata.inheritedIntercomSessionId;
   if (metadata.orchestratorTarget !== undefined) process.env.PI_SUBAGENT_ORCHESTRATOR_TARGET = metadata.orchestratorTarget;
+  if (metadata.orchestratorSessionId !== undefined) process.env.PI_SUBAGENT_ORCHESTRATOR_SESSION_ID = metadata.orchestratorSessionId;
   if (metadata.runId !== undefined) process.env.PI_SUBAGENT_RUN_ID = metadata.runId;
   if (metadata.agent !== undefined) process.env.PI_SUBAGENT_CHILD_AGENT = metadata.agent;
   if (metadata.index !== undefined) process.env.PI_SUBAGENT_CHILD_INDEX = metadata.index;
@@ -194,25 +213,8 @@ async function setupClients() {
 
   try {
     await waitForBrokerReady(broker);
-    const planner = new IntercomClient();
-    const orchestrator = new IntercomClient();
-
-    await planner.connect({
-      name: "planner",
-      cwd: repoDir,
-      model: "test-model",
-      pid: process.pid,
-      startedAt: Date.now(),
-      lastActivity: Date.now(),
-    });
-    await orchestrator.connect({
-      name: "orchestrator",
-      cwd: repoDir,
-      model: "test-model",
-      pid: process.pid,
-      startedAt: Date.now(),
-      lastActivity: Date.now(),
-    });
+    const planner = await connectTestClient("planner");
+    const orchestrator = await connectTestClient("orchestrator");
 
     return {
       planner,
@@ -591,6 +593,139 @@ test("supervisor tool registers only when child metadata is present", async () =
     assert.match(JSON.stringify(supervisorTool?.parameters), /interview_request/);
     assert.match(JSON.stringify(supervisorTool?.parameters), /questions/);
   });
+});
+
+test("sessions publish their broker id for subagent inheritance", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { planner, cleanup } = await setupClients();
+  const previousIntercomSessionId = process.env.PI_INTERCOM_SESSION_ID;
+  process.env.PI_INTERCOM_SESSION_ID = "parent-broker-session";
+  const harness = createExtensionHarness("supervisor-for-env", { hasUI: true });
+
+  try {
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+
+    const supervisorSession = await waitForSessionByName(planner, "supervisor-for-env");
+    assert.equal(process.env.PI_INTERCOM_SESSION_ID, supervisorSession.id);
+
+    await harness.emitLifecycle("session_shutdown");
+    assert.equal(process.env.PI_INTERCOM_SESSION_ID, "parent-broker-session");
+  } finally {
+    await harness.emitLifecycle("session_shutdown");
+    await cleanup();
+    if (previousIntercomSessionId === undefined) delete process.env.PI_INTERCOM_SESSION_ID;
+    else process.env.PI_INTERCOM_SESSION_ID = previousIntercomSessionId;
+  }
+});
+
+test("child supervisor tool routes by stable broker id when supervisor names collide", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { orchestrator, cleanup } = await setupClients();
+  let duplicateOrchestrator: InstanceType<typeof IntercomClient> | undefined;
+
+  try {
+    duplicateOrchestrator = await connectTestClient("orchestrator");
+
+    const sessions = await orchestrator.listSessions();
+    assert.equal(sessions.filter((session) => session.name === "orchestrator").length, 2);
+
+    await withChildOrchestratorEnv({
+      orchestratorTarget: "orchestrator",
+      orchestratorSessionId: orchestrator.sessionId!,
+      runId: "78f659a3",
+      agent: "worker",
+      index: "0",
+      sessionName: "subagent-worker-78f659a3-1",
+    }, async () => {
+      const harness = createExtensionHarness("subagent-worker-78f659a3-1");
+      piIntercomExtension(harness.pi as never);
+      await harness.emitLifecycle("session_start");
+
+      const supervisorTool = harness.tools.find((tool) => tool.name === "contact_supervisor")!;
+      const updateReceived = once(orchestrator, "message") as Promise<[SessionInfo, Message]>;
+      const updateResult = await supervisorTool.execute("update-duplicate-name", { reason: "progress_update", message: "Found a schema mismatch." }, new AbortController().signal, undefined, harness.ctx);
+      const [_from, updateMessage] = await updateReceived;
+
+      assert.equal(updateResult.isError, false);
+      assert.match(updateMessage.content.text, /Subagent progress update/);
+      assert.match(updateMessage.content.text, /Run: 78f659a3/);
+      assert.match(updateMessage.content.text, /Found a schema mismatch/);
+
+      await harness.emitLifecycle("session_shutdown");
+    });
+  } finally {
+    await duplicateOrchestrator?.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("child supervisor tool uses inherited parent broker id when explicit id is absent", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { orchestrator, cleanup } = await setupClients();
+  let duplicateOrchestrator: InstanceType<typeof IntercomClient> | undefined;
+
+  try {
+    duplicateOrchestrator = await connectTestClient("orchestrator");
+
+    await withChildOrchestratorEnv({
+      orchestratorTarget: "orchestrator",
+      inheritedIntercomSessionId: orchestrator.sessionId!,
+      runId: "78f659a3",
+      agent: "worker",
+      index: "0",
+      sessionName: "subagent-worker-78f659a3-1",
+    }, async () => {
+      const harness = createExtensionHarness("subagent-worker-78f659a3-1");
+      piIntercomExtension(harness.pi as never);
+      await harness.emitLifecycle("session_start");
+
+      const supervisorTool = harness.tools.find((tool) => tool.name === "contact_supervisor")!;
+      const updateReceived = once(orchestrator, "message") as Promise<[SessionInfo, Message]>;
+      const updateResult = await supervisorTool.execute("update-inherited-id", { reason: "progress_update", message: "Inherited routing works." }, new AbortController().signal, undefined, harness.ctx);
+      const [_from, updateMessage] = await updateReceived;
+
+      assert.equal(updateResult.isError, false);
+      assert.match(updateMessage.content.text, /Inherited routing works/);
+
+      await harness.emitLifecycle("session_shutdown");
+    });
+  } finally {
+    await duplicateOrchestrator?.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("child supervisor tool falls back to target when broker id is stale", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { orchestrator, cleanup } = await setupClients();
+
+  try {
+    await withChildOrchestratorEnv({
+      orchestratorTarget: "orchestrator",
+      orchestratorSessionId: "stale-broker-session",
+      runId: "78f659a3",
+      agent: "worker",
+      index: "0",
+      sessionName: "subagent-worker-78f659a3-1",
+    }, async () => {
+      const harness = createExtensionHarness("subagent-worker-78f659a3-1");
+      piIntercomExtension(harness.pi as never);
+      await harness.emitLifecycle("session_start");
+
+      const supervisorTool = harness.tools.find((tool) => tool.name === "contact_supervisor")!;
+      const updateReceived = once(orchestrator, "message") as Promise<[SessionInfo, Message]>;
+      const updateResult = await supervisorTool.execute("update-stale-id", { reason: "progress_update", message: "Fallback routing works." }, new AbortController().signal, undefined, harness.ctx);
+      const [_from, updateMessage] = await updateReceived;
+
+      assert.equal(updateResult.isError, false);
+      assert.match(updateMessage.content.text, /Fallback routing works/);
+
+      await harness.emitLifecycle("session_shutdown");
+    });
+  } finally {
+    await cleanup();
+  }
 });
 
 test("child supervisor tool resolves target and includes run metadata", { concurrency: false }, async () => {


### PR DESCRIPTION
## Summary

Fixes #35. `contact_supervisor` could fail to reach a still-connected supervisor when the supervisor was targeted by a display name/fallback alias that more than one session shared. The child was told to use `contact_supervisor`, but target resolution threw `Multiple sessions named "..."` and the ask was never sent.

This change lets `contact_supervisor` route by a stable broker session ID first, falling back to the existing name-based target for backwards compatibility.

## Root cause

`readChildOrchestratorMetadata()` only captured `PI_SUBAGENT_ORCHESTRATOR_TARGET` (a display name or ID), and `contact_supervisor` resolved it via `resolveSessionTarget(...)`. When two connected sessions shared that name, resolution threw before the message was sent, and the child had no ID to retry with.

## What changed

- **Stable-ID routing**: `contact_supervisor` now prefers a stable broker session ID when one is available, then falls back to the name target.
  - New optional `PI_SUBAGENT_ORCHESTRATOR_SESSION_ID` for the supervisor's broker session ID.
  - If absent, an inherited `PI_INTERCOM_SESSION_ID` from the parent process environment is used as the supervisor ID.
  - `PI_SUBAGENT_ORCHESTRATOR_TARGET` remains for display and name-based routing, so existing behavior is unchanged when no ID is provided.
- **ID publication**: each connected session now publishes its own broker session ID as `PI_INTERCOM_SESSION_ID` in `process.env`, so a `pi-subagents` bridge that inherits the parent environment can route children back to the exact parent session. The previous value is saved and restored on disconnect/shutdown to avoid leaking state across sessions.
- **Graceful fallback**: `resolveSupervisorTarget(...)` tries the session ID, then the name; if a stale ID can no longer be resolved, it falls back to the name target instead of failing hard. When resolution still fails and no stable ID was supplied, the error now hints which env vars enable stable routing.
- **Docs**: README "When the Tool Appears" documents the new env contract and routing precedence.

## Backwards compatibility

- No `pi-subagents` change is required for this PR to be safe to merge: when the new env vars are absent, routing is identical to today.
- To fully resolve the duplicate-name failure end to end, `pi-subagents` should populate `PI_SUBAGENT_ORCHESTRATOR_SESSION_ID` (or rely on inherited `PI_INTERCOM_SESSION_ID`). This PR makes `pi-intercom` ready for that without breaking the current name-based path.

## Tests

Added focused integration tests in `intercom.integration.test.ts`:

- sessions publish their broker id for subagent inheritance (and restore the prior value on shutdown)
- `contact_supervisor` routes by stable broker id when two supervisors share a name
- `contact_supervisor` uses an inherited parent broker id when no explicit id is set
- `contact_supervisor` falls back to the name target when the broker id is stale

Refactored duplicated client setup into a `connectTestClient(name)` helper.

```text
npm test
# 40 pass, 0 fail
```
