### PR TITLE
fix: propagate session name to broker after /name rename (#11)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,19 @@ const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
 const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delivery";
 const INBOUND_FLUSH_DELAY_MS = 200;
+// pi exposes no session-name-changed event, so a `/name` rename made while the
+// session is idle does not reach the broker until an unrelated event (turn_start,
+// model_select, a tool call) happens to re-sync presence. Until then other
+// sessions keep seeing the stale fallback alias and sends to the new name fail.
+// Poll for the resolved presence name and push an update only when it actually
+// changes. The timer is unref()'d so it never keeps the process alive. Fixes #11.
+// PI_INTERCOM_NAME_POLL_MS overrides the cadence (used by tests; also lets a
+// deployment tune how quickly renames propagate).
+const PRESENCE_NAME_POLL_INTERVAL_MS = 3000;
+function presenceNamePollIntervalMs(): number {
+  const raw = Number(process.env.PI_INTERCOM_NAME_POLL_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : PRESENCE_NAME_POLL_INTERVAL_MS;
+}
 const INBOUND_IDLE_RETRY_MS = 500;
 const DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX = "subagent-chat";
 const SUBAGENT_ORCHESTRATOR_TARGET_ENV = "PI_SUBAGENT_ORCHESTRATOR_TARGET";
@@ -421,6 +434,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   let reconnectPromiseGeneration: number | null = null;
   let startupConnectTimer: NodeJS.Timeout | null = null;
   let reconnectAttempt = 0;
+  let presenceNamePollTimer: NodeJS.Timeout | null = null;
+  let lastPresenceName: string | null = null;
   let shuttingDown = false;
   let disposed = true;
   let runtimeStarted = false;
@@ -497,6 +512,31 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     clearTimeout(inboundFlushTimer);
     inboundFlushTimer = null;
   }
+  function clearPresenceNamePoll(): void {
+    if (!presenceNamePollTimer) {
+      return;
+    }
+    clearInterval(presenceNamePollTimer);
+    presenceNamePollTimer = null;
+  }
+  function startPresenceNamePoll(): void {
+    if (presenceNamePollTimer) {
+      return;
+    }
+    presenceNamePollTimer = setInterval(() => {
+      if (!client || !currentSessionId || !getLiveContext()) {
+        return;
+      }
+      const name = buildPresenceIdentity(pi, currentSessionId).name;
+      if (name === lastPresenceName) {
+        return;
+      }
+      lastPresenceName = name;
+      client.updatePresence({ name, status: currentStatus() });
+    }, presenceNamePollIntervalMs());
+    // Do not let the heartbeat keep the Node event loop alive on its own.
+    presenceNamePollTimer.unref?.();
+  }
   function getLiveContext(ctx: ExtensionContext | null = runtimeContext, generation = runtimeGeneration): ExtensionContext | null {
     if (disposed || shuttingDown || generation !== runtimeGeneration || !ctx) {
       return null;
@@ -553,7 +593,10 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     if (!client || !getLiveContext()) {
       return;
     }
-    client.updatePresence({ ...buildPresenceIdentity(pi, sessionId), status: currentStatus() });
+    const identity = buildPresenceIdentity(pi, sessionId);
+    // Track the last pushed name so the presence-name poll only emits on change.
+    lastPresenceName = identity.name;
+    client.updatePresence({ ...identity, status: currentStatus() });
   }
   function syncPresenceStatus(): void {
     if (!client || !currentSessionId || !getLiveContext()) {
@@ -923,6 +966,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     currentModel = ctx.model?.id ?? "unknown";
     sessionStartedAt = Date.now();
     agentRunning = false;
+    lastPresenceName = null;
+    startPresenceNamePoll();
     activeTools.clear();
     const startupGeneration = runtimeGeneration;
     startupConnectTimer = setTimeout(() => {
@@ -946,6 +991,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     runtimeGeneration += 1;
     clearStartupConnectTimer();
     clearReconnectTimer();
+    clearPresenceNamePoll();
+    lastPresenceName = null;
     rejectReplyWaiter(new Error("Session shutting down"));
     replyTracker.reset();
     pendingIdleMessages.length = 0;

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -127,6 +127,7 @@ function createExtensionHarness(sessionName = "child-worker", options: {
   hasUI?: boolean;
   isIdle?: () => boolean;
   ui?: unknown;
+  getSessionName?: () => string | undefined;
 } = {}) {
   const events = new EventEmitter();
   const lifecycleHandlers = new Map<string, Array<(event: unknown, ctx: unknown) => unknown>>();
@@ -135,7 +136,7 @@ function createExtensionHarness(sessionName = "child-worker", options: {
   const entries: Array<{ type: string; data: unknown }> = [];
   const sentMessages: Array<{ message: { customType?: string; content?: string; details?: unknown }; options?: { triggerTurn?: boolean; deliverAs?: string } }> = [];
   const pi = {
-    getSessionName: () => sessionName,
+    getSessionName: options.getSessionName ?? (() => sessionName),
     events: {
       on: (channel: string, handler: (payload: unknown) => void) => {
         events.on(channel, handler);
@@ -391,6 +392,45 @@ test("sessions publish automatic lifecycle status", { concurrency: false }, asyn
   } finally {
     await harness.emitLifecycle("session_shutdown");
     await cleanup();
+  }
+});
+
+test("renaming an idle session propagates to the broker without a new turn (#11)", { concurrency: false }, async () => {
+  // Regression for #11: a /name rename made while the session is idle must reach
+  // the broker via the presence-name poll, so peers can target the new name
+  // without waiting for an unrelated turn_start/model_select/tool call. A check
+  // that only asserted the initial name would pass even with the bug, so the
+  // point of this test is the post-rename discovery + the stale-name absence.
+  const previousPoll = process.env.PI_INTERCOM_NAME_POLL_MS;
+  process.env.PI_INTERCOM_NAME_POLL_MS = "25";
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { planner, cleanup } = await setupClients();
+  let advertisedName = "subagent-chat-pre";
+  const harness = createExtensionHarness("unused", {
+    hasUI: true,
+    getSessionName: () => advertisedName,
+  });
+
+  try {
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+
+    // Initial fallback name is advertised.
+    await waitForSessionByName(planner, "subagent-chat-pre");
+
+    // Rename while idle — no turn_start, no model_select, no tool call.
+    advertisedName = "DCA-worker";
+
+    // Poll must publish the new name, and the stale one must disappear.
+    const renamed = await waitForSessionByName(planner, "DCA-worker");
+    assert.equal(renamed.name, "DCA-worker");
+    const names = (await planner.listSessions()).map((s) => s.name);
+    assert.equal(names.includes("subagent-chat-pre"), false);
+  } finally {
+    await harness.emitLifecycle("session_shutdown");
+    await cleanup();
+    if (previousPoll === undefined) delete process.env.PI_INTERCOM_NAME_POLL_MS;
+    else process.env.PI_INTERCOM_NAME_POLL_MS = previousPoll;
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes #11. A `/name` rename made while a session is **idle** never reaches the broker, so peers keep seeing the stale `subagent-chat-*` fallback alias and sends to the new name fail with `Session not found`.

## Root cause

Presence identity is only re-synced from `pi.getSessionName()` on a handful of activity paths — `turn_start`, `model_select`, intercom tool execution, overlay open. pi exposes **no session-name-changed event**, so if the session is renamed while idle (and doesn't start a new turn), `syncPresenceIdentity()` is never called and the broker keeps the old `SessionInfo.name`.

## Fix

A change-detecting presence-name poll:

- Every `PI_INTERCOM_NAME_POLL_MS` (default `3000`ms) the resolved presence name is recomputed and an update is published **only when it actually changed** — no broker traffic on the steady state.
- `syncPresenceIdentity()` records the last published name, so the poll stays silent whenever an event-driven sync already covered the change.
- The interval is `unref()`'d so it never keeps the Node event loop alive on its own (relevant to the subagent-exit class of issues), and it is cleared on `session_shutdown`.

This is the automatic, no-new-command approach suggested in the issue (the polling fallback), rather than a manual `/intercom-name` command.

## Test

Adds an integration test that renames an **idle** session (no `turn_start` / `model_select` / tool call) and asserts the new name is discoverable by a peer **and** the stale alias is gone. Verified it **fails without** the poll (times out, peer still sees `subagent-chat-pre`) and passes with it.

```
ℹ tests 37
ℹ pass 37
ℹ fail 0
```
