### PR TITLE
Prevent mutual-ask deadlock; make ask timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,24 @@ Create `~/.pi/agent/intercom/config.json`:
 | `replyHint` | true | Include reply instruction in incoming messages |
 | `status` | — | Optional custom status suffix shown after the automatic lifecycle status, for example `thinking · researching` |
 
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PI_INTERCOM_ASK_TIMEOUT_MS` | `600000` (10 min) | How long a blocking `ask` waits for a reply before failing. Also used by the broker as the TTL for pruning stale ask edges. Values below `1000` are ignored. |
+
+### Deadlock prevention
+
+`ask` blocks the caller's turn until a reply arrives, so two sessions that `ask`
+each other at the same time would each wait for a reply the other cannot send
+while blocked — a deadlock that only clears at the reply timeout. The broker
+prevents this: it tracks each session's outstanding `ask` and, if a session
+asks a peer that is **already awaiting a reply from it**, the reverse `ask` is
+refused immediately with a `Mutual ask refused` delivery error instead of
+blocking. Whichever `ask` the broker processes first wins (FIFO); the other
+fails fast so the caller can fall back to `send`/`reply`. A plain `send` (no
+reply expected) is never affected.
+
 For example, if you have Bun installed and want it to start the broker directly, use:
 
 ```json

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -5,6 +5,7 @@ import { homedir } from "os";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.js";
 import { getBrokerSocketPath } from "./paths.js";
+import { resolveAskTimeoutMs } from "../config.js";
 import type { SessionInfo, Message, Attachment, BrokerMessage } from "../types.js";
 
 const INTERCOM_DIR = join(homedir(), ".pi/agent/intercom");
@@ -99,6 +100,15 @@ class IntercomBroker {
   private server: net.Server;
   private shutdownTimer: NodeJS.Timeout | null = null;
 
+  // Outstanding ask edges: askerId -> { to, questionId, at }. A session has at
+  // most one outstanding ask (the extension enforces a single reply waiter), so
+  // a single entry per asker suffices. Used to refuse a mutual "ask" before it
+  // blocks: if A asks B while B is already awaiting A's reply, A's ask is
+  // rejected immediately instead of both turns stalling until the reply
+  // timeout. Whichever ask the broker dequeues first wins (FIFO).
+  private askEdges = new Map<string, { to: string; questionId: string; at: number }>();
+  private readonly askTimeoutMs = resolveAskTimeoutMs();
+
   constructor() {
     mkdirSync(INTERCOM_DIR, { recursive: true });
     if (process.platform !== "win32") {
@@ -136,6 +146,7 @@ class IntercomBroker {
     socket.on("close", () => {
       if (sessionId) {
         this.sessions.delete(sessionId);
+        this.clearAskEdgesFor(sessionId);
         this.broadcast({ type: "session_left", sessionId }, sessionId);
 
         this.scheduleShutdownCheck();
@@ -202,6 +213,7 @@ class IntercomBroker {
 
       case "unregister": {
         this.sessions.delete(currentId);
+        this.clearAskEdgesFor(currentId);
         this.broadcast({ type: "session_left", sessionId: currentId }, currentId);
         setId(null);
         this.scheduleShutdownCheck();
@@ -242,6 +254,33 @@ class IntercomBroker {
             });
             break;
           }
+
+          const recipientId = targets[0].info.id;
+          const now = Date.now();
+          this.pruneAskEdges(now);
+          if (message.expectsReply === true) {
+            // Mutual-ask deadlock guard: if the recipient is already awaiting a
+            // reply from this sender, a reverse ask would block both turns until
+            // the reply timeout. Refuse it immediately so the caller fails fast.
+            const reverse = this.askEdges.get(recipientId);
+            if (reverse && reverse.to === currentId) {
+              writeMessage(socket, {
+                type: "delivery_failed",
+                messageId: message.id,
+                reason: `Mutual ask refused: "${targets[0].info.name ?? recipientId}" is already awaiting a reply from you. Use send/reply instead of ask, or wait for the pending ask to resolve.`,
+              });
+              break;
+            }
+            this.askEdges.set(currentId, { to: recipientId, questionId: message.id, at: now });
+          } else if (typeof message.replyTo === "string") {
+            // A reply clears the asker's edge. The reply flows answerer -> asker,
+            // so the asker is this message's recipient; match the question id.
+            const askerEdge = this.askEdges.get(recipientId);
+            if (askerEdge && askerEdge.questionId === message.replyTo) {
+              this.askEdges.delete(recipientId);
+            }
+          }
+
           writeMessage(targets[0].socket, {
             type: "message",
             from: fromSession.info,
@@ -297,6 +336,27 @@ class IntercomBroker {
 
       default:
         throw new Error(`Unknown client message type: ${clientMessage.type}`);
+    }
+  }
+
+  // Drop ask edges older than the configured reply timeout, matching the
+  // extension's waitForReply timeout so a timed-out ask leaves no phantom edge.
+  private pruneAskEdges(now: number): void {
+    for (const [asker, edge] of this.askEdges) {
+      if (now - edge.at > this.askTimeoutMs) {
+        this.askEdges.delete(asker);
+      }
+    }
+  }
+
+  // On disconnect, drop this session's own outstanding ask and any ask awaiting
+  // a reply from it, so a peer can re-ask without falsely tripping the guard.
+  private clearAskEdgesFor(id: string): void {
+    this.askEdges.delete(id);
+    for (const [asker, edge] of this.askEdges) {
+      if (edge.to === id) {
+        this.askEdges.delete(asker);
+      }
     }
   }
 

--- a/config.ts
+++ b/config.ts
@@ -24,6 +24,22 @@ export interface IntercomConfig {
 
 const CONFIG_PATH = join(homedir(), ".pi/agent/intercom/config.json");
 
+/** Default reply timeout (ms) for a blocking `ask`. */
+export const DEFAULT_ASK_TIMEOUT_MS = 10 * 60 * 1000;
+
+// Configurable ask reply timeout. The extension uses it to bound waitForReply;
+// the broker uses it as a TTL to prune stale ask edges, so a timed-out ask
+// cannot leave a phantom edge that later trips the mutual-ask deadlock guard.
+// Both processes read the same env var, keeping the values aligned. Values
+// below 1s are ignored to avoid pathological busy-waiting.
+export function resolveAskTimeoutMs(): number {
+  const raw = Number(process.env.PI_INTERCOM_ASK_TIMEOUT_MS);
+  if (Number.isFinite(raw) && raw >= 1000) {
+    return raw;
+  }
+  return DEFAULT_ASK_TIMEOUT_MS;
+}
+
 const defaults: IntercomConfig = {
   brokerCommand: "npx",
   brokerArgs: ["--no-install", "tsx"],

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import { spawnBrokerIfNeeded } from "./broker/spawn.ts";
 import { SessionListOverlay } from "./ui/session-list.ts";
 import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
 import { InlineMessageComponent } from "./ui/inline-message.ts";
-import { loadConfig, type IntercomConfig } from "./config.ts";
+import { loadConfig, resolveAskTimeoutMs, type IntercomConfig } from "./config.ts";
 import type { SessionInfo, Message, Attachment } from "./types.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
 
@@ -368,6 +368,15 @@ function parseSubagentIntercomPayload(payload: unknown): { to: string; message: 
   const requestId = typeof record.requestId === "string" ? record.requestId : undefined;
   return { to: record.to, message: record.message, ...(requestId ? { requestId } : {}) };
 }
+function formatAskTimeout(ms: number): string {
+  if (ms % 60000 === 0) {
+    const minutes = ms / 60000;
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  const seconds = Math.round(ms / 1000);
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
+}
+
 function resolveIntercomPresenceName(sessionName: string | undefined, sessionId: string): string {
   const trimmedName = sessionName?.trim();
   if (trimmedName) {
@@ -427,7 +436,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   let runtimeGeneration = 0;
   let agentRunning = false;
   const activeTools = new Map<string, string>();
-  const replyTracker = new ReplyTracker();
+  const replyTracker = new ReplyTracker(resolveAskTimeoutMs());
   const pendingIdleMessages: InboundMessageEntry[] = [];
   let inboundFlushTimer: NodeJS.Timeout | null = null;
   let replyWaiter: {
@@ -443,10 +452,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     if (signal?.aborted) {
       return Promise.reject(new Error("Cancelled"));
     }
+    const askTimeoutMs = resolveAskTimeoutMs();
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
-        rejectReplyWaiter(new Error(`No reply from "${from}" within 10 minutes`));
-      }, 10 * 60 * 1000);
+        rejectReplyWaiter(new Error(`No reply from "${from}" within ${formatAskTimeout(askTimeoutMs)}`));
+      }, askTimeoutMs);
       const cleanup = () => {
         clearTimeout(timeout);
         signal?.removeEventListener("abort", onAbort);

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -967,3 +967,69 @@ test("async ask can be replied to later from the single pending ask fallback", {
     await cleanup();
   }
 });
+
+test("mutual ask is refused immediately so two sessions cannot deadlock", { concurrency: false }, async () => {
+  // Regression for the mutual-ask deadlock: A asks B (expectsReply) and B asks
+  // A back before A's reply lands. Without the guard both turns block in their
+  // own ask until the reply timeout. The broker tracks the outstanding ask edge
+  // and refuses the reverse ask immediately (FIFO: whichever ask it dequeues
+  // first wins). Asserting only delivery of the first ask would pass even with
+  // the bug; the point is the SECOND, reverse ask failing fast — and a plain
+  // send / a reply still working so the guard is not over-broad.
+  const { planner, orchestrator, cleanup } = await setupClients();
+  try {
+    const askA = await planner.send(orchestrator.sessionId!, {
+      messageId: "ask-A",
+      text: "A asks B",
+      expectsReply: true,
+    });
+    assert.equal(askA.delivered, true);
+
+    // Reverse ask while A is still awaiting B's reply → refused immediately.
+    const askB = await orchestrator.send(planner.sessionId!, {
+      messageId: "ask-B",
+      text: "B asks A",
+      expectsReply: true,
+    });
+    assert.equal(askB.delivered, false);
+    assert.match(askB.reason ?? "", /Mutual ask refused/i);
+
+    // A plain (non-reply) send in the reverse direction is unaffected.
+    const plain = await orchestrator.send(planner.sessionId!, { text: "just a note" });
+    assert.equal(plain.delivered, true);
+
+    // Answering A's ask clears the edge; B may then ask A.
+    const reply = await orchestrator.send(planner.sessionId!, { text: "here is B's answer", replyTo: "ask-A" });
+    assert.equal(reply.delivered, true);
+
+    const askBAgain = await orchestrator.send(planner.sessionId!, {
+      messageId: "ask-B2",
+      text: "now B asks A",
+      expectsReply: true,
+    });
+    assert.equal(askBAgain.delivered, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resolveAskTimeoutMs honours PI_INTERCOM_ASK_TIMEOUT_MS and ignores junk", async () => {
+  const { resolveAskTimeoutMs, DEFAULT_ASK_TIMEOUT_MS } = await import("./config.ts");
+  const previous = process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+  try {
+    delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+    assert.equal(resolveAskTimeoutMs(), DEFAULT_ASK_TIMEOUT_MS);
+
+    process.env.PI_INTERCOM_ASK_TIMEOUT_MS = "30000";
+    assert.equal(resolveAskTimeoutMs(), 30000);
+
+    // Below the 1s floor and non-numeric values fall back to the default.
+    process.env.PI_INTERCOM_ASK_TIMEOUT_MS = "500";
+    assert.equal(resolveAskTimeoutMs(), DEFAULT_ASK_TIMEOUT_MS);
+    process.env.PI_INTERCOM_ASK_TIMEOUT_MS = "not-a-number";
+    assert.equal(resolveAskTimeoutMs(), DEFAULT_ASK_TIMEOUT_MS);
+  } finally {
+    if (previous === undefined) delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+    else process.env.PI_INTERCOM_ASK_TIMEOUT_MS = previous;
+  }
+});


### PR DESCRIPTION
Fixes #41. Relates to #14 (configurable timeout) and #29 (the single-session concurrent-ask crash, a different failure mode).

## Problem

Two sessions that `ask` each other at the same time deadlock: each `ask` blocks its caller's turn, so neither is idle to answer the other, and both only unblock at the 10-minute reply timeout. See #41 for the full reproduction.

## Fix

**Broker-side cycle guard** (the broker is the only component with a global view of all sessions):

- Track each session's single outstanding ask edge (`asker -> recipient`).
- When an `ask` (`expectsReply`) arrives whose recipient is already awaiting a reply from the sender, refuse it immediately with a `Mutual ask refused` `delivery_failed`. The caller's existing `!delivered` path turns this into an immediate tool error, so it fails fast and can fall back to `send`/`reply`.
- **FIFO**: whichever ask the broker dequeues first installs the edge and wins; the reverse one is refused. A plain `send` (no reply expected) is untouched.
- Edges clear on reply (`replyTo` match), on disconnect, and via a TTL.

**Configurable reply timeout** (relates to #14): the previously hardcoded 10-minute timeout (in both `waitForReply` and `ReplyTracker`) is now `PI_INTERCOM_ASK_TIMEOUT_MS`, read by both the extension and the broker so the edge TTL stays aligned with the caller-side timeout (a timed-out ask leaves no phantom edge). Values below 1s are ignored.

## Tests

- `mutual ask is refused immediately so two sessions cannot deadlock`: A asks B; the reverse B→A ask fails fast with `Mutual ask refused`; a plain `send` and a `reply` still work; after the reply clears the edge, B can ask A. (Asserts the *reverse* ask fails — the test fails if the guard is removed or is over-broad.)
- `resolveAskTimeoutMs honours PI_INTERCOM_ASK_TIMEOUT_MS and ignores junk`.

`npm test` → 38/38 passing.

## Notes

No protocol/message-type changes — reuses the existing `delivery_failed` path and the `expectsReply` / `replyTo` fields the broker already receives. No new dependencies.
