### PR TITLE
fix(ui): align intercom overlay widths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1735,7 +1735,7 @@ Usage:
 
     const selectedSession = await ctx.ui.custom<SessionInfo | undefined>(
       (_tui, theme, keybindings, done) => new SessionListOverlay(theme, keybindings, currentSession, sessions, done),
-      { overlay: true }
+      { overlay: true, width: 88 }
     ).catch(() => undefined);
 
     if (!selectedSession || !getLiveContext(ctx, overlayGeneration)) return;
@@ -1752,7 +1752,7 @@ Usage:
 
     const result = await ctx.ui.custom<ComposeResult>(
       (tui, theme, keybindings, done) => new ComposeOverlay(tui, theme, keybindings, selectedSession, targetLabel, overlayClient, done),
-      { overlay: true }
+      { overlay: true, width: 72 }
     ).catch(() => undefined);
 
     if (result?.sent && result.messageId && result.text && getLiveContext(ctx, overlayGeneration)) {

--- a/test/overlay-width.test.ts
+++ b/test/overlay-width.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { ComposeOverlay } from "../ui/compose.ts";
+import { SessionListOverlay } from "../ui/session-list.ts";
+import type { SessionInfo } from "../types.ts";
+
+const theme = {
+  fg(_name: string, text: string): string {
+    return text;
+  },
+  bold(text: string): string {
+    return text;
+  },
+};
+
+const keybindings = {
+  matches(): boolean {
+    return false;
+  },
+  getKeys(id: string): string[] {
+    return id.includes("confirm") ? ["enter"] : ["escape", "ctrl+c"];
+  },
+};
+
+const session: SessionInfo = {
+  id: "session-12345678",
+  name: "subagent-chat-019ecaf6",
+  cwd: "/Users/envvar/.config/ghostty",
+  model: "bsy-deepseek-v4-pro",
+  pid: 1,
+  startedAt: 0,
+  lastActivity: 0,
+};
+
+function assertLineWidths(label: string, lines: string[], expectedWidth: number): void {
+  assert.ok(lines.length > 0, `${label} should render lines`);
+  for (const [index, line] of lines.entries()) {
+    assert.equal(visibleWidth(line), expectedWidth, `${label} line ${index} should match overlay width`);
+  }
+}
+
+test("compose overlay renders lines at the declared overlay width", () => {
+  const overlay = new ComposeOverlay(
+    { requestRender() {} } as any,
+    theme as any,
+    keybindings as any,
+    session,
+    "subagent-chat-019ecaf6",
+    { send: async () => ({ delivered: true, id: "message-1" }) } as any,
+    () => {},
+  );
+
+  for (const width of [40, 72]) {
+    assertLineWidths("compose overlay", overlay.render(width), width);
+  }
+});
+
+test("session list overlay renders lines at the declared overlay width", () => {
+  const overlay = new SessionListOverlay(theme as any, keybindings as any, session, [session], () => {});
+
+  for (const width of [50, 88]) {
+    assertLineWidths("session list overlay", overlay.render(width), width);
+  }
+});

--- a/ui/compose.ts
+++ b/ui/compose.ts
@@ -103,7 +103,7 @@ export class ComposeOverlay implements Component {
   }
 
   render(width: number): string[] {
-    const innerWidth = Math.max(24, Math.min(width - 2, 72));
+    const innerWidth = Math.max(24, Math.min(width, 72));
     const contentWidth = Math.max(1, innerWidth - 2);
     const footer = `${this.keybindings.getKeys("tui.select.confirm").join("/")}: Send • ${this.keybindings.getKeys("tui.select.cancel").join("/")}: Close`;
     const border = (text: string) => this.theme.fg("accent", text);

--- a/ui/session-list.ts
+++ b/ui/session-list.ts
@@ -101,7 +101,7 @@ export class SessionListOverlay implements Component {
   }
 
   render(width: number): string[] {
-    const innerWidth = Math.max(36, Math.min(width - 2, 88));
+    const innerWidth = Math.max(36, Math.min(width, 88));
     const contentWidth = Math.max(1, innerWidth - 2);
     const footer = `${this.keybindings.getKeys("tui.select.confirm").join("/")}: Message • ${this.keybindings.getKeys("tui.select.cancel").join("/")}: Close`;
     const border = (text: string) => this.theme.fg("accent", text);


### PR DESCRIPTION
## Summary

Fixes a visual misalignment in the `pi-intercom` session list and compose overlays by making the Pi TUI overlay's declared width match the width rendered by the hand-drawn overlay boxes.

## Problem

`pi-intercom` opens overlays with `ctx.ui.custom(..., { overlay: true })` without declaring width. Pi TUI defaults the overlay width to 80 columns. The overlay components then subtract 2 columns internally (`width - 2`) and draw a narrower box.

That leaves the compositor and component disagreeing about how wide the overlay is. In terminals this can make right-side borders/dividers appear offset or leave background content visually bleeding around the modal.

This is independent of terminal font rendering: before the fix, the pure render contract already fails without a real terminal involved:

- `ComposeOverlay.render(72)` produces 70-column visible lines.
- `SessionListOverlay.render(88)` produces 86-column visible lines.

## History checked

The `width - 2` calculation was introduced in `c5e6a763 fix: polish intercom overlays and reply flow`, when the overlays were changed from floating unboxed content / `SelectList` rendering into hand-drawn bordered modal panels.

That suggests the subtraction was likely intended as visual breathing room while adding panel chrome, not as a Pi TUI API requirement. In Pi TUI's overlay compositor, however, the component is rendered with the resolved overlay width and then composited using that same width. If a component wants an internal gutter, it should still return lines matching the overlay width and put the gutter inside those lines, or the caller should declare a narrower overlay width.

This PR chooses the narrower explicit overlay-width approach so the rendered box and compositor width agree.

## Fix

- Declare the session list overlay width as `88`.
- Declare the compose overlay width as `72`.
- Make `SessionListOverlay.render()` and `ComposeOverlay.render()` use the provided width directly rather than subtracting 2 before drawing the outer box.
- Add regression tests asserting rendered overlay lines match the declared overlay width across multiple widths, not just the default modal widths.

## Verification

Ran targeted regression test:

```bash
npx --yes tsx --test test/overlay-width.test.ts
```

Ran package test subset including the new test:

```bash
npx --yes tsx --test broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts test/inline-message.test.ts test/overlay-width.test.ts
```

Result: 21 tests passed.
