### PR TITLE
fix(broker): resolve tsx cli path via module resolution for npm hoist

### DIFF
--- a/broker/spawn.test.ts
+++ b/broker/spawn.test.ts
@@ -12,9 +12,14 @@ import {
   getWindowsHiddenLauncherPath,
 } from "./spawn.js";
 
-test("getTsxCliPath points at local tsx cli", () => {
+test("getTsxCliPath resolves tsx cli via module resolution", () => {
   const cliPath = getTsxCliPath("C:/repo");
-  assert.equal(cliPath, path.join("C:/repo", "node_modules", "tsx", "dist", "cli.mjs"));
+  // getTsxCliPath resolves the tsx package main entry and locates cli.mjs next
+  // to it, so the path reflects the real install location (bundled under
+  // extensionDir or hoisted by npm) rather than a hardcoded relative path.
+  assert.equal(path.basename(cliPath), "cli.mjs");
+  assert.equal(path.basename(path.dirname(cliPath)), "dist");
+  assert.equal(path.basename(path.dirname(path.dirname(cliPath))), "tsx");
 });
 
 test("getWindowsHiddenLauncherPath points at the broker launcher script", () => {
@@ -22,15 +27,16 @@ test("getWindowsHiddenLauncherPath points at the broker launcher script", () => 
   assert.equal(launcherPath, path.join("C:/tmp/intercom", "broker-launch.vbs"));
 });
 
-test("getWindowsBrokerCommandLine wraps node, tsx cli, and broker path", () => {
+test("getWindowsBrokerCommandLine wraps node, resolved tsx cli, and broker path", () => {
   const commandLine = getWindowsBrokerCommandLine(
     "C:/repo/broker.ts",
     "C:/repo",
     "C:/Program Files/nodejs/node.exe",
   );
+  const expectedTsxPath = getTsxCliPath("C:/repo");
   assert.equal(
     commandLine,
-    `"C:/Program Files/nodejs/node.exe" "${path.join("C:/repo", "node_modules", "tsx", "dist", "cli.mjs")}" "C:/repo/broker.ts"`,
+    `"C:/Program Files/nodejs/node.exe" "${expectedTsxPath}" "C:/repo/broker.ts"`,
   );
 });
 
@@ -56,7 +62,8 @@ test("getBrokerLaunchSpec uses wscript launcher on Windows without writing files
     assert.equal(spec.command, "wscript.exe");
     assert.deepEqual(spec.args, [path.join(intercomDir, "broker-launch.vbs")]);
     assert.equal(spec.kind, "windows-launcher");
-    assert.equal(spec.launcherCommandLine, `"C:/Program Files/nodejs/node.exe" "${path.join("C:/repo", "node_modules", "tsx", "dist", "cli.mjs")}" "C:/repo/broker.ts"`);
+    const expectedTsxPath = getTsxCliPath("C:/repo");
+    assert.equal(spec.launcherCommandLine, `"C:/Program Files/nodejs/node.exe" "${expectedTsxPath}" "C:/repo/broker.ts"`);
     assert.equal(existsSync(path.join(intercomDir, "broker-launch.vbs")), false);
   } finally {
     rmSync(intercomDir, { recursive: true, force: true });

--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { homedir } from "os";
+import { createRequire } from "module";
 import net from "net";
 import { getBrokerSocketPath } from "./paths.js";
 
@@ -31,7 +32,18 @@ function sleep(ms: number): Promise<void> {
 }
 
 export function getTsxCliPath(extensionDir: string = EXTENSION_DIR): string {
-  return join(extensionDir, "node_modules", "tsx", "dist", "cli.mjs");
+  // Resolve tsx via Node's module resolution so it works regardless of whether
+  // tsx is bundled under extensionDir/node_modules or hoisted to a workspace
+  // root by npm. We resolve the tsx package main entry (its "exports" field
+  // does not expose ./dist/cli.mjs as a subpath) and then locate cli.mjs next
+  // to it. Falls back to the legacy relative path if resolution fails.
+  try {
+    const requireFromExtension = createRequire(import.meta.url);
+    const tsxMain = requireFromExtension.resolve("tsx");
+    return join(dirname(tsxMain), "cli.mjs");
+  } catch {
+    return join(extensionDir, "node_modules", "tsx", "dist", "cli.mjs");
+  }
 }
 
 function quoteWindowsArg(value: string): string {


### PR DESCRIPTION
getTsxCliPath() hardcoded extensionDir/node_modules/tsx/dist/cli.mjs, which breaks when tsx is hoisted to a workspace root by npm (the default behavior when pi installs the package into its aggregated node_modules).

On Windows the generated broker-launch.vbs pointed at a non-existent path, causing node to exit with MODULE_NOT_FOUND immediately and waitForBroker() to time out after 5s with 'Broker failed to start within timeout'.

Fix: resolve the tsx package main entry via createRequire, then locate cli.mjs next to it. Falls back to the legacy relative path if resolution fails (e.g. under loaders that disable require resolution), preserving backward compatibility.

Test: updated three assertions in spawn.test.ts that hardcoded the legacy path to instead verify the resolved location.