### PR TITLE
fix(ui): align intercom overlay widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 - Updated Pi runtime peer metadata and tool schemas for the `@earendil-works` package scope and Pi-bundled `typebox`/`pi-ai` packages.
 
 ### Fixed
+- Aligned intercom overlay widths with their rendered modal boxes. Thanks to Cat for PR #43.
 - Marked failed `intercom` and `contact_supervisor` tool results through Pi's `tool_result` error flag path while preserving structured renderer details.
 - Limited the intercom overlay to TUI mode and unsubscribed subagent relay event handlers during session shutdown.
 

--- a/index.ts
+++ b/index.ts
@@ -1718,7 +1718,7 @@ Usage:
 
     const selectedSession = await ctx.ui.custom<SessionInfo | undefined>(
       (_tui, theme, keybindings, done) => new SessionListOverlay(theme, keybindings, currentSession, sessions, done),
-      { overlay: true }
+      { overlay: true, overlayOptions: { width: 88 } }
     ).catch(() => undefined);
 
     if (!selectedSession || !getLiveContext(ctx, overlayGeneration)) return;
@@ -1735,7 +1735,7 @@ Usage:
 
     const result = await ctx.ui.custom<ComposeResult>(
       (tui, theme, keybindings, done) => new ComposeOverlay(tui, theme, keybindings, selectedSession, targetLabel, overlayClient, done),
-      { overlay: true }
+      { overlay: true, overlayOptions: { width: 72 } }
     ).catch(() => undefined);
 
     if (result?.sent && result.messageId && result.text && getLiveContext(ctx, overlayGeneration)) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts"
+    "test": "tsx --test broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/test/overlay-width.test.ts
+++ b/test/overlay-width.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { ComposeOverlay } from "../ui/compose.ts";
+import { SessionListOverlay } from "../ui/session-list.ts";
+import type { SessionInfo } from "../types.ts";
+
+const theme = {
+  fg(_name: string, text: string): string {
+    return text;
+  },
+  bold(text: string): string {
+    return text;
+  },
+};
+
+const keybindings = {
+  matches(): boolean {
+    return false;
+  },
+  getKeys(id: string): string[] {
+    return id.includes("confirm") ? ["enter"] : ["escape", "ctrl+c"];
+  },
+};
+
+const session: SessionInfo = {
+  id: "session-12345678",
+  name: "subagent-chat-019ecaf6",
+  cwd: "/Users/envvar/.config/ghostty",
+  model: "bsy-deepseek-v4-pro",
+  pid: 1,
+  startedAt: 0,
+  lastActivity: 0,
+};
+
+function assertLineWidths(label: string, lines: string[], expectedWidth: number): void {
+  assert.ok(lines.length > 0, `${label} should render lines`);
+  for (const [index, line] of lines.entries()) {
+    assert.equal(visibleWidth(line), expectedWidth, `${label} line ${index} should match overlay width`);
+  }
+}
+
+test("compose overlay renders lines at the declared overlay width", () => {
+  const overlay = new ComposeOverlay(
+    { requestRender() {} } as any,
+    theme as any,
+    keybindings as any,
+    session,
+    "subagent-chat-019ecaf6",
+    { send: async () => ({ delivered: true, id: "message-1" }) } as any,
+    () => {},
+  );
+
+  for (const width of [1, 2, 20, 40, 72]) {
+    assertLineWidths("compose overlay", overlay.render(width), width);
+  }
+});
+
+test("session list overlay renders lines at the declared overlay width", () => {
+  const overlay = new SessionListOverlay(theme as any, keybindings as any, session, [session], () => {});
+
+  for (const width of [1, 2, 20, 50, 88]) {
+    assertLineWidths("session list overlay", overlay.render(width), width);
+  }
+});

--- a/ui/compose.ts
+++ b/ui/compose.ts
@@ -103,8 +103,12 @@ export class ComposeOverlay implements Component {
   }
 
   render(width: number): string[] {
-    const innerWidth = Math.max(24, Math.min(width - 2, 72));
-    const contentWidth = Math.max(1, innerWidth - 2);
+    const innerWidth = Math.max(1, Math.min(width, 72));
+    if (innerWidth === 1) {
+      return [this.theme.fg("accent", "│")];
+    }
+
+    const contentWidth = Math.max(0, innerWidth - 2);
     const footer = `${this.keybindings.getKeys("tui.select.confirm").join("/")}: Send • ${this.keybindings.getKeys("tui.select.cancel").join("/")}: Close`;
     const border = (text: string) => this.theme.fg("accent", text);
     const row = (text = "") => {

--- a/ui/session-list.ts
+++ b/ui/session-list.ts
@@ -101,8 +101,12 @@ export class SessionListOverlay implements Component {
   }
 
   render(width: number): string[] {
-    const innerWidth = Math.max(36, Math.min(width - 2, 88));
-    const contentWidth = Math.max(1, innerWidth - 2);
+    const innerWidth = Math.max(1, Math.min(width, 88));
+    if (innerWidth === 1) {
+      return [this.theme.fg("accent", "│")];
+    }
+
+    const contentWidth = Math.max(0, innerWidth - 2);
     const footer = `${this.keybindings.getKeys("tui.select.confirm").join("/")}: Message • ${this.keybindings.getKeys("tui.select.cancel").join("/")}: Close`;
     const border = (text: string) => this.theme.fg("accent", text);
     const row = (text = "") => {


### PR DESCRIPTION
## Summary

This fixes the intercom session-list and compose overlays so the width requested from Pi's overlay compositor matches the width rendered by the modal boxes.

Cat identified the bug and proposed the original fix in #43. This branch applies that work directly on current `main`, updates it for the current `@earendil-works` package scope and `overlayOptions` API, includes the regression test in `npm test`, and adds changelog credit.

## Verification

- `npm test` passed, 39/39
- `git diff --check` passed
- `tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --allowImportingTsExtensions ...` passed
- `npm pack --dry-run` passed
- fresh reviewer pass: no issues found

Closes #43 after merge.
