### PR TITLE
fix: harden broker framing and runtime files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 - Updated Pi runtime peer metadata and tool schemas for the `@earendil-works` package scope and Pi-bundled `typebox`/`pi-ai` packages.
 
 ### Fixed
+- Added an inbound broker frame size cap to reject oversized local IPC messages before buffering their payloads.
+- Restricted Unix intercom runtime directory, socket, PID, and spawn-lock permissions.
 - Aligned intercom overlay widths with their rendered modal boxes. Thanks to Cat for PR #43.
 - Marked failed `intercom` and `contact_supervisor` tool results through Pi's `tool_result` error flag path while preserving structured renderer details.
 - Limited the intercom overlay to TUI mode and unsubscribed subagent relay event handlers during session shutdown.

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -1,13 +1,18 @@
 import net from "net";
-import { writeFileSync, unlinkSync, mkdirSync } from "fs";
+import { writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
-import { getBrokerSocketPath } from "./paths.ts";
+import {
+  ensureIntercomRuntimeDir,
+  getBrokerSocketPath,
+  getIntercomDirPath,
+  INTERCOM_RUNTIME_FILE_MODE,
+  restrictIntercomRuntimeFile,
+} from "./paths.ts";
 import type { SessionInfo, Message, Attachment, BrokerMessage } from "../types.ts";
 
-const INTERCOM_DIR = join(homedir(), ".pi/agent/intercom");
+const INTERCOM_DIR = getIntercomDirPath();
 const SOCKET_PATH = getBrokerSocketPath();
 const PID_PATH = join(INTERCOM_DIR, "broker.pid");
 
@@ -100,7 +105,7 @@ class IntercomBroker {
   private shutdownTimer: NodeJS.Timeout | null = null;
 
   constructor() {
-    mkdirSync(INTERCOM_DIR, { recursive: true });
+    ensureIntercomRuntimeDir(INTERCOM_DIR);
     if (process.platform !== "win32") {
       try {
         unlinkSync(SOCKET_PATH);
@@ -113,7 +118,9 @@ class IntercomBroker {
 
   start(): void {
     this.server.listen(SOCKET_PATH, () => {
-      writeFileSync(PID_PATH, String(process.pid));
+      restrictIntercomRuntimeFile(SOCKET_PATH);
+      writeFileSync(PID_PATH, String(process.pid), { mode: INTERCOM_RUNTIME_FILE_MODE });
+      restrictIntercomRuntimeFile(PID_PATH);
       console.log(`Intercom broker started (pid: ${process.pid})`);
     });
     process.on("SIGTERM", () => this.shutdown());

--- a/broker/framing.test.ts
+++ b/broker/framing.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createMessageReader, writeMessage } from "./framing.ts";
+
+function framePayload(payload: Buffer): Buffer {
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(payload.length, 0);
+  return Buffer.concat([header, payload]);
+}
+
+test("createMessageReader handles normal fragmented frames", () => {
+  const messages: unknown[] = [];
+  const errors: Error[] = [];
+  const reader = createMessageReader(
+    (message) => messages.push(message),
+    (error) => errors.push(error),
+    64,
+  );
+  const frameA = framePayload(Buffer.from(JSON.stringify({ type: "one" }), "utf-8"));
+  const frameB = framePayload(Buffer.from(JSON.stringify({ type: "two" }), "utf-8"));
+  const combined = Buffer.concat([frameA, frameB]);
+
+  reader(combined.subarray(0, 2));
+  reader(combined.subarray(2, 7));
+  reader(combined.subarray(7));
+
+  assert.deepEqual(messages, [{ type: "one" }, { type: "two" }]);
+  assert.deepEqual(errors, []);
+});
+
+test("createMessageReader rejects an oversized declared frame", () => {
+  const messages: unknown[] = [];
+  const errors: Error[] = [];
+  const reader = createMessageReader(
+    (message) => messages.push(message),
+    (error) => errors.push(error),
+    8,
+  );
+  const oversizedFrame = framePayload(Buffer.from(JSON.stringify({ text: "too large" }), "utf-8"));
+
+  reader(oversizedFrame);
+
+  assert.deepEqual(messages, []);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0].message, /Intercom frame length \d+ exceeds maximum 8 bytes/);
+});
+
+test("createMessageReader rejects an oversized frame before retaining same-chunk payload bytes", () => {
+  const messages: unknown[] = [];
+  const errors: Error[] = [];
+  const reader = createMessageReader(
+    (message) => messages.push(message),
+    (error) => errors.push(error),
+    8,
+  );
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(9, 0);
+
+  reader(Buffer.concat([header, Buffer.alloc(1024 * 1024)]));
+
+  assert.deepEqual(messages, []);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].message, "Intercom frame length 9 exceeds maximum 8 bytes");
+});
+
+test("createMessageReader rejects a partial oversized frame before buffering the payload", () => {
+  const messages: unknown[] = [];
+  const errors: Error[] = [];
+  const reader = createMessageReader(
+    (message) => messages.push(message),
+    (error) => errors.push(error),
+    8,
+  );
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(9, 0);
+
+  reader(header);
+
+  assert.deepEqual(messages, []);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].message, "Intercom frame length 9 exceeds maximum 8 bytes");
+});
+
+test("writeMessage emits frames accepted by createMessageReader", () => {
+  const chunks: Buffer[] = [];
+  const socket = { write: (chunk: Buffer) => chunks.push(chunk) };
+  const messages: unknown[] = [];
+  const reader = createMessageReader((message) => messages.push(message), assert.fail, 64);
+
+  writeMessage(socket as never, { ok: true });
+  reader(Buffer.concat(chunks));
+
+  assert.deepEqual(messages, [{ ok: true }]);
+});

--- a/broker/framing.ts
+++ b/broker/framing.ts
@@ -1,5 +1,7 @@
 import type { Socket } from "net";
 
+export const MAX_FRAME_BYTES = 1024 * 1024;
+
 /**
  * Write a length-prefixed message to a socket.
  * Format: 4-byte big-endian length + JSON payload
@@ -20,36 +22,64 @@ export function writeMessage(socket: Socket, msg: unknown): void {
 export function createMessageReader(
   onMessage: (msg: unknown) => void,
   onError: (error: Error) => void,
+  maxFrameBytes = MAX_FRAME_BYTES,
 ) {
   let buffer = Buffer.alloc(0);
 
-  return (data: Buffer) => {
-    buffer = Buffer.concat([buffer, data]);
+  function reportMessage(payload: Buffer): boolean {
+    let msg: unknown;
+    try {
+      msg = JSON.parse(payload.toString("utf-8"));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      onError(new Error(`Failed to parse intercom message: ${message}`, { cause: error }));
+      return false;
+    }
 
-    while (buffer.length >= 4) {
-      const length = buffer.readUInt32BE(0);
-      
-      if (buffer.length < 4 + length) {
-        break;
+    try {
+      onMessage(msg);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      onError(new Error(`Failed to handle intercom message: ${message}`, { cause: error }));
+      return false;
+    }
+  }
+
+  return (data: Buffer) => {
+    let remaining = data;
+
+    while (remaining.length > 0) {
+      if (buffer.length < 4) {
+        const headerBytes = Math.min(4 - buffer.length, remaining.length);
+        buffer = Buffer.concat([buffer, remaining.subarray(0, headerBytes)]);
+        remaining = remaining.subarray(headerBytes);
+        if (buffer.length < 4) {
+          return;
+        }
       }
 
-      const payload = buffer.subarray(4, 4 + length);
-      buffer = buffer.subarray(4 + length);
-
-      let msg: unknown;
-      try {
-        msg = JSON.parse(payload.toString("utf-8"));
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        onError(new Error(`Failed to parse intercom message: ${message}`, { cause: error }));
+      const length = buffer.readUInt32BE(0);
+      if (length > maxFrameBytes) {
+        buffer = Buffer.alloc(0);
+        onError(new Error(`Intercom frame length ${length} exceeds maximum ${maxFrameBytes} bytes`));
         return;
       }
 
-      try {
-        onMessage(msg);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        onError(new Error(`Failed to handle intercom message: ${message}`, { cause: error }));
+      const missingPayloadBytes = length - Math.max(0, buffer.length - 4);
+      const payloadBytes = Math.min(missingPayloadBytes, remaining.length);
+      if (payloadBytes > 0) {
+        buffer = Buffer.concat([buffer, remaining.subarray(0, payloadBytes)]);
+        remaining = remaining.subarray(payloadBytes);
+      }
+
+      if (buffer.length < 4 + length) {
+        return;
+      }
+
+      const payload = buffer.subarray(4, 4 + length);
+      buffer = Buffer.alloc(0);
+      if (!reportMessage(payload)) {
         return;
       }
     }

--- a/broker/paths.test.ts
+++ b/broker/paths.test.ts
@@ -1,6 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { getBrokerSocketPath } from "./paths.ts";
+import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ensureIntercomRuntimeDir,
+  getBrokerSocketPath,
+  getIntercomDirPath,
+  INTERCOM_DIR_MODE,
+  INTERCOM_RUNTIME_FILE_MODE,
+  restrictIntercomRuntimeFile,
+} from "./paths.ts";
 
 test("getBrokerSocketPath uses named pipe on Windows", () => {
   const pipePath = getBrokerSocketPath("win32", "C:/Users/rcroh");
@@ -12,4 +22,50 @@ test("getBrokerSocketPath uses broker.sock on non-Windows", () => {
   const socketPath = getBrokerSocketPath("linux", "/home/rcroh");
   assert.match(socketPath, /broker\.sock$/);
   assert.match(socketPath, /rcroh/);
+});
+
+test("getIntercomDirPath points at the pi intercom runtime directory", () => {
+  assert.equal(getIntercomDirPath("/home/rcroh"), join("/home/rcroh", ".pi/agent/intercom"));
+});
+
+test("ensureIntercomRuntimeDir creates and repairs restrictive Unix directory permissions", { skip: process.platform === "win32" }, () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-paths-"));
+  const intercomDir = join(root, "intercom");
+
+  try {
+    ensureIntercomRuntimeDir(intercomDir, "linux");
+    assert.equal(statSync(intercomDir).mode & 0o777, INTERCOM_DIR_MODE);
+
+    chmodSync(intercomDir, 0o755);
+    ensureIntercomRuntimeDir(intercomDir, "linux");
+    assert.equal(statSync(intercomDir).mode & 0o777, INTERCOM_DIR_MODE);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("restrictIntercomRuntimeFile applies restrictive Unix file permissions", { skip: process.platform === "win32" }, () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-paths-"));
+  const filePath = join(root, "broker.pid");
+
+  try {
+    writeFileSync(filePath, "123", { mode: 0o644 });
+    restrictIntercomRuntimeFile(filePath, "linux");
+    assert.equal(statSync(filePath).mode & 0o777, INTERCOM_RUNTIME_FILE_MODE);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runtime permission helpers skip chmod on Windows paths", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-paths-"));
+  const filePath = join(root, "broker.pid");
+
+  try {
+    ensureIntercomRuntimeDir(root, "win32");
+    writeFileSync(filePath, "123");
+    assert.doesNotThrow(() => restrictIntercomRuntimeFile(filePath, "win32"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/broker/paths.ts
+++ b/broker/paths.ts
@@ -1,11 +1,19 @@
+import { chmodSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+
+export const INTERCOM_DIR_MODE = 0o700;
+export const INTERCOM_RUNTIME_FILE_MODE = 0o600;
 
 function sanitizePipeSegment(value: string): string {
   return value
     .replace(/[^a-zA-Z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .toLowerCase() || "default";
+}
+
+export function getIntercomDirPath(homeDir: string = homedir()): string {
+  return join(homeDir, ".pi/agent/intercom");
 }
 
 export function getBrokerSocketPath(
@@ -16,5 +24,24 @@ export function getBrokerSocketPath(
     return `\\\\.\\pipe\\pi-intercom-${sanitizePipeSegment(homeDir)}`;
   }
 
-  return join(homeDir, ".pi/agent/intercom/broker.sock");
+  return join(getIntercomDirPath(homeDir), "broker.sock");
+}
+
+export function ensureIntercomRuntimeDir(
+  intercomDir: string = getIntercomDirPath(),
+  platform: NodeJS.Platform = process.platform,
+): void {
+  mkdirSync(intercomDir, { recursive: true, mode: INTERCOM_DIR_MODE });
+  if (platform !== "win32") {
+    chmodSync(intercomDir, INTERCOM_DIR_MODE);
+  }
+}
+
+export function restrictIntercomRuntimeFile(
+  filePath: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== "win32") {
+    chmodSync(filePath, INTERCOM_RUNTIME_FILE_MODE);
+  }
 }

--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -1,13 +1,18 @@
 import { spawn } from "child_process";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { homedir } from "os";
 import { createRequire } from "module";
 import net from "net";
-import { getBrokerSocketPath } from "./paths.ts";
+import {
+  ensureIntercomRuntimeDir,
+  getBrokerSocketPath,
+  getIntercomDirPath,
+  INTERCOM_RUNTIME_FILE_MODE,
+  restrictIntercomRuntimeFile,
+} from "./paths.ts";
 
-const INTERCOM_DIR = join(homedir(), ".pi/agent/intercom");
+const INTERCOM_DIR = getIntercomDirPath();
 const EXTENSION_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
 const BROKER_SOCKET = getBrokerSocketPath();
 const BROKER_PID = join(INTERCOM_DIR, "broker.pid");
@@ -88,8 +93,12 @@ function writeWindowsHiddenLauncher(
   commandLine: string,
   launcherPath: string = getWindowsHiddenLauncherPath(),
 ): string {
-  mkdirSync(dirname(launcherPath), { recursive: true });
-  writeFileSync(launcherPath, getWindowsHiddenLauncherScript(commandLine), "utf-8");
+  ensureIntercomRuntimeDir(dirname(launcherPath));
+  writeFileSync(launcherPath, getWindowsHiddenLauncherScript(commandLine), {
+    encoding: "utf-8",
+    mode: INTERCOM_RUNTIME_FILE_MODE,
+  });
+  restrictIntercomRuntimeFile(launcherPath);
   return launcherPath;
 }
 
@@ -141,7 +150,7 @@ function toError(error: unknown): Error {
 }
 
 export async function spawnBrokerIfNeeded(brokerCommand: string, brokerArgs: string[]): Promise<void> {
-  mkdirSync(INTERCOM_DIR, { recursive: true });
+  ensureIntercomRuntimeDir(INTERCOM_DIR);
 
   if (await isBrokerRunning()) {
     return;
@@ -252,7 +261,11 @@ function acquireSpawnLock(): boolean {
   const maxRetries = 5;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      writeFileSync(BROKER_SPAWN_LOCK, `${process.pid}\n${Date.now()}\n`, { flag: "wx" });
+      writeFileSync(BROKER_SPAWN_LOCK, `${process.pid}\n${Date.now()}\n`, {
+        flag: "wx",
+        mode: INTERCOM_RUNTIME_FILE_MODE,
+      });
+      restrictIntercomRuntimeFile(BROKER_SPAWN_LOCK);
       return true;
     } catch (error) {
       if (!(error instanceof Error) || (error as NodeJS.ErrnoException).code !== "EEXIST") {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"


### PR DESCRIPTION
## Summary

Hardens the local intercom broker around two security issues:

- adds a 1 MiB inbound frame cap so oversized frames are rejected before buffering payload bytes
- restricts Unix runtime directory, socket, PID, and spawn-lock permissions

## Verification

- `npm test` passed, 48/48
- `git diff --check` passed
- `tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --allowImportingTsExtensions $(git ls-files '*.ts')` passed
- `npm pack --dry-run` passed
- fresh reviewer pass: no issues found

Closes #18.
Closes #17.
