### PR TITLE
fix: guard ask concurrency deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Fixed
 - Added an inbound broker frame size cap to reject oversized local IPC messages before buffering their payloads.
 - Restricted Unix intercom runtime directory, socket, PID, and spawn-lock permissions.
+- Rechecked single-flight ask state after session target resolution so concurrent regular asks fail safely instead of crashing on an unhandled rejected reply waiter.
+- Refused broker-level mutual asks that would deadlock two sessions, and cleared outstanding ask edges when asks are replied to, cancelled, or disconnected.
 - Aligned intercom overlay widths with their rendered modal boxes. Thanks to Cat for PR #43.
 - Marked failed `intercom` and `contact_supervisor` tool results through Pi's `tool_result` error flag path while preserving structured renderer details.
 - Limited the intercom overlay to TUI mode and unsubscribed subagent relay event handlers during session shutdown.

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -10,6 +10,7 @@ import {
   INTERCOM_RUNTIME_FILE_MODE,
   restrictIntercomRuntimeFile,
 } from "./paths.ts";
+import { getAskTimeoutMs } from "../config.ts";
 import type { SessionInfo, Message, Attachment, BrokerMessage } from "../types.ts";
 
 const INTERCOM_DIR = getIntercomDirPath();
@@ -19,6 +20,12 @@ const PID_PATH = join(INTERCOM_DIR, "broker.pid");
 interface ConnectedSession {
   socket: net.Socket;
   info: SessionInfo;
+}
+
+interface AskEdge {
+  from: string;
+  to: string;
+  createdAt: number;
 }
 
 function isAttachment(value: unknown): value is Attachment {
@@ -101,8 +108,10 @@ function isSessionRegistration(value: unknown): value is Omit<SessionInfo, "id">
 
 class IntercomBroker {
   private sessions = new Map<string, ConnectedSession>();
+  private askEdges = new Map<string, AskEdge>();
   private server: net.Server;
   private shutdownTimer: NodeJS.Timeout | null = null;
+  private readonly askTimeoutMs = getAskTimeoutMs();
 
   constructor() {
     ensureIntercomRuntimeDir(INTERCOM_DIR);
@@ -143,6 +152,7 @@ class IntercomBroker {
     socket.on("close", () => {
       if (sessionId) {
         this.sessions.delete(sessionId);
+        this.clearAskEdgesForSession(sessionId);
         this.broadcast({ type: "session_left", sessionId }, sessionId);
 
         this.scheduleShutdownCheck();
@@ -208,7 +218,11 @@ class IntercomBroker {
       }
 
       case "unregister": {
+        if (!currentId) {
+          throw new Error("Received unregister before register");
+        }
         this.sessions.delete(currentId);
+        this.clearAskEdgesForSession(currentId);
         this.broadcast({ type: "session_left", sessionId: currentId }, currentId);
         setId(null);
         this.scheduleShutdownCheck();
@@ -226,6 +240,9 @@ class IntercomBroker {
       }
 
       case "send": {
+        if (!currentId) {
+          throw new Error("Received send before register");
+        }
         const message = clientMessage.message;
         const messageId = isMessage(message) ? message.id : "unknown";
 
@@ -238,6 +255,9 @@ class IntercomBroker {
           break;
         }
 
+        this.pruneAskEdges();
+        const replyEdge = message.replyTo ? this.askEdges.get(message.replyTo) : undefined;
+
         const targets = this.findSessions(clientMessage.to);
         if (targets.length === 1) {
           const fromSession = this.sessions.get(currentId);
@@ -249,11 +269,35 @@ class IntercomBroker {
             });
             break;
           }
-          writeMessage(targets[0].socket, {
+          const target = targets[0];
+          if (replyEdge && (replyEdge.to !== currentId || replyEdge.from !== target.info.id)) {
+            writeMessage(socket, {
+              type: "delivery_failed",
+              messageId: message.id,
+              reason: "Reply target does not match the pending ask",
+            });
+            break;
+          }
+          if (message.expectsReply) {
+            const reverseEdge = Array.from(this.askEdges.entries()).find(([edgeMessageId, edge]) => edgeMessageId !== message.replyTo && edge.from === target.info.id && edge.to === currentId);
+            if (reverseEdge) {
+              writeMessage(socket, {
+                type: "delivery_failed",
+                messageId: message.id,
+                reason: "Mutual ask refused: target session is already waiting for a reply from this session.",
+              });
+              break;
+            }
+            this.askEdges.set(message.id, { from: currentId, to: target.info.id, createdAt: Date.now() });
+          }
+          writeMessage(target.socket, {
             type: "message",
             from: fromSession.info,
             message,
           });
+          if (message.replyTo) {
+            this.askEdges.delete(message.replyTo);
+          }
           writeMessage(socket, { type: "delivered", messageId: message.id });
           break;
         }
@@ -275,7 +319,24 @@ class IntercomBroker {
         break;
       }
 
+      case "cancel_ask": {
+        if (!currentId) {
+          throw new Error("Received cancel_ask before register");
+        }
+        if (typeof clientMessage.messageId !== "string") {
+          throw new Error("Invalid cancel_ask message");
+        }
+        const edge = this.askEdges.get(clientMessage.messageId);
+        if (edge?.from === currentId) {
+          this.askEdges.delete(clientMessage.messageId);
+        }
+        break;
+      }
+
       case "presence": {
+        if (!currentId) {
+          throw new Error("Received presence before register");
+        }
         const session = this.sessions.get(currentId);
         if (session) {
           if (clientMessage.name !== undefined) {
@@ -307,6 +368,22 @@ class IntercomBroker {
     }
   }
 
+  private pruneAskEdges(now = Date.now()): void {
+    for (const [messageId, edge] of this.askEdges) {
+      if (now - edge.createdAt > this.askTimeoutMs) {
+        this.askEdges.delete(messageId);
+      }
+    }
+  }
+
+  private clearAskEdgesForSession(sessionId: string): void {
+    for (const [messageId, edge] of this.askEdges) {
+      if (edge.from === sessionId || edge.to === sessionId) {
+        this.askEdges.delete(messageId);
+      }
+    }
+  }
+
   private findSessions(nameOrId: string): ConnectedSession[] {
     const byId = this.sessions.get(nameOrId);
     if (byId) {
@@ -332,6 +409,7 @@ class IntercomBroker {
       session.socket.end();
     }
     this.sessions.clear();
+    this.askEdges.clear();
     if (process.platform !== "win32") {
       try {
         unlinkSync(SOCKET_PATH);

--- a/broker/client.test.ts
+++ b/broker/client.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { IntercomClient } from "./client.ts";
+
+test("cancelAsk ignores synchronous socket write failures", () => {
+  const client = new IntercomClient();
+  (client as any)._sessionId = "session-1";
+  (client as any).socket = {
+    destroyed: false,
+    writableEnded: false,
+    writable: true,
+    write() {
+      throw new Error("write failed");
+    },
+  };
+
+  assert.doesNotThrow(() => client.cancelAsk("ask-1"));
+});

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -520,6 +520,23 @@ export class IntercomClient extends EventEmitter {
     });
   }
 
+  cancelAsk(messageId: string): void {
+    if (this.disconnecting) {
+      return;
+    }
+
+    const socket = this.socket;
+    if (!socket || !this._sessionId || socket.destroyed || socket.writableEnded || !socket.writable) {
+      return;
+    }
+
+    try {
+      writeMessage(socket, { type: "cancel_ask", messageId });
+    } catch {
+      // Cancellation is best-effort; local waiter cleanup must still proceed.
+    }
+  }
+
   updatePresence(updates: { name?: string; status?: string; model?: string }): void {
     if (this.disconnecting) {
       return;

--- a/config.ts
+++ b/config.ts
@@ -2,6 +2,21 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
+export const DEFAULT_ASK_TIMEOUT_MS = 10 * 60 * 1000;
+
+export function getAskTimeoutMs(): number {
+  const raw = process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_ASK_TIMEOUT_MS;
+  }
+
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error("PI_INTERCOM_ASK_TIMEOUT_MS must be a positive integer number of milliseconds");
+  }
+  return value;
+}
+
 export interface IntercomConfig {
   /** Broker command used to spawn the broker process (e.g. "npx" or "bun") */
   brokerCommand: string;

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ import { spawnBrokerIfNeeded } from "./broker/spawn.ts";
 import { SessionListOverlay } from "./ui/session-list.ts";
 import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
 import { InlineMessageComponent } from "./ui/inline-message.ts";
-import { loadConfig, type IntercomConfig } from "./config.ts";
+import { getAskTimeoutMs, loadConfig, type IntercomConfig } from "./config.ts";
 import type { SessionInfo, Message, Attachment } from "./types.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
 
@@ -413,6 +413,7 @@ function firstTextContent(result: { content?: Array<{ type: string; text?: strin
 export default function piIntercomExtension(pi: ExtensionAPI) {
   let client: IntercomClient | null = null;
   const config: IntercomConfig = loadConfig();
+  const askTimeoutMs = getAskTimeoutMs();
   let runtimeContext: ExtensionContext | null = null;
   let currentSessionId: string | null = null;
   let currentModel = "unknown";
@@ -437,7 +438,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     resolve: (message: Message) => void;
     reject: (error: Error) => void;
   } | null = null;
-  function waitForReply(from: string, replyTo: string, signal?: AbortSignal): Promise<Message> {
+  function waitForReply(from: string, replyTo: string, signal?: AbortSignal, onCancel?: () => void): Promise<Message> {
     if (replyWaiter) {
       return Promise.reject(new Error("Already waiting for a reply"));
     }
@@ -446,8 +447,10 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
-        rejectReplyWaiter(new Error(`No reply from "${from}" within 10 minutes`));
-      }, 10 * 60 * 1000);
+        onCancel?.();
+        const timeoutDescription = askTimeoutMs % 60000 === 0 ? `${askTimeoutMs / 60000} minutes` : `${askTimeoutMs}ms`;
+        rejectReplyWaiter(new Error(`No reply from "${from}" within ${timeoutDescription}`));
+      }, askTimeoutMs);
       const cleanup = () => {
         clearTimeout(timeout);
         signal?.removeEventListener("abort", onAbort);
@@ -456,6 +459,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         }
       };
       const onAbort = () => {
+        onCancel?.();
         cleanup();
         reject(new Error("Cancelled"));
       };
@@ -1187,7 +1191,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         let replyPromise: Promise<Message> | null = null;
         try {
           const questionId = randomUUID();
-          replyPromise = waitForReply(sendTo, questionId, signal);
+          replyPromise = waitForReply(sendTo, questionId, signal, () => connectedClient.cancelAsk(questionId));
           replyPromise.catch(() => undefined);
           if (signal?.aborted) {
             rejectReplyWaiter(new Error("Cancelled"));
@@ -1489,8 +1493,15 @@ Usage:
                 details: { error: true },
               };
             }
+            if (replyWaiter) {
+              return {
+                content: [{ type: "text", text: "Already waiting for a reply" }],
+                details: { error: true },
+              };
+            }
             const questionId = randomUUID();
-            replyPromise = waitForReply(sendTo, questionId, _signal);
+            replyPromise = waitForReply(sendTo, questionId, _signal, () => connectedClient.cancelAsk(questionId));
+            replyPromise.catch(() => undefined);
             const sendResult = await connectedClient.send(sendTo, {
               messageId: questionId,
               text: message,

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -805,6 +805,199 @@ test("child supervisor tool preserves delivery failure reasons", { concurrency: 
   }
 });
 
+test("regular intercom asks fail safely when started concurrently", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { orchestrator, cleanup } = await setupClients();
+
+  try {
+    const harness = createExtensionHarness("regular-ask-worker");
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    await waitForSessionByName(orchestrator, "regular-ask-worker");
+    const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
+
+    const firstMessage = once(orchestrator, "message") as Promise<[SessionInfo, Message]>;
+    const firstAsk = intercomTool.execute("ask-1", { action: "ask", to: "orchestrator", message: "First?" }, new AbortController().signal, undefined, harness.ctx);
+    const secondAsk = intercomTool.execute("ask-2", { action: "ask", to: "orchestrator", message: "Second?" }, new AbortController().signal, undefined, harness.ctx);
+    const [from, askMessage] = await firstMessage;
+    assert.equal(askMessage.expectsReply, true);
+
+    const earlyResults = await Promise.race([
+      Promise.all([firstAsk, secondAsk]),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 100)),
+    ]);
+    assert.equal(earlyResults, null);
+
+    const pendingResult = await Promise.race([firstAsk, secondAsk]);
+    assert.equal(pendingResult.details?.error, true);
+    assert.match(pendingResult.content[0]?.text ?? "", /Already waiting/);
+
+    const reply = await orchestrator.send(from.id, { text: "First answer.", replyTo: askMessage.id });
+    assert.equal(reply.delivered, true);
+
+    const results = await Promise.all([firstAsk, secondAsk]);
+    assert.equal(results.filter((result) => result.details?.error === true).length, 1);
+    assert.equal(results.filter((result) => /First answer/.test(result.content[0]?.text ?? "")).length, 1);
+    await harness.emitLifecycle("session_shutdown");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("broker refuses reverse mutual asks until the original ask is answered", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+
+  try {
+    const askToOrchestrator = await planner.send(orchestrator.sessionId!, {
+      messageId: "planner-to-orchestrator",
+      text: "Can you decide?",
+      expectsReply: true,
+    });
+    assert.equal(askToOrchestrator.delivered, true);
+
+    const reverseAsk = await orchestrator.send(planner.sessionId!, {
+      messageId: "orchestrator-to-planner",
+      text: "Can you decide instead?",
+      expectsReply: true,
+    });
+    assert.equal(reverseAsk.delivered, false);
+    assert.match(reverseAsk.reason ?? "", /Mutual ask refused/);
+
+    const plainSend = await orchestrator.send(planner.sessionId!, { text: "Plain update still works." });
+    assert.equal(plainSend.delivered, true);
+
+    const reply = await orchestrator.send(planner.sessionId!, {
+      text: "Answered.",
+      replyTo: "planner-to-orchestrator",
+    });
+    assert.equal(reply.delivered, true);
+
+    const nextAsk = await orchestrator.send(planner.sessionId!, {
+      messageId: "orchestrator-to-planner-after-reply",
+      text: "Now can I ask?",
+      expectsReply: true,
+    });
+    assert.equal(nextAsk.delivered, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("a reply can start a new reverse ask", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+
+  try {
+    const askToOrchestrator = await planner.send(orchestrator.sessionId!, {
+      messageId: "planner-to-orchestrator-transition",
+      text: "Can you decide?",
+      expectsReply: true,
+    });
+    assert.equal(askToOrchestrator.delivered, true);
+
+    const replyAndAsk = await orchestrator.send(planner.sessionId!, {
+      messageId: "orchestrator-reply-and-ask",
+      text: "I answered; can you decide the next thing?",
+      replyTo: "planner-to-orchestrator-transition",
+      expectsReply: true,
+    });
+    assert.equal(replyAndAsk.delivered, true);
+
+    const duplicateReverseAsk = await orchestrator.send(planner.sessionId!, {
+      messageId: "orchestrator-duplicate-reverse-ask",
+      text: "Can I ask another before the first is answered?",
+      expectsReply: true,
+    });
+    assert.equal(duplicateReverseAsk.delivered, true);
+
+    const plannerReverseAsk = await planner.send(orchestrator.sessionId!, {
+      messageId: "planner-reverse-while-orchestrator-waits",
+      text: "Can I ask while you wait?",
+      expectsReply: true,
+    });
+    assert.equal(plannerReverseAsk.delivered, false);
+    assert.match(plannerReverseAsk.reason ?? "", /Mutual ask refused/);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("failed replies do not clear broker mutual-ask edges", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+
+  try {
+    const askToOrchestrator = await planner.send(orchestrator.sessionId!, {
+      messageId: "planner-to-orchestrator-missing-reply",
+      text: "Can you decide?",
+      expectsReply: true,
+    });
+    assert.equal(askToOrchestrator.delivered, true);
+
+    const missingReply = await orchestrator.send("missing-session", {
+      messageId: "reply-to-missing-session",
+      text: "Answered, maybe?",
+      replyTo: "planner-to-orchestrator-missing-reply",
+    });
+    assert.equal(missingReply.delivered, false);
+    assert.match(missingReply.reason ?? "", /Session not found/);
+
+    const reverseAsk = await orchestrator.send(planner.sessionId!, {
+      messageId: "reverse-after-missing-reply",
+      text: "Can I ask now?",
+      expectsReply: true,
+    });
+    assert.equal(reverseAsk.delivered, false);
+    assert.match(reverseAsk.reason ?? "", /Mutual ask refused/);
+
+    const deliveredReply = await orchestrator.send(planner.sessionId!, {
+      messageId: "reply-to-planner",
+      text: "Actually answered.",
+      replyTo: "planner-to-orchestrator-missing-reply",
+    });
+    assert.equal(deliveredReply.delivered, true);
+
+    const nextAsk = await orchestrator.send(planner.sessionId!, {
+      messageId: "reverse-after-delivered-reply",
+      text: "Now can I ask?",
+      expectsReply: true,
+    });
+    assert.equal(nextAsk.delivered, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("regular intercom ask cancellation clears broker mutual-ask edge", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { orchestrator, cleanup } = await setupClients();
+
+  try {
+    const harness = createExtensionHarness("cancel-cleanup-worker");
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    const worker = await waitForSessionByName(orchestrator, "cancel-cleanup-worker");
+    const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
+
+    const controller = new AbortController();
+    const cancelledMessage = once(orchestrator, "message") as Promise<[SessionInfo, Message]>;
+    const cancelledResultPromise = intercomTool.execute("ask-cancelled", { action: "ask", to: "orchestrator", message: "Should I continue?" }, controller.signal, undefined, harness.ctx);
+    await cancelledMessage;
+    controller.abort();
+    const cancelledResult = await cancelledResultPromise;
+    assert.equal(cancelledResult.details?.error, true);
+    assert.match(cancelledResult.content[0]?.text ?? "", /Cancelled/);
+
+    const reverseAsk = await orchestrator.send(worker.id, {
+      messageId: "reverse-after-cancel",
+      text: "Can I ask after your cancellation?",
+      expectsReply: true,
+    });
+    assert.equal(reverseAsk.delivered, true);
+    await harness.emitLifecycle("session_shutdown");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("child supervisor tool clears reply waiter when cancelled", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { orchestrator, cleanup } = await setupClients();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/reply-tracker.test.ts
+++ b/reply-tracker.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { getAskTimeoutMs } from "./config.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
 import type { Message, SessionInfo } from "./types.ts";
 
@@ -74,4 +75,19 @@ test("reply removes pending ask after successful reply", () => {
   tracker.markReplied("ask-1");
 
   assert.deepEqual(tracker.listPending(1001), []);
+});
+
+test("ask timeout can be configured from environment", () => {
+  const previous = process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+  process.env.PI_INTERCOM_ASK_TIMEOUT_MS = "42";
+  try {
+    assert.equal(getAskTimeoutMs(), 42);
+    assert.throws(() => {
+      process.env.PI_INTERCOM_ASK_TIMEOUT_MS = "0";
+      getAskTimeoutMs();
+    }, /positive integer/);
+  } finally {
+    if (previous === undefined) delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+    else process.env.PI_INTERCOM_ASK_TIMEOUT_MS = previous;
+  }
 });

--- a/reply-tracker.ts
+++ b/reply-tracker.ts
@@ -1,3 +1,4 @@
+import { getAskTimeoutMs } from "./config.ts";
 import type { Message, SessionInfo } from "./types.ts";
 
 export interface IntercomContext {
@@ -19,7 +20,7 @@ export class ReplyTracker {
   private readonly pendingTurnContexts: IntercomContext[] = [];
   private currentTurnContext: IntercomContext | null = null;
 
-  constructor(private readonly askTimeoutMs = 10 * 60 * 1000) {}
+  constructor(private readonly askTimeoutMs = getAskTimeoutMs()) {}
 
   recordIncomingMessage(from: SessionInfo, message: Message, receivedAt = Date.now()): IntercomContext {
     const context = { from, message, receivedAt };

--- a/types.ts
+++ b/types.ts
@@ -32,6 +32,7 @@ export type ClientMessage =
   | { type: "unregister" }
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }
+  | { type: "cancel_ask"; messageId: string }
   | { type: "presence"; name?: string; status?: string; model?: string };
 
 export type BrokerMessage =


### PR DESCRIPTION
## Summary

Implements the approved single-flight ask-safety lane:

- keeps blocking `ask` single-flight for now and makes concurrent asks fail safely instead of tripping an unhandled rejected waiter
- adds broker-side mutual-ask refusal so two sessions cannot deadlock waiting on each other
- clears outstanding ask edges on reply, cancellation, disconnect, and timeout paths
- adds `PI_INTERCOM_ASK_TIMEOUT_MS` for the shared ask timeout

## Verification

- `npm test` passed, 55/55
- `git diff --check` passed
- `tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --allowImportingTsExtensions $(git ls-files '*.ts') broker/client.test.ts` passed
- `npm pack --dry-run` passed
- fresh reviewer pass: no issues found

Closes #29.
Closes #41.
