### PR TITLE
feat: centralize intercom platform paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ### Changed
 - Updated Pi runtime peer metadata and tool schemas for the `@earendil-works` package scope and Pi-bundled `typebox`/`pi-ai` packages.
+- Centralized pi-intercom runtime and config paths under `PI_CODING_AGENT_DIR` when set, defaulting to `~/.pi/agent`.
 
 ### Fixed
 - Added an inbound broker frame size cap to reject oversized local IPC messages before buffering their payloads.
@@ -16,6 +17,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 - Aligned intercom overlay widths with their rendered modal boxes. Thanks to Cat for PR #43.
 - Marked failed `intercom` and `contact_supervisor` tool results through Pi's `tool_result` error flag path while preserving structured renderer details.
 - Limited the intercom overlay to TUI mode and unsubscribed subagent relay event handlers during session shutdown.
+- Added an opt-in Windows localhost TCP transport using a dynamic port, broker protocol health checks, and a local endpoint secret instead of a fixed-port default.
 
 ## [0.6.0] - 2026-05-03
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Coordinate with other local pi sessions on related codebases. Use `/skill:pi-int
 
 A session becomes intercom-connected when all of these are true:
 - the `pi-intercom` extension is installed and loaded in that session
-- `enabled` is not set to `false` in `~/.pi/agent/intercom/config.json`
+- `enabled` is not set to `false` in the intercom config file, which defaults to `~/.pi/agent/intercom/config.json`
 - the session has started or reloaded after the extension was installed
 - the local broker is running or can be auto-started
 
@@ -392,6 +392,8 @@ For example, if you have Bun installed and want it to start the broker directly,
 
 Pi-intercom publishes live session status automatically. Sessions register as `idle`, switch to `thinking` while the agent is running, show `tool:<name>` during tool execution, and return to `idle` on agent completion. If `status` is set in config, it is appended as context instead of replacing the lifecycle status.
 
+By default, runtime state and config live under `~/.pi/agent/intercom`. If Pi is launched with `PI_CODING_AGENT_DIR`, pi-intercom uses `$PI_CODING_AGENT_DIR/intercom` instead, including `config.json`, broker PID/lock files, sockets, and launcher state.
+
 ## How It Works
 
 ```mermaid
@@ -424,15 +426,17 @@ Messages use length-prefixed JSON over a local socket/pipe transport (4-byte len
 
 Async extension work (startup, inbound flushes, reconnects, overlays, and relays) no-ops if the session shuts down or reloads before it settles.
 
-Runtime files live at `~/.pi/agent/intercom/`:
+Runtime files live at `~/.pi/agent/intercom/` by default, or `$PI_CODING_AGENT_DIR/intercom/` when `PI_CODING_AGENT_DIR` is set:
 - `broker.sock` — Unix domain socket for communication (macOS/Linux only; Windows uses a named pipe instead)
 - `broker-launch.vbs` — Windows helper script used to launch the broker without a console window
 - `broker.pid` — Broker process ID
+- `broker.spawn.lock` — Auto-spawn lock file
+- `broker.port.json` — Dynamic localhost TCP endpoint, only when Windows TCP transport is explicitly enabled
 - `config.json` — User configuration
 
 ## Design Decisions
 
-**Local IPC instead of TCP.** Same-machine only by design. `pi-intercom` uses Unix sockets on macOS/Linux and a named pipe on Windows, which keeps setup simple and avoids port management.
+**Local IPC instead of TCP.** Same-machine only by design. `pi-intercom` uses Unix sockets on macOS/Linux and a named pipe on Windows, which keeps setup simple and avoids port management. Windows TCP is available only as an explicit escape hatch with `PI_INTERCOM_TRANSPORT=tcp` (or `PI_INTERCOM_TCP=1`) for environments where named pipes are blocked. In that mode the broker binds a dynamic `127.0.0.1` port, records the endpoint plus a local secret under the intercom state dir, and requires that secret before health or registration succeeds. Health replies do not echo the secret, so a random localhost process cannot discover it through the broker protocol.
 
 **Auto-spawn with file lock.** The broker starts on first connection and exits after 5 seconds idle. There is no daemon to manage. A spawn lock file, keyed by PID and timestamp, prevents duplicate brokers when multiple sessions start at once.
 

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -5,17 +5,23 @@ import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
 import {
   ensureIntercomRuntimeDir,
-  getBrokerSocketPath,
+  getBrokerListenTarget,
+  getBrokerPortFilePath,
   getIntercomDirPath,
+  INTERCOM_PROTOCOL_NAME,
+  INTERCOM_PROTOCOL_VERSION,
   INTERCOM_RUNTIME_FILE_MODE,
   restrictIntercomRuntimeFile,
+  type BrokerConnectTarget,
 } from "./paths.ts";
 import { getAskTimeoutMs } from "../config.ts";
 import type { SessionInfo, Message, Attachment, BrokerMessage } from "../types.ts";
 
 const INTERCOM_DIR = getIntercomDirPath();
-const SOCKET_PATH = getBrokerSocketPath();
+const LISTEN_TARGET = getBrokerListenTarget();
 const PID_PATH = join(INTERCOM_DIR, "broker.pid");
+const PORT_PATH = getBrokerPortFilePath(INTERCOM_DIR);
+const BROKER_STATE_ID = randomUUID();
 
 interface ConnectedSession {
   socket: net.Socket;
@@ -119,9 +125,9 @@ class IntercomBroker {
 
   constructor() {
     ensureIntercomRuntimeDir(INTERCOM_DIR);
-    if (process.platform !== "win32") {
+    if (typeof LISTEN_TARGET === "string" && process.platform !== "win32") {
       try {
-        unlinkSync(SOCKET_PATH);
+        unlinkSync(LISTEN_TARGET);
       } catch {
         // A clean startup has no stale socket to remove.
       }
@@ -130,12 +136,33 @@ class IntercomBroker {
   }
 
   start(): void {
-    this.server.listen(SOCKET_PATH, () => {
-      restrictIntercomRuntimeFile(SOCKET_PATH);
+    const onListening = () => {
+      if (typeof LISTEN_TARGET === "string") {
+        restrictIntercomRuntimeFile(LISTEN_TARGET);
+      } else {
+        const address = this.server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Intercom TCP broker started without a TCP address");
+        }
+        const endpoint: BrokerConnectTarget = {
+          transport: "tcp",
+          host: LISTEN_TARGET.host,
+          port: address.port,
+          stateId: BROKER_STATE_ID,
+        };
+        writeFileSync(PORT_PATH, `${JSON.stringify(endpoint)}\n`, { mode: INTERCOM_RUNTIME_FILE_MODE });
+        restrictIntercomRuntimeFile(PORT_PATH);
+      }
       writeFileSync(PID_PATH, String(process.pid), { mode: INTERCOM_RUNTIME_FILE_MODE });
       restrictIntercomRuntimeFile(PID_PATH);
       console.log(`Intercom broker started (pid: ${process.pid})`);
-    });
+    };
+
+    if (typeof LISTEN_TARGET === "string") {
+      this.server.listen(LISTEN_TARGET, onListening);
+    } else {
+      this.server.listen({ host: LISTEN_TARGET.host, port: LISTEN_TARGET.port }, onListening);
+    }
     process.on("SIGTERM", () => this.shutdown());
     process.on("SIGINT", () => this.shutdown());
   }
@@ -193,6 +220,28 @@ class IntercomBroker {
     }
 
     const clientMessage = msg as { type: string } & Record<string, unknown>;
+    const requiresEndpointAuth = typeof LISTEN_TARGET !== "string";
+    const hasEndpointAuth = clientMessage.stateId === BROKER_STATE_ID;
+
+    if (clientMessage.type === "health") {
+      if (typeof clientMessage.requestId !== "string") {
+        throw new Error("Invalid health message");
+      }
+      if (requiresEndpointAuth && !hasEndpointAuth) {
+        throw new Error("Invalid intercom TCP endpoint credentials");
+      }
+      writeMessage(socket, {
+        type: "health_ok",
+        requestId: clientMessage.requestId,
+        protocol: INTERCOM_PROTOCOL_NAME,
+        version: INTERCOM_PROTOCOL_VERSION,
+      });
+      return;
+    }
+
+    if (requiresEndpointAuth && clientMessage.type === "register" && !hasEndpointAuth) {
+      throw new Error("Invalid intercom TCP endpoint credentials");
+    }
 
     if (currentId === null && clientMessage.type !== "register") {
       throw new Error(`Received ${clientMessage.type} before register`);
@@ -438,12 +487,17 @@ class IntercomBroker {
     }
     this.sessions.clear();
     this.askEdges.clear();
-    if (process.platform !== "win32") {
+    if (typeof LISTEN_TARGET === "string" && process.platform !== "win32") {
       try {
-        unlinkSync(SOCKET_PATH);
+        unlinkSync(LISTEN_TARGET);
       } catch {
         // The socket may already be gone if shutdown started after a disconnect.
       }
+    }
+    try {
+      unlinkSync(PORT_PATH);
+    } catch {
+      // The TCP endpoint file only exists when opt-in TCP transport is active.
     }
     try {
       unlinkSync(PID_PATH);

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -2,10 +2,8 @@ import { EventEmitter } from "events";
 import net from "net";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
-import { getBrokerSocketPath } from "./paths.ts";
+import { getBrokerConnectTarget, type BrokerConnectTarget } from "./paths.ts";
 import type { SessionInfo, Message, Attachment } from "../types.ts";
-
-const BROKER_SOCKET = getBrokerSocketPath();
 
 interface SendOptions {
   text: string;
@@ -23,6 +21,12 @@ interface SendResult {
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function connectToBrokerTarget(target: BrokerConnectTarget): net.Socket {
+  return typeof target === "string"
+    ? net.connect(target)
+    : net.connect({ host: target.host, port: target.port });
 }
 
 function isAttachment(value: unknown): value is Attachment {
@@ -155,7 +159,15 @@ export class IntercomClient extends EventEmitter {
     }
 
     return new Promise((resolve, reject) => {
-      const socket = net.connect(BROKER_SOCKET);
+      let socket: net.Socket;
+      let target: BrokerConnectTarget;
+      try {
+        target = getBrokerConnectTarget();
+        socket = connectToBrokerTarget(target);
+      } catch (error) {
+        reject(toError(error));
+        return;
+      }
       this.socket = socket;
       this.disconnectError = null;
       let settled = false;
@@ -254,7 +266,12 @@ export class IntercomClient extends EventEmitter {
       this.once("_registered", onRegistered);
       
       try {
-        writeMessage(socket, { type: "register", session, ...(sessionId ? { sessionId } : {}) });
+        writeMessage(socket, {
+          type: "register",
+          session,
+          ...(sessionId ? { sessionId } : {}),
+          ...(typeof target === "string" ? {} : { stateId: target.stateId }),
+        });
       } catch (error) {
         cleanupConnectionAttempt();
         cleanupSocketListeners();

--- a/broker/paths.test.ts
+++ b/broker/paths.test.ts
@@ -5,27 +5,107 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   ensureIntercomRuntimeDir,
+  getAgentDirPath,
+  getBrokerConnectTarget,
+  getBrokerListenTarget,
+  getBrokerPortFilePath,
   getBrokerSocketPath,
   getIntercomDirPath,
   INTERCOM_DIR_MODE,
   INTERCOM_RUNTIME_FILE_MODE,
+  INTERCOM_TCP_HOST,
   restrictIntercomRuntimeFile,
+  shouldUseWindowsTcpTransport,
 } from "./paths.ts";
 
+test("getAgentDirPath defaults to the pi agent directory under home", () => {
+  assert.equal(getAgentDirPath({}, "/home/rcroh"), join("/home/rcroh", ".pi/agent"));
+});
+
+test("getAgentDirPath honors PI_CODING_AGENT_DIR", () => {
+  assert.equal(getAgentDirPath({ PI_CODING_AGENT_DIR: "/tmp/pi-agent" }, "/home/rcroh"), "/tmp/pi-agent");
+});
+
+test("getAgentDirPath resolves relative PI_CODING_AGENT_DIR values from the caller cwd", () => {
+  assert.equal(
+    getAgentDirPath({ PI_CODING_AGENT_DIR: "relative-agent" }, "/home/rcroh", "/workspace/project"),
+    join("/workspace/project", "relative-agent"),
+  );
+});
+
+test("getIntercomDirPath points at the intercom runtime directory under the agent dir", () => {
+  assert.equal(getIntercomDirPath("/tmp/pi-agent"), join("/tmp/pi-agent", "intercom"));
+});
+
 test("getBrokerSocketPath uses named pipe on Windows", () => {
-  const pipePath = getBrokerSocketPath("win32", "C:/Users/rcroh");
+  const pipePath = getBrokerSocketPath("win32", "C:/Users/rcroh/.pi/agent");
   assert.match(pipePath, /^\\\\\.\\pipe\\pi-intercom-/);
   assert.doesNotMatch(pipePath, /broker\.sock$/);
 });
 
-test("getBrokerSocketPath uses broker.sock on non-Windows", () => {
-  const socketPath = getBrokerSocketPath("linux", "/home/rcroh");
-  assert.match(socketPath, /broker\.sock$/);
-  assert.match(socketPath, /rcroh/);
+test("getBrokerSocketPath uses broker.sock under PI_CODING_AGENT_DIR on non-Windows", () => {
+  const socketPath = getBrokerSocketPath("linux", "/tmp/pi-agent");
+  assert.equal(socketPath, join("/tmp/pi-agent", "intercom", "broker.sock"));
 });
 
-test("getIntercomDirPath points at the pi intercom runtime directory", () => {
-  assert.equal(getIntercomDirPath("/home/rcroh"), join("/home/rcroh", ".pi/agent/intercom"));
+test("Windows TCP transport is opt-in", () => {
+  assert.equal(shouldUseWindowsTcpTransport("win32", {}), false);
+  assert.equal(shouldUseWindowsTcpTransport("win32", { PI_INTERCOM_TRANSPORT: "tcp" }), true);
+  assert.equal(shouldUseWindowsTcpTransport("win32", { PI_INTERCOM_TCP: "1" }), true);
+  assert.equal(shouldUseWindowsTcpTransport("linux", { PI_INTERCOM_TRANSPORT: "tcp" }), false);
+});
+
+test("getBrokerListenTarget uses dynamic localhost TCP only when opted in on Windows", () => {
+  assert.deepEqual(getBrokerListenTarget("win32", { PI_INTERCOM_TRANSPORT: "tcp" }), {
+    transport: "tcp",
+    host: INTERCOM_TCP_HOST,
+    port: 0,
+  });
+  assert.equal(getBrokerListenTarget("win32", {}), getBrokerSocketPath("win32", getAgentDirPath({})));
+});
+
+test("getBrokerConnectTarget reads opt-in Windows TCP endpoint from intercom state", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-paths-"));
+  const intercomDir = join(root, "intercom");
+
+  try {
+    ensureIntercomRuntimeDir(intercomDir, "win32");
+    writeFileSync(getBrokerPortFilePath(intercomDir), JSON.stringify({
+      transport: "tcp",
+      host: "127.0.0.1",
+      port: 41234,
+      stateId: "state-1",
+    }));
+    assert.deepEqual(getBrokerConnectTarget("win32", { PI_INTERCOM_TRANSPORT: "tcp" }, intercomDir), {
+      transport: "tcp",
+      host: "127.0.0.1",
+      port: 41234,
+      stateId: "state-1",
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("getBrokerConnectTarget rejects non-local TCP endpoint hosts", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-paths-"));
+  const intercomDir = join(root, "intercom");
+
+  try {
+    ensureIntercomRuntimeDir(intercomDir, "win32");
+    writeFileSync(getBrokerPortFilePath(intercomDir), JSON.stringify({
+      transport: "tcp",
+      host: "10.0.0.5",
+      port: 41234,
+      stateId: "state-1",
+    }));
+    assert.throws(
+      () => getBrokerConnectTarget("win32", { PI_INTERCOM_TRANSPORT: "tcp" }, intercomDir),
+      /Invalid intercom TCP endpoint/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("ensureIntercomRuntimeDir creates and repairs restrictive Unix directory permissions", { skip: process.platform === "win32" }, () => {

--- a/broker/paths.ts
+++ b/broker/paths.ts
@@ -1,9 +1,21 @@
-import { chmodSync, mkdirSync } from "fs";
-import { join } from "path";
+import { chmodSync, mkdirSync, readFileSync } from "fs";
+import { isAbsolute, join, resolve } from "path";
 import { homedir } from "os";
 
 export const INTERCOM_DIR_MODE = 0o700;
 export const INTERCOM_RUNTIME_FILE_MODE = 0o600;
+export const INTERCOM_TCP_HOST = "127.0.0.1";
+export const INTERCOM_PROTOCOL_NAME = "pi-intercom";
+export const INTERCOM_PROTOCOL_VERSION = 1;
+
+export interface BrokerTcpEndpoint {
+  transport: "tcp";
+  host: string;
+  port: number;
+  stateId?: string;
+}
+
+export type BrokerConnectTarget = string | BrokerTcpEndpoint;
 
 function sanitizePipeSegment(value: string): string {
   return value
@@ -12,19 +24,95 @@ function sanitizePipeSegment(value: string): string {
     .toLowerCase() || "default";
 }
 
-export function getIntercomDirPath(homeDir: string = homedir()): string {
-  return join(homeDir, ".pi/agent/intercom");
+export function getAgentDirPath(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = homedir(),
+  cwd: string = process.cwd(),
+): string {
+  const configured = env.PI_CODING_AGENT_DIR?.trim();
+  if (!configured) {
+    return join(homeDir, ".pi/agent");
+  }
+
+  return isAbsolute(configured) ? configured : resolve(cwd, configured);
+}
+
+export function getIntercomDirPath(agentDir: string = getAgentDirPath()): string {
+  return join(agentDir, "intercom");
+}
+
+export function shouldUseWindowsTcpTransport(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (platform !== "win32") {
+    return false;
+  }
+
+  const transport = env.PI_INTERCOM_TRANSPORT?.trim().toLowerCase();
+  if (transport === "tcp") {
+    return true;
+  }
+
+  const legacyOptIn = env.PI_INTERCOM_TCP?.trim().toLowerCase();
+  return legacyOptIn === "1" || legacyOptIn === "true";
+}
+
+export function getBrokerPortFilePath(intercomDir: string = getIntercomDirPath()): string {
+  return join(intercomDir, "broker.port.json");
 }
 
 export function getBrokerSocketPath(
   platform: NodeJS.Platform = process.platform,
-  homeDir: string = homedir(),
+  agentDir: string = getAgentDirPath(),
 ): string {
   if (platform === "win32") {
-    return `\\\\.\\pipe\\pi-intercom-${sanitizePipeSegment(homeDir)}`;
+    return `\\\\.\\pipe\\pi-intercom-${sanitizePipeSegment(agentDir)}`;
   }
 
-  return join(getIntercomDirPath(homeDir), "broker.sock");
+  return join(getIntercomDirPath(agentDir), "broker.sock");
+}
+
+export function getBrokerConnectTarget(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  intercomDir: string = getIntercomDirPath(getAgentDirPath(env)),
+): BrokerConnectTarget {
+  if (shouldUseWindowsTcpTransport(platform, env)) {
+    const endpointFile = getBrokerPortFilePath(intercomDir);
+    const raw = readFileSync(endpointFile, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(`Invalid intercom TCP endpoint at ${endpointFile}: expected a JSON object`);
+    }
+    const endpoint = parsed as Record<string, unknown>;
+    if (
+      endpoint.transport !== "tcp"
+      || endpoint.host !== INTERCOM_TCP_HOST
+      || typeof endpoint.port !== "number"
+      || !Number.isSafeInteger(endpoint.port)
+      || endpoint.port <= 0
+      || endpoint.port > 65535
+      || typeof endpoint.stateId !== "string"
+      || endpoint.stateId.length === 0
+    ) {
+      throw new Error(`Invalid intercom TCP endpoint at ${endpointFile}`);
+    }
+    return { transport: "tcp", host: endpoint.host, port: endpoint.port, stateId: endpoint.stateId };
+  }
+
+  return getBrokerSocketPath(platform, getAgentDirPath(env));
+}
+
+export function getBrokerListenTarget(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): BrokerConnectTarget {
+  if (shouldUseWindowsTcpTransport(platform, env)) {
+    return { transport: "tcp", host: INTERCOM_TCP_HOST, port: 0 };
+  }
+
+  return getBrokerSocketPath(platform, getAgentDirPath(env));
 }
 
 export function ensureIntercomRuntimeDir(

--- a/broker/spawn.test.ts
+++ b/broker/spawn.test.ts
@@ -10,6 +10,7 @@ import {
   getWindowsHiddenLauncherScript,
   getWindowsBrokerCommandLine,
   getWindowsHiddenLauncherPath,
+  isBrokerHealthOkMessage,
 } from "./spawn.ts";
 
 test("getTsxCliPath resolves tsx cli via module resolution", () => {
@@ -115,4 +116,16 @@ test("getBrokerSpawnOptions keeps portable defaults on non-Windows platforms", (
   assert.equal(options.detached, true);
   assert.equal(options.stdio, "ignore");
   assert.equal(options.cwd, "/repo");
+});
+
+test("getBrokerSpawnOptions passes an absolute PI_CODING_AGENT_DIR to the broker", () => {
+  const options = getBrokerSpawnOptions("/repo", { PI_CODING_AGENT_DIR: "relative-agent" });
+  assert.equal(options.env.PI_CODING_AGENT_DIR, path.resolve("relative-agent"));
+});
+
+test("isBrokerHealthOkMessage requires the intercom protocol marker", () => {
+  assert.equal(isBrokerHealthOkMessage({ type: "health_ok", requestId: "req-1", protocol: "pi-intercom", version: 1 }, "req-1"), true);
+  assert.equal(isBrokerHealthOkMessage({ type: "health_ok", requestId: "req-1" }, "req-1"), false);
+  assert.equal(isBrokerHealthOkMessage({ type: "health_ok", requestId: "req-2", protocol: "pi-intercom", version: 1 }, "req-1"), false);
+  assert.equal(isBrokerHealthOkMessage("ok", "req-1"), false);
 });

--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -4,17 +4,22 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 import net from "net";
+import { randomUUID } from "crypto";
+import { createMessageReader, writeMessage } from "./framing.ts";
 import {
   ensureIntercomRuntimeDir,
-  getBrokerSocketPath,
+  getAgentDirPath,
+  getBrokerConnectTarget,
   getIntercomDirPath,
+  INTERCOM_PROTOCOL_NAME,
+  INTERCOM_PROTOCOL_VERSION,
   INTERCOM_RUNTIME_FILE_MODE,
   restrictIntercomRuntimeFile,
+  type BrokerConnectTarget,
 } from "./paths.ts";
 
 const INTERCOM_DIR = getIntercomDirPath();
 const EXTENSION_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
-const BROKER_SOCKET = getBrokerSocketPath();
 const BROKER_PID = join(INTERCOM_DIR, "broker.pid");
 const BROKER_SPAWN_LOCK = join(INTERCOM_DIR, "broker.spawn.lock");
 
@@ -89,6 +94,17 @@ export function getWindowsHiddenLauncherScript(commandLine: string): string {
   ].join("\r\n");
 }
 
+export function isBrokerHealthOkMessage(message: unknown, requestId: string): boolean {
+  if (typeof message !== "object" || message === null || !("type" in message)) {
+    return false;
+  }
+  const response = message as Record<string, unknown>;
+  return response.type === "health_ok"
+    && response.requestId === requestId
+    && response.protocol === INTERCOM_PROTOCOL_NAME
+    && response.version === INTERCOM_PROTOCOL_VERSION;
+}
+
 function writeWindowsHiddenLauncher(
   commandLine: string,
   launcherPath: string = getWindowsHiddenLauncherPath(),
@@ -129,7 +145,10 @@ export function getBrokerLaunchSpec(
   };
 }
 
-export function getBrokerSpawnOptions(extensionDir: string = EXTENSION_DIR): {
+export function getBrokerSpawnOptions(
+  extensionDir: string = EXTENSION_DIR,
+  env: NodeJS.ProcessEnv = process.env,
+): {
   detached: true;
   stdio: "ignore";
   cwd: string;
@@ -140,7 +159,7 @@ export function getBrokerSpawnOptions(extensionDir: string = EXTENSION_DIR): {
     detached: true,
     stdio: "ignore",
     cwd: extensionDir,
-    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    env: { ...env, PI_CODING_AGENT_DIR: getAgentDirPath(env), NODE_NO_WARNINGS: "1" },
     windowsHide: true,
   };
 }
@@ -231,29 +250,57 @@ async function isBrokerRunning(): Promise<boolean> {
   }
 }
 
+function connectToBrokerTarget(target: BrokerConnectTarget): net.Socket {
+  return typeof target === "string"
+    ? net.connect(target)
+    : net.connect({ host: target.host, port: target.port });
+}
+
 function checkSocketConnectable(): Promise<boolean> {
   return new Promise((resolve) => {
-    const socket = net.connect(BROKER_SOCKET);
+    let target: BrokerConnectTarget;
+    try {
+      target = getBrokerConnectTarget();
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    const socket = connectToBrokerTarget(target);
+    const requestId = randomUUID();
+    const expectedStateId = typeof target === "string" ? undefined : target.stateId;
+    let settled = false;
     const finish = (isConnected: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       clearTimeout(timeout);
       socket.off("connect", onConnect);
       socket.off("error", onError);
+      socket.off("data", reader);
+      socket.destroy();
       resolve(isConnected);
     };
     const onConnect = () => {
-      socket.end();
-      finish(true);
+      try {
+        writeMessage(socket, {
+          type: "health",
+          requestId,
+          ...(expectedStateId ? { stateId: expectedStateId } : {}),
+        });
+      } catch {
+        finish(false);
+      }
     };
-    const onError = () => {
-      socket.destroy();
-      finish(false);
-    };
+    const onError = () => finish(false);
+    const reader = createMessageReader((message) => {
+      finish(isBrokerHealthOkMessage(message, requestId));
+    }, () => finish(false));
     socket.on("connect", onConnect);
     socket.on("error", onError);
-    const timeout = setTimeout(() => {
-      socket.destroy();
-      finish(false);
-    }, 1000);
+    socket.on("data", reader);
+    const timeout = setTimeout(() => finish(false), 1000);
   });
 }
 

--- a/config.test.ts
+++ b/config.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getConfigPath, loadConfig } from "./config.ts";
+
+test("getConfigPath uses the centralized intercom runtime directory", () => {
+  assert.equal(getConfigPath("/tmp/pi-agent/intercom"), join("/tmp/pi-agent", "intercom", "config.json"));
+});
+
+test("loadConfig reads config below PI_CODING_AGENT_DIR", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
+  const previous = process.env.PI_CODING_AGENT_DIR;
+
+  try {
+    process.env.PI_CODING_AGENT_DIR = root;
+    const intercomDir = join(root, "intercom");
+    mkdirSync(intercomDir, { recursive: true });
+    writeFileSync(join(intercomDir, "config.json"), JSON.stringify({ status: "platform-test" }));
+
+    assert.equal(loadConfig().status, "platform-test");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previous;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { getIntercomDirPath } from "./broker/paths.ts";
 
 export const DEFAULT_ASK_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -37,7 +37,9 @@ export interface IntercomConfig {
   replyHint: boolean;
 }
 
-const CONFIG_PATH = join(homedir(), ".pi/agent/intercom/config.json");
+export function getConfigPath(intercomDir: string = getIntercomDirPath()): string {
+  return join(intercomDir, "config.json");
+}
 
 const defaults: IntercomConfig = {
   brokerCommand: "npx",
@@ -48,12 +50,13 @@ const defaults: IntercomConfig = {
 };
 
 export function loadConfig(): IntercomConfig {
-  if (!existsSync(CONFIG_PATH)) {
+  const configPath = getConfigPath();
+  if (!existsSync(configPath)) {
     return { ...defaults };
   }
   
   try {
-    const raw = readFileSync(CONFIG_PATH, "utf-8");
+    const raw = readFileSync(configPath, "utf-8");
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       throw new Error("Config must be a JSON object");
@@ -117,7 +120,7 @@ export function loadConfig(): IntercomConfig {
 
     return config;
   } catch (error) {
-    console.error(`Failed to load intercom config at ${CONFIG_PATH}:`, error);
+    console.error(`Failed to load intercom config at ${configPath}:`, error);
     return { ...defaults };
   }
 }

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -236,6 +236,122 @@ async function connectRawRegistered(sessionId: string, name: string) {
   return { socket, writeMessage };
 }
 
+test("opt-in TCP broker requires endpoint state for health and registration", { concurrency: false }, async () => {
+  const net = await import("node:net");
+  const { readFileSync } = await import("node:fs");
+  const { createMessageReader, writeMessage } = await import("./broker/framing.ts");
+  const agentDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-tcp-agent-"));
+  const broker = spawn("npx", [
+    "--no-install",
+    "tsx",
+    "-e",
+    "Object.defineProperty(process, 'platform', { value: 'win32' }); import('./broker/broker.ts').catch((error) => { console.error(error); process.exit(1); });",
+  ], {
+    cwd: repoDir,
+    env: {
+      ...process.env,
+      HOME: agentDir,
+      USERPROFILE: agentDir,
+      PI_CODING_AGENT_DIR: agentDir,
+      PI_INTERCOM_TRANSPORT: "tcp",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const exchange = async (message: unknown, waitForResponse: boolean): Promise<unknown[]> => {
+    const socket = net.connect({ host, port });
+    const messages: unknown[] = [];
+    return await new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        socket.off("data", reader);
+        socket.off("close", finish);
+        socket.off("error", onSocketError);
+        socket.destroy();
+        resolve(messages);
+      };
+      const onSocketError = () => finish();
+      const reader = createMessageReader((received) => {
+        messages.push(received);
+        if (waitForResponse) {
+          finish();
+        }
+      }, reject);
+      const timeout = setTimeout(finish, 500);
+      socket.once("connect", () => writeMessage(socket, message));
+      socket.on("data", reader);
+      socket.once("close", finish);
+      socket.once("error", onSocketError);
+    });
+  };
+
+  let host = "";
+  let port = 0;
+  let stateId = "";
+  try {
+    await waitForBrokerReady(broker);
+    const endpoint: unknown = JSON.parse(readFileSync(path.join(agentDir, "intercom", "broker.port.json"), "utf-8"));
+    if (typeof endpoint !== "object" || endpoint === null || Array.isArray(endpoint)) {
+      throw new Error("Invalid TCP endpoint fixture");
+    }
+    const endpointRecord = endpoint as Record<string, unknown>;
+    if (endpointRecord.host !== "127.0.0.1" || typeof endpointRecord.port !== "number" || typeof endpointRecord.stateId !== "string") {
+      throw new Error(`Invalid TCP endpoint fixture: ${JSON.stringify(endpointRecord)}`);
+    }
+    host = endpointRecord.host;
+    port = endpointRecord.port;
+    stateId = endpointRecord.stateId;
+
+    assert.deepEqual(await exchange({ type: "health", requestId: "unauthorized-health" }, false), []);
+    assert.deepEqual(await exchange({
+      type: "register",
+      sessionId: "unauthorized-tcp-client",
+      session: {
+        name: "unauthorized",
+        cwd: repoDir,
+        model: "test-model",
+        pid: process.pid,
+        startedAt: Date.now(),
+        lastActivity: Date.now(),
+      },
+    }, false), []);
+
+    const healthMessages = await exchange({ type: "health", requestId: "authorized-health", stateId }, true);
+    assert.deepEqual(healthMessages, [{
+      type: "health_ok",
+      requestId: "authorized-health",
+      protocol: "pi-intercom",
+      version: 1,
+    }]);
+
+    const registerMessages = await exchange({
+      type: "register",
+      sessionId: "authorized-tcp-client",
+      stateId,
+      session: {
+        name: "authorized",
+        cwd: repoDir,
+        model: "test-model",
+        pid: process.pid,
+        startedAt: Date.now(),
+        lastActivity: Date.now(),
+      },
+    }, true);
+    assert.deepEqual(registerMessages, [{ type: "registered", sessionId: "authorized-tcp-client" }]);
+  } finally {
+    if (broker.exitCode === null && broker.signalCode === null) {
+      broker.kill("SIGTERM");
+      await once(broker, "exit").catch(() => undefined);
+    }
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
 async function setupClients() {
   const broker = spawn("npx", ["--no-install", "tsx", path.join(repoDir, "broker", "broker.ts")], {
     cwd: repoDir,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"
@@ -35,5 +35,11 @@
   },
   "dependencies": {
     "tsx": "^4.20.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -28,7 +28,7 @@ export interface Attachment {
 }
 
 export type ClientMessage =
-  | { type: "register"; session: Omit<SessionInfo, "id">; sessionId?: string }
+  | { type: "register"; session: Omit<SessionInfo, "id">; sessionId?: string; stateId?: string }
   | { type: "unregister" }
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }


### PR DESCRIPTION
## Summary

Centralizes pi-intercom runtime/config paths and makes the Windows TCP fallback safe enough to keep as an explicit escape hatch.

This includes:

- `PI_CODING_AGENT_DIR` support for config, sockets, PID/lock files, launcher state, and TCP endpoint state
- normalized relative `PI_CODING_AGENT_DIR` handling so spawned brokers and clients share the same runtime path
- default Windows named-pipe behavior preserved
- opt-in Windows TCP transport using a dynamic `127.0.0.1` port, endpoint host validation, protocol health checks, and endpoint-state authentication before health/register
- dev-time peer dependencies so installed checkouts can run the package test script
- docs, changelog, and regression tests for the new path/transport behavior

## Verification

- `npm test` passed, 80/80, using the repo root `node_modules` symlink required for temporary worktrees
- `git diff --check HEAD~1` passed
- `tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --allowImportingTsExtensions $(git ls-files '*.ts')` passed
- `npm pack --dry-run` passed
- final reviewer pass: no platform blockers found; one reviewer caveat was the expected missing `node_modules` state in its checkout, now covered by package devDependency declarations and the validated worktree run above
