### PR TITLE
feat: harden intercom trust controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Changed
 - Updated Pi runtime peer metadata and tool schemas for the `@earendil-works` package scope and Pi-bundled `typebox`/`pi-ai` packages.
 - Centralized pi-intercom runtime and config paths under `PI_CODING_AGENT_DIR` when set, defaulting to `~/.pi/agent`.
+- Hardened default broker auto-spawn to launch the resolved bundled `tsx` CLI through the current Node executable instead of resolving `npx` through `PATH`; custom `brokerCommand`/`brokerArgs` remain available as advanced trusted config.
+- Added an `inboundTrigger` policy (`always`, `replies`, or `never`) so users can reduce inbound auto-trigger risk while preserving existing behavior by default.
 
 ### Fixed
+- Added broker-owned local trust metadata, clearer stable-ID trust boundaries for duplicate names, per-connection rate limiting, and no-op presence coalescing for local IPC abuse hardening.
 - Added an inbound broker frame size cap to reject oversized local IPC messages before buffering their payloads.
 - Restricted Unix intercom runtime directory, socket, PID, and spawn-lock permissions.
 - Rechecked single-flight ask state after session target resolution so concurrent regular asks fail safely instead of crashing on an unhandled rejected reply waiter.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Pi-intercom also integrates well with [pi-subagents](https://github.com/nicobail
 
 ## In One Minute
 
-Each pi session that has `pi-intercom` loaded and enabled connects to a tiny local broker over a local IPC transport. The broker keeps track of connected sessions and routes direct messages to the one you target by name or session ID. The extension gives you both a tool (`intercom`) and a small overlay UI (`/intercom` or `Alt+M`). Incoming messages are rendered inline inside the recipient session, can trigger a turn immediately, and are also stored in Pi session history as extension entries.
+Each pi session that has `pi-intercom` loaded and enabled connects to a tiny local broker over a local IPC transport. The broker keeps track of connected sessions and routes direct messages to the one you target by name or session ID. The extension gives you both a tool (`intercom`) and a small overlay UI (`/intercom` or `Alt+M`). Incoming messages are rendered inline inside the recipient session, can trigger a turn immediately by default, and are also stored in Pi session history as extension entries. If you want a stricter local trust posture, `inboundTrigger` can reduce or disable auto-triggering.
 
 ## Install
 
@@ -366,6 +366,7 @@ Create `~/.pi/agent/intercom/config.json`:
   "brokerCommand": "npx",
   "brokerArgs": ["--no-install", "tsx"],
   "confirmSend": false,
+  "inboundTrigger": "always",
   "enabled": true,
   "replyHint": true,
   "status": "researching"
@@ -374,14 +375,17 @@ Create `~/.pi/agent/intercom/config.json`:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `brokerCommand` | `"npx"` | Command used to start the local broker process |
-| `brokerArgs` | `["--no-install", "tsx"]` | Arguments passed to `brokerCommand` before the broker script path |
+| `brokerCommand` | `"npx"` | Advanced trusted override for the broker executable. The default value is hardened internally to launch the resolved bundled `tsx` CLI through the current Node executable instead of resolving `npx` through `PATH`. |
+| `brokerArgs` | `["--no-install", "tsx"]` | Advanced trusted arguments passed to custom `brokerCommand` before the broker script path |
 | `confirmSend` | false | Show a confirmation dialog before non-reply sends from an interactive session with UI |
+| `inboundTrigger` | `"always"` | Auto-trigger policy for inbound broker messages: `"always"`, `"replies"`, or `"never"`. Local in-process subagent relay events still trigger the addressed session. |
 | `enabled` | true | Enable/disable intercom entirely |
 | `replyHint` | true | Include reply instruction in incoming messages |
 | `status` | — | Optional custom status suffix shown after the automatic lifecycle status, for example `thinking · researching` |
 
-For example, if you have Bun installed and want it to start the broker directly, use:
+If `config.json` cannot be parsed or contains an invalid value, pi-intercom logs the error and fails closed for inbound broker auto-triggering by using `inboundTrigger: "never"` until the config is fixed.
+
+Custom broker commands are trusted local configuration: anyone who can edit this config can choose the executable used for future broker auto-spawns. For example, if you have Bun installed and want it to start the broker directly, use:
 
 ```json
 {
@@ -422,7 +426,9 @@ graph TB
 
 The broker is a standalone TypeScript process that manages session registration and message routing. It auto-spawns when the first intercom-enabled session needs it and exits after 5 seconds when the last connected session disconnects. Clients now reconnect automatically if the broker disappears and later comes back.
 
-Messages use length-prefixed JSON over a local socket/pipe transport (4-byte length + JSON payload) to handle fragmentation properly. The protocol includes request correlation for session listing, explicit delivery failures, and validation for malformed or out-of-order messages.
+Messages use length-prefixed JSON over a local socket/pipe transport (4-byte length + JSON payload) to handle fragmentation properly. The protocol includes request correlation for session listing, explicit delivery failures, validation for malformed or out-of-order messages, a frame-size cap, per-connection local rate limiting, and no-op presence coalescing.
+
+Session IDs are the trusted addressing key. Duplicate names remain allowed for same-user workflows, but sends to ambiguous names fail and users should target the stable session ID shown by `list`/`status` in trust-sensitive flows. The broker owns local trust metadata such as `trustedLocal`; `peerUid` is reserved for runtimes that can expose real peer credentials and is left unset otherwise. Client-supplied cwd/model/pid/status are display metadata, not authentication.
 
 Async extension work (startup, inbound flushes, reconnects, overlays, and relays) no-ops if the session shuts down or reloads before it settles.
 

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -15,17 +15,30 @@ import {
   type BrokerConnectTarget,
 } from "./paths.ts";
 import { getAskTimeoutMs } from "../config.ts";
-import type { SessionInfo, Message, Attachment, BrokerMessage } from "../types.ts";
+import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration } from "../types.ts";
 
 const INTERCOM_DIR = getIntercomDirPath();
 const LISTEN_TARGET = getBrokerListenTarget();
 const PID_PATH = join(INTERCOM_DIR, "broker.pid");
 const PORT_PATH = getBrokerPortFilePath(INTERCOM_DIR);
 const BROKER_STATE_ID = randomUUID();
+const MAX_SESSIONS = 128;
+const MAX_UNREGISTERED_CONNECTIONS = 32;
+const REGISTRATION_TIMEOUT_MS = 1000;
+const RATE_LIMIT_CAPACITY = 240;
+const RATE_LIMIT_REFILL_PER_SECOND = 120;
+const PRESENCE_HEARTBEAT_MS = 1000;
 
 interface ConnectedSession {
   socket: net.Socket;
   info: SessionInfo;
+  lastPresenceBroadcastAt: number;
+}
+
+interface ConnectionState {
+  socket: net.Socket;
+  tokens: number;
+  lastRefillAt: number;
 }
 
 interface AskEdge {
@@ -92,7 +105,7 @@ function isSessionId(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function isSessionRegistration(value: unknown): value is Omit<SessionInfo, "id"> {
+function isSessionRegistration(value: unknown): value is SessionRegistration {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
   }
@@ -119,6 +132,8 @@ function isSessionRegistration(value: unknown): value is Omit<SessionInfo, "id">
 class IntercomBroker {
   private sessions = new Map<string, ConnectedSession>();
   private askEdges = new Map<string, AskEdge>();
+  private connections = new Set<net.Socket>();
+  private unregisteredConnections = new Set<net.Socket>();
   private server: net.Server;
   private shutdownTimer: NodeJS.Timeout | null = null;
   private readonly askTimeoutMs = getAskTimeoutMs();
@@ -168,11 +183,50 @@ class IntercomBroker {
   }
 
   private handleConnection(socket: net.Socket): void {
+    this.connections.add(socket);
     let sessionId: string | null = null;
+    let registrationTimeout: NodeJS.Timeout | null = null;
+    const armRegistrationTimeout = () => {
+      if (registrationTimeout) {
+        clearTimeout(registrationTimeout);
+      }
+      this.unregisteredConnections.delete(socket);
+      this.unregisteredConnections.add(socket);
+      this.evictOldestUnregisteredConnections(socket);
+      registrationTimeout = setTimeout(() => {
+        if (!sessionId) {
+          socket.destroy();
+        }
+      }, REGISTRATION_TIMEOUT_MS);
+      registrationTimeout.unref?.();
+    };
+    const clearRegistrationTimeout = () => {
+      if (registrationTimeout) {
+        clearTimeout(registrationTimeout);
+        registrationTimeout = null;
+      }
+      this.unregisteredConnections.delete(socket);
+    };
+    armRegistrationTimeout();
+    const connection: ConnectionState = {
+      socket,
+      tokens: RATE_LIMIT_CAPACITY,
+      lastRefillAt: Date.now(),
+    };
 
     const reader = createMessageReader((msg) => {
+      if (!this.consumeToken(connection)) {
+        writeMessage(socket, { type: "error", error: "Intercom broker rate limit exceeded" });
+        socket.destroy(new Error("Intercom broker rate limit exceeded"));
+        return;
+      }
       this.handleMessage(socket, msg, sessionId, (id) => {
         sessionId = id;
+        if (id) {
+          clearRegistrationTimeout();
+        } else {
+          armRegistrationTimeout();
+        }
       });
     }, (error) => {
       socket.destroy(error);
@@ -181,6 +235,8 @@ class IntercomBroker {
     socket.on("data", reader);
 
     socket.on("close", () => {
+      clearRegistrationTimeout();
+      this.connections.delete(socket);
       if (sessionId) {
         const existing = this.sessions.get(sessionId);
         if (existing?.socket === socket) {
@@ -195,6 +251,36 @@ class IntercomBroker {
     socket.on("error", (error) => {
       console.error("Socket error:", error);
     });
+  }
+
+  private evictOldestUnregisteredConnections(currentSocket: net.Socket): void {
+    while (this.unregisteredConnections.size > MAX_UNREGISTERED_CONNECTIONS) {
+      const [oldest] = this.unregisteredConnections;
+      if (!oldest) {
+        return;
+      }
+      if (oldest === currentSocket && this.unregisteredConnections.size === 1) {
+        return;
+      }
+      this.unregisteredConnections.delete(oldest);
+      oldest.destroy();
+    }
+  }
+
+  private consumeToken(connection: ConnectionState, now = Date.now()): boolean {
+    const elapsedMs = now - connection.lastRefillAt;
+    if (elapsedMs > 0) {
+      connection.tokens = Math.min(
+        RATE_LIMIT_CAPACITY,
+        connection.tokens + elapsedMs * RATE_LIMIT_REFILL_PER_SECOND / 1000,
+      );
+      connection.lastRefillAt = now;
+    }
+    if (connection.tokens < 1) {
+      return false;
+    }
+    connection.tokens -= 1;
+    return true;
   }
 
   private scheduleShutdownCheck(): void {
@@ -265,13 +351,29 @@ class IntercomBroker {
           id = clientMessage.sessionId;
         }
         const previous = this.sessions.get(id);
+        if (!previous && this.sessions.size >= MAX_SESSIONS) {
+          writeMessage(socket, { type: "error", error: "Too many registered intercom sessions" });
+          socket.destroy();
+          break;
+        }
         if (previous) {
           this.clearAskEdgesForSession(id);
           previous.socket.end();
         }
         setId(id);
-        const info: SessionInfo = { ...clientMessage.session, id };
-        this.sessions.set(id, { socket, info });
+        const session = clientMessage.session;
+        const info: SessionInfo = {
+          id,
+          ...(session.name !== undefined ? { name: session.name } : {}),
+          cwd: session.cwd,
+          model: session.model,
+          pid: session.pid,
+          startedAt: session.startedAt,
+          lastActivity: session.lastActivity,
+          ...(session.status !== undefined ? { status: session.status } : {}),
+          trustedLocal: typeof LISTEN_TARGET === "string" && process.platform !== "win32",
+        };
+        this.sessions.set(id, { socket, info, lastPresenceBroadcastAt: Date.now() });
         
         if (this.shutdownTimer) {
           clearTimeout(this.shutdownTimer);
@@ -329,6 +431,14 @@ class IntercomBroker {
 
         const targets = this.findSessions(clientMessage.to);
         if (targets.length === 1) {
+          if (message.replyTo && !replyEdge) {
+            writeMessage(socket, {
+              type: "delivery_failed",
+              messageId: message.id,
+              reason: "Reply target does not match a pending ask",
+            });
+            break;
+          }
           const fromSession = this.sessions.get(currentId);
           if (!fromSession || fromSession.socket !== socket) {
             writeMessage(socket, {
@@ -409,26 +519,40 @@ class IntercomBroker {
         }
         const session = this.sessions.get(currentId);
         if (session?.socket === socket) {
+          let changed = false;
           if (clientMessage.name !== undefined) {
             if (typeof clientMessage.name !== "string") {
               throw new Error("Invalid presence name");
             }
-            session.info.name = clientMessage.name;
+            if (session.info.name !== clientMessage.name) {
+              session.info.name = clientMessage.name;
+              changed = true;
+            }
           }
           if (clientMessage.status !== undefined) {
             if (typeof clientMessage.status !== "string") {
               throw new Error("Invalid presence status");
             }
-            session.info.status = clientMessage.status;
+            if (session.info.status !== clientMessage.status) {
+              session.info.status = clientMessage.status;
+              changed = true;
+            }
           }
           if (clientMessage.model !== undefined) {
             if (typeof clientMessage.model !== "string") {
               throw new Error("Invalid presence model");
             }
-            session.info.model = clientMessage.model;
+            if (session.info.model !== clientMessage.model) {
+              session.info.model = clientMessage.model;
+              changed = true;
+            }
           }
-          session.info.lastActivity = Date.now();
-          this.broadcast({ type: "presence_update", session: session.info }, currentId);
+          const now = Date.now();
+          session.info.lastActivity = now;
+          if (changed || now - session.lastPresenceBroadcastAt >= PRESENCE_HEARTBEAT_MS) {
+            session.lastPresenceBroadcastAt = now;
+            this.broadcast({ type: "presence_update", session: session.info }, currentId);
+          }
         }
         break;
       }

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -3,7 +3,7 @@ import net from "net";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
 import { getBrokerConnectTarget, type BrokerConnectTarget } from "./paths.ts";
-import type { SessionInfo, Message, Attachment } from "../types.ts";
+import type { SessionInfo, Message, Attachment, SessionRegistration } from "../types.ts";
 
 interface SendOptions {
   text: string;
@@ -105,7 +105,15 @@ function isSessionInfo(value: unknown): value is SessionInfo {
     return false;
   }
 
-  return session.status === undefined || typeof session.status === "string";
+  if (session.status !== undefined && typeof session.status !== "string") {
+    return false;
+  }
+
+  if (session.peerUid !== undefined && typeof session.peerUid !== "number") {
+    return false;
+  }
+
+  return session.trustedLocal === undefined || typeof session.trustedLocal === "boolean";
 }
 
 export class IntercomClient extends EventEmitter {
@@ -153,7 +161,7 @@ export class IntercomClient extends EventEmitter {
     return socket;
   }
 
-  connect(session: Omit<SessionInfo, "id">, sessionId?: string): Promise<void> {
+  connect(session: SessionRegistration, sessionId?: string): Promise<void> {
     if (this.socket) {
       return Promise.reject(new Error("Already connected"));
     }
@@ -291,7 +299,7 @@ export class IntercomClient extends EventEmitter {
 
     const brokerMessage = msg as { type: string } & Record<string, unknown>;
 
-    if (this._sessionId === null && brokerMessage.type !== "registered") {
+    if (this._sessionId === null && brokerMessage.type !== "registered" && brokerMessage.type !== "error") {
       throw new Error(`Received ${brokerMessage.type} before registered`);
     }
 
@@ -403,6 +411,9 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Invalid error message");
         }
 
+        if (this._sessionId === null) {
+          throw new Error(brokerMessage.error);
+        }
         this.emit("error", new Error(brokerMessage.error));
         break;
       }

--- a/broker/spawn.test.ts
+++ b/broker/spawn.test.ts
@@ -84,12 +84,11 @@ test("getBrokerLaunchSpec uses custom broker command on Windows", () => {
   }
 });
 
-test("getBrokerLaunchSpec uses npx + tsx on non-Windows", () => {
+test("getBrokerLaunchSpec uses node + resolved tsx for the default non-Windows launch", () => {
   const spec = getBrokerLaunchSpec("C:/repo/broker.ts", "npx", ["--no-install", "tsx"], "C:/repo", "linux", "/tmp/intercom", "/usr/bin/node");
-  assert.equal(spec.command, "npx");
+  assert.equal(spec.command, "/usr/bin/node");
   assert.deepEqual(spec.args, [
-    "--no-install",
-    "tsx",
+    getTsxCliPath("C:/repo"),
     "C:/repo/broker.ts",
   ]);
   assert.equal(spec.kind, "direct");

--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -138,6 +138,14 @@ export function getBrokerLaunchSpec(
     };
   }
 
+  if (usesDefaultBrokerCommand(brokerCommand, brokerArgs)) {
+    return {
+      kind: "direct",
+      command: nodePath,
+      args: [getTsxCliPath(extensionDir), brokerPath],
+    };
+  }
+
   return {
     kind: "direct",
     command: brokerCommand,

--- a/config.test.ts
+++ b/config.test.ts
@@ -1,31 +1,80 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { getConfigPath, loadConfig } from "./config.ts";
+
+async function withAgentDir<T>(agentDir: string, fn: () => T | Promise<T>): Promise<T> {
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    return await fn();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+}
 
 test("getConfigPath uses the centralized intercom runtime directory", () => {
   assert.equal(getConfigPath("/tmp/pi-agent/intercom"), join("/tmp/pi-agent", "intercom", "config.json"));
 });
 
-test("loadConfig reads config below PI_CODING_AGENT_DIR", () => {
+test("loadConfig reads config below PI_CODING_AGENT_DIR", async () => {
   const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
-  const previous = process.env.PI_CODING_AGENT_DIR;
 
   try {
-    process.env.PI_CODING_AGENT_DIR = root;
     const intercomDir = join(root, "intercom");
     mkdirSync(intercomDir, { recursive: true });
     writeFileSync(join(intercomDir, "config.json"), JSON.stringify({ status: "platform-test" }));
 
-    assert.equal(loadConfig().status, "platform-test");
+    await withAgentDir(root, () => {
+      assert.equal(loadConfig().status, "platform-test");
+    });
   } finally {
-    if (previous === undefined) {
-      delete process.env.PI_CODING_AGENT_DIR;
-    } else {
-      process.env.PI_CODING_AGENT_DIR = previous;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig defaults inboundTrigger to current auto-trigger behavior", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
+  try {
+    await withAgentDir(root, () => {
+      assert.equal(loadConfig().inboundTrigger, "always");
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig accepts inboundTrigger replies policy", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
+  try {
+    mkdirSync(join(root, "intercom"), { recursive: true });
+    writeFileSync(join(root, "intercom", "config.json"), JSON.stringify({ inboundTrigger: "replies" }));
+    await withAgentDir(root, () => {
+      assert.equal(loadConfig().inboundTrigger, "replies");
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig rejects invalid inboundTrigger values by failing closed", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
+  try {
+    mkdirSync(join(root, "intercom"), { recursive: true });
+    writeFileSync(join(root, "intercom", "config.json"), JSON.stringify({ inboundTrigger: "prompt" }));
+    const previousError = console.error;
+    console.error = () => undefined;
+    try {
+      await withAgentDir(root, () => {
+        assert.equal(loadConfig().inboundTrigger, "never");
+      });
+    } finally {
+      console.error = previousError;
     }
+  } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/config.ts
+++ b/config.ts
@@ -17,6 +17,8 @@ export function getAskTimeoutMs(): number {
   return value;
 }
 
+export type InboundTriggerPolicy = "always" | "replies" | "never";
+
 export interface IntercomConfig {
   /** Broker command used to spawn the broker process (e.g. "npx" or "bun") */
   brokerCommand: string;
@@ -26,6 +28,9 @@ export interface IntercomConfig {
 
   /** Require confirmation before non-reply sends from interactive sessions */
   confirmSend: boolean;
+
+  /** Controls whether inbound broker messages may automatically trigger a model turn */
+  inboundTrigger: InboundTriggerPolicy;
 
   /** Optional custom status suffix shown after automatic lifecycle status */
   status?: string;
@@ -45,6 +50,7 @@ const defaults: IntercomConfig = {
   brokerCommand: "npx",
   brokerArgs: ["--no-install", "tsx"],
   confirmSend: false,
+  inboundTrigger: "always",
   enabled: true,
   replyHint: true,
 };
@@ -104,6 +110,17 @@ export function loadConfig(): IntercomConfig {
       config.enabled = parsedConfig.enabled;
     }
 
+    if (Object.hasOwn(parsedConfig, "inboundTrigger")) {
+      if (
+        parsedConfig.inboundTrigger !== "always"
+        && parsedConfig.inboundTrigger !== "replies"
+        && parsedConfig.inboundTrigger !== "never"
+      ) {
+        throw new Error(`"inboundTrigger" must be "always", "replies", or "never"`);
+      }
+      config.inboundTrigger = parsedConfig.inboundTrigger;
+    }
+
     if (Object.hasOwn(parsedConfig, "replyHint")) {
       if (typeof parsedConfig.replyHint !== "boolean") {
         throw new Error(`"replyHint" must be a boolean`);
@@ -121,6 +138,6 @@ export function loadConfig(): IntercomConfig {
     return config;
   } catch (error) {
     console.error(`Failed to load intercom config at ${configPath}:`, error);
-    return { ...defaults };
+    return { ...defaults, inboundTrigger: "never" };
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -632,7 +632,19 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     return Boolean(resolvedTo && activeClient?.sessionId && resolvedTo === activeClient.sessionId)
       || targets.has(to.trim().toLowerCase());
   }
-  function sendIncomingMessage(entry: InboundMessageEntry, delivery: "trigger" | "followUp", generation = runtimeGeneration): void {
+  function shouldTriggerInboundMessage(entry: InboundMessageEntry, forceTrigger = false): boolean {
+    if (forceTrigger) {
+      return true;
+    }
+    if (config.inboundTrigger === "always") {
+      return true;
+    }
+    if (config.inboundTrigger === "replies") {
+      return Boolean(entry.message.replyTo);
+    }
+    return false;
+  }
+  function sendIncomingMessage(entry: InboundMessageEntry, delivery: "trigger" | "followUp", generation = runtimeGeneration, forceTrigger = false): void {
     if (runtimeStarted && !getLiveContext(runtimeContext, generation)) {
       return;
     }
@@ -648,7 +660,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         display: true,
         details: entry,
       },
-      delivery === "trigger"
+      delivery === "trigger" && shouldTriggerInboundMessage(entry, forceTrigger)
         ? { triggerTurn: true }
         : { deliverAs: "followUp" }
     );
@@ -894,7 +906,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         content: { text: messageText },
       },
       bodyText: messageText,
-    }, "trigger");
+    }, "trigger", runtimeGeneration, true);
   }
   function recordSubagentDeliveryError(entryType: string, to: string, message: string, error: unknown): void {
     pi.appendEntry(entryType, {

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -203,7 +203,7 @@ function createExtensionHarness(sessionName: string | (() => string) = "child-wo
   };
 }
 
-async function connectRawRegistered(sessionId: string, name: string) {
+async function connectRawRegistered(sessionId: string, name: string, sessionOverrides: Record<string, unknown> = {}) {
   const net = await import("node:net");
   const { getBrokerSocketPath } = await import("./broker/paths.ts");
   const { createMessageReader, writeMessage } = await import("./broker/framing.ts");
@@ -230,6 +230,7 @@ async function connectRawRegistered(sessionId: string, name: string) {
       pid: process.pid,
       startedAt: Date.now(),
       lastActivity: Date.now(),
+      ...sessionOverrides,
     },
   });
   await registered;
@@ -509,6 +510,156 @@ test("broker accepts caller supplied stable IDs across reconnect", { concurrency
     assert.equal(reconnected.sessionId, "stable-session-id");
     await waitForSessionId(planner, "stable-session-id");
     await reconnected.disconnect();
+  } finally {
+    await worker.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("broker owns local trust metadata instead of trusting registration payloads", { concurrency: false }, async () => {
+  const { planner, cleanup } = await setupClients();
+  const raw = await connectRawRegistered("trust-metadata-worker-id", "trust-metadata-worker", {
+    peerUid: 0,
+    trustedLocal: false,
+  });
+
+  try {
+    const session = await waitForSessionId(planner, "trust-metadata-worker-id");
+    assert.equal(session.trustedLocal, process.platform !== "win32");
+    assert.equal(session.peerUid, undefined);
+  } finally {
+    raw.socket.destroy();
+    await cleanup();
+  }
+});
+
+test("broker rejects unknown replyTo values instead of delivering forged replies", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+
+  try {
+    const result = await planner.send(orchestrator.sessionId!, {
+      text: "This is not a real reply.",
+      replyTo: "not-a-pending-ask",
+    });
+    assert.equal(result.delivered, false);
+    assert.match(result.reason ?? "", /pending ask/i);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("broker disconnects a connection that exceeds the local rate limit", { concurrency: false }, async () => {
+  const { cleanup } = await setupClients();
+  const raw = await connectRawRegistered("rate-limit-worker-id", "rate-limit-worker");
+
+  try {
+    raw.socket.on("error", () => undefined);
+    const closed = once(raw.socket, "close");
+    for (let i = 0; i < 300; i += 1) {
+      raw.writeMessage(raw.socket, { type: "list", requestId: `flood-${i}` });
+    }
+    await closed;
+    assert.equal(raw.socket.destroyed, true);
+  } finally {
+    raw.socket.destroy();
+    await cleanup();
+  }
+});
+
+test("broker idle raw connections cannot block legitimate registration", { concurrency: false }, async () => {
+  const net = await import("node:net");
+  const { getBrokerSocketPath } = await import("./broker/paths.ts");
+  const { cleanup } = await setupClients();
+  const sockets: ReturnType<typeof net.connect>[] = [];
+  const legitimate = new IntercomClient();
+
+  try {
+    for (let i = 0; i < 140; i += 1) {
+      const socket = net.connect(getBrokerSocketPath());
+      socket.on("error", () => undefined);
+      sockets.push(socket);
+      await Promise.race([
+        once(socket, "connect").catch(() => undefined),
+        once(socket, "close").catch(() => undefined),
+        new Promise((resolve) => setTimeout(resolve, 200)),
+      ]);
+    }
+
+    await legitimate.connect({
+      name: "legitimate-after-idle-flood",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    });
+    assert.equal(legitimate.isConnected(), true);
+  } finally {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await legitimate.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("broker times out sockets that unregister and go idle", { concurrency: false }, async () => {
+  const { cleanup } = await setupClients();
+  const raws: Array<Awaited<ReturnType<typeof connectRawRegistered>>> = [];
+  const legitimate = new IntercomClient();
+
+  try {
+    for (let i = 0; i < 40; i += 1) {
+      const raw = await connectRawRegistered(`unregister-idle-${i}`, `unregister-idle-${i}`);
+      raw.socket.on("error", () => undefined);
+      raw.writeMessage(raw.socket, { type: "unregister" });
+      raws.push(raw);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    await legitimate.connect({
+      name: "legitimate-after-unregister-idle-flood",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    });
+    assert.equal(legitimate.isConnected(), true);
+  } finally {
+    for (const raw of raws) {
+      raw.socket.destroy();
+    }
+    await legitimate.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("broker coalesces no-op presence floods", { concurrency: false }, async () => {
+  const { planner, cleanup } = await setupClients();
+  const worker = new IntercomClient();
+  const updates: SessionInfo[] = [];
+  planner.on("presence_update", (session: SessionInfo) => {
+    if (session.name === "presence-worker") {
+      updates.push(session);
+    }
+  });
+
+  try {
+    await worker.connect({
+      name: "presence-worker",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    });
+    worker.updatePresence({ status: "idle" });
+    for (let i = 0; i < 20; i += 1) {
+      worker.updatePresence({ status: "idle" });
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.equal(updates.length, 1);
   } finally {
     await worker.disconnect().catch(() => undefined);
     await cleanup();

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,8 @@ export interface SessionInfo {
   startedAt: number;
   lastActivity: number;
   status?: string;
+  peerUid?: number;
+  trustedLocal?: boolean;
 }
 
 export interface Message {
@@ -27,8 +29,10 @@ export interface Attachment {
   language?: string;
 }
 
+export type SessionRegistration = Omit<SessionInfo, "id" | "peerUid" | "trustedLocal">;
+
 export type ClientMessage =
-  | { type: "register"; session: Omit<SessionInfo, "id">; sessionId?: string; stateId?: string }
+  | { type: "register"; session: SessionRegistration; sessionId?: string; stateId?: string }
   | { type: "unregister" }
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }


### PR DESCRIPTION
## Summary

Hardens local intercom trust boundaries and abuse controls.

This includes:

- broker-owned local trust metadata instead of trusting registration payloads
- registered-session caps plus bounded unauthenticated sockets, registration timeouts, and re-armed timeouts after unregister
- per-connection rate limiting and presence coalescing
- broker validation that `replyTo` belongs to a pending ask before delivering replies to live targets
- `inboundTrigger` policy (`always`, `replies`, `never`) with invalid config failing closed to `never`
- default broker auto-spawn hardened to launch the resolved bundled `tsx` CLI through the current Node executable instead of resolving `npx` through `PATH`
- docs, changelog, and regression coverage for the security controls

## Verification

- `npm test` passed, 89/89, using the repo root `node_modules` symlink required for temporary worktrees
- `git diff --check HEAD~1` passed
- `tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --allowImportingTsExtensions $(git ls-files '*.ts')` passed
- `npm pack --dry-run` passed
- final focused adversarial review: no issues found

Closes #15.
Closes #16.
Closes #19.
Closes #20.
