### PR TITLE
feat: collapse inline intercom messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 - Centralized pi-intercom runtime and config paths under `PI_CODING_AGENT_DIR` when set, defaulting to `~/.pi/agent`.
 - Hardened default broker auto-spawn to launch the resolved bundled `tsx` CLI through the current Node executable instead of resolving `npx` through `PATH`; custom `brokerCommand`/`brokerArgs` remain available as advanced trusted config.
 - Added an `inboundTrigger` policy (`always`, `replies`, or `never`) so users can reduce inbound auto-trigger risk while preserving existing behavior by default.
+- Made inline intercom messages collapse and expand with Pi's `Ctrl+O` custom-message toggle while keeping sender, preview, reply, and attachment cues visible. Thanks to RyanKim17920 for PR #32.
 
 ### Fixed
 - Added broker-owned local trust metadata, clearer stable-ID trust boundaries for duplicate names, per-connection rate limiting, and no-op presence coalescing for local IPC abuse hardening.

--- a/index.ts
+++ b/index.ts
@@ -1139,10 +1139,10 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
   });
 
-  pi.registerMessageRenderer("intercom_message", (message, _options, theme) => {
+  pi.registerMessageRenderer("intercom_message", (message, options, theme) => {
     const details = message.details as { from: SessionInfo; message: Message; replyCommand?: string; bodyText?: string } | undefined;
     if (!details) return undefined;
-    return new InlineMessageComponent(details.from, details.message, theme, details.replyCommand, details.bodyText);
+    return new InlineMessageComponent(details.from, details.message, theme, details.replyCommand, details.bodyText, !options.expanded);
   });
 
   pi.on("tool_result", (event) => {

--- a/test/inline-message.test.ts
+++ b/test/inline-message.test.ts
@@ -37,3 +37,43 @@ test("inline intercom messages render at the available terminal width", () => {
   assert.ok(lines.length > 0);
   for (const line of lines) assert.equal(visibleWidth(line), 120);
 });
+
+test("expanded inline intercom messages show the full body without collapse controls", () => {
+  const component = new InlineMessageComponent(from, message, theme as any, "intercom({ action: \"reply\", message: \"...\" })");
+
+  const rendered = component.render(100).join("\n");
+
+  assert.match(rendered, /available terminal width/);
+  assert.match(rendered, /narrow fixed/);
+  assert.match(rendered, /card/);
+  assert.match(rendered, /To reply: intercom/);
+  assert.doesNotMatch(rendered, /Ctrl\+O/);
+});
+
+test("collapsed inline intercom messages keep preview, reply hint, and expand key visible", () => {
+  const component = new InlineMessageComponent(
+    from,
+    {
+      ...message,
+      content: {
+        text: "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu. This tail should only appear when expanded because the collapsed preview is intentionally brief.",
+        attachments: [{ type: "snippet", name: "note.txt", content: "important details" }],
+      },
+    },
+    theme as any,
+    "intercom({ action: \"reply\", message: \"...\" })",
+    undefined,
+    true,
+  );
+
+  const lines = component.render(120);
+  const rendered = lines.join("\n");
+
+  assert.equal(lines.length, 4);
+  for (const line of lines) assert.equal(visibleWidth(line), 120);
+  assert.match(rendered, /Alpha beta gamma/);
+  assert.doesNotMatch(rendered, /intentionally brief/);
+  assert.match(rendered, /To reply: intercom/);
+  assert.match(rendered, /Ctrl\+O/);
+  assert.match(rendered, /1 attachment/);
+});

--- a/ui/inline-message.ts
+++ b/ui/inline-message.ts
@@ -9,13 +9,22 @@ export class InlineMessageComponent implements Component {
   private theme: Theme;
   private replyCommand?: string;
   private bodyText?: string;
+  private collapsed: boolean;
 
-  constructor(from: SessionInfo, message: Message, theme: Theme, replyCommand?: string, bodyText?: string) {
+  constructor(
+    from: SessionInfo,
+    message: Message,
+    theme: Theme,
+    replyCommand?: string,
+    bodyText?: string,
+    collapsed = false,
+  ) {
     this.from = from;
     this.message = message;
     this.theme = theme;
     this.replyCommand = replyCommand;
     this.bodyText = bodyText;
+    this.collapsed = collapsed;
   }
 
   invalidate(): void {}
@@ -23,16 +32,38 @@ export class InlineMessageComponent implements Component {
   render(width: number): string[] {
     const lines: string[] = [];
     const borderChar = "─";
+    const senderName = this.from.name || this.from.id.slice(0, 8);
     if (width < 3) {
-      return [truncateToWidth(`From ${this.from.name || this.from.id.slice(0, 8)}`, width)];
+      return [truncateToWidth(`From ${senderName}`, width)];
     }
     const bodyWidth = Math.max(1, width - 2);
 
-    const senderName = this.from.name || this.from.id.slice(0, 8);
     const header = ` 📨 From: ${senderName} (${this.from.cwd}) `;
-    const headerText = truncateToWidth(header, bodyWidth, "");
+    const headerText = truncateToWidth(this.collapsed ? `${header} Ctrl+O expands ` : header, bodyWidth, "");
     const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
     lines.push(this.theme.fg("accent", `╭${headerText}${borderChar.repeat(headerPadding)}╮`));
+
+    if (this.collapsed) {
+      const preview = (this.bodyText || this.message.content.text).replace(/\s+/g, " ").trim();
+      const previewText = truncateToWidth(preview, bodyWidth, "");
+      const previewPadding = Math.max(0, bodyWidth - visibleWidth(previewText));
+      lines.push(this.theme.fg("accent", `│${previewText}${" ".repeat(previewPadding)}│`));
+
+      const meta: string[] = [];
+      if (this.replyCommand) meta.push(`↩ To reply: ${this.replyCommand}`);
+      if (this.message.content.attachments?.length) {
+        const count = this.message.content.attachments.length;
+        meta.push(`📎 ${count} attachment${count === 1 ? "" : "s"}`);
+      }
+      if (this.message.replyTo && !this.message.expectsReply) meta.push(`↳ Reply to ${this.message.replyTo.slice(0, 8)}`);
+      meta.push("Ctrl+O to expand");
+
+      const metaText = truncateToWidth(this.theme.fg("dim", ` ${meta.join(" · ")}`), bodyWidth, "");
+      const metaPadding = Math.max(0, bodyWidth - visibleWidth(metaText));
+      lines.push(this.theme.fg("accent", `│${metaText}${" ".repeat(metaPadding)}│`));
+      lines.push(this.theme.fg("accent", `╰${borderChar.repeat(bodyWidth)}╯`));
+      return lines;
+    }
 
     const contentLines = wrapTextWithAnsi(this.bodyText || this.message.content.text, bodyWidth);
     for (const line of contentLines) {


### PR DESCRIPTION
## Summary

Reimplements PR #32 on current `main` after the overlay width, platform, and security work landed.

Inline intercom messages now render a collapsed view when Pi custom-message expanded state is off, and expand through the existing `Ctrl+O` custom-message toggle. The collapsed view keeps the sender, preview, reply hint, attachment/reply cues, and expand hint visible so coordination is not hidden completely.

Thanks to RyanKim17920 for PR #32.

## Verification

- `npm test` passed, 91/91, using the repo root `node_modules` symlink required for temporary worktrees
- `git diff --check HEAD~1` passed
- `tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --allowImportingTsExtensions $(git ls-files '*.ts')` passed
- `npm pack --dry-run` passed
- Direct source review confirmed Pi passes `{ expanded: this._expanded }` to custom message renderers and `Ctrl+O` toggles that state
