### PR TITLE
feat: add list-cwd action to scope peer discovery by working directory

### DIFF
--- a/cwd.test.ts
+++ b/cwd.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync, mkdirSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { normalizeCwd, sameCwd } from "./cwd.ts";
+
+test("sameCwd collapses a trailing slash", () => {
+  assert.equal(sameCwd("/usr/local", "/usr/local/"), true);
+});
+
+test("sameCwd collapses lexical '.' and '..' segments", () => {
+  assert.equal(sameCwd("/usr/local/../local/./bin", "/usr/local/bin"), true);
+});
+
+test("sameCwd treats genuinely different directories as different", () => {
+  assert.equal(sameCwd("/usr/local", "/usr/lib"), false);
+});
+
+test("sameCwd collapses a symlink to its real target", () => {
+  const base = mkdtempSync(join(tmpdir(), "cwd-symlink-"));
+  try {
+    const real = join(base, "real");
+    const link = join(base, "link");
+    mkdirSync(real);
+    symlinkSync(real, link);
+    // Reached via the symlink vs its canonical path — must compare equal.
+    assert.equal(sameCwd(link, real), true);
+    // And normalizeCwd resolves the link to the real path.
+    assert.equal(normalizeCwd(link), realpathSync(real));
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("normalizeCwd falls back to the resolved path for a nonexistent dir", () => {
+  // realpathSync throws for a missing dir; normalizeCwd must still collapse the
+  // lexical variants rather than throw.
+  assert.equal(normalizeCwd("/no/such/dir/../dir"), "/no/such/dir");
+});

--- a/cwd.ts
+++ b/cwd.ts
@@ -1,0 +1,31 @@
+import { resolve } from "node:path";
+import { realpathSync } from "node:fs";
+
+// Normalize a cwd for same-directory comparison. A raw string match ("a === b")
+// hides genuine same-directory peers when two cwd strings differ only by a
+// trailing slash, a "."/".." segment, or a symlink (e.g. macOS /tmp <->
+// /private/tmp). resolve() collapses the lexical variants; realpathSync()
+// collapses symlinks (best-effort: falls back to the resolved path if the
+// directory no longer exists). Memoized — the set of distinct cwd strings is
+// small and stable, so repeat comparisons are free after warmup.
+const normalizeCache = new Map<string, string>();
+
+export function normalizeCwd(cwd: string): string {
+  const cached = normalizeCache.get(cwd);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const resolved = resolve(cwd);
+  let normalized: string;
+  try {
+    normalized = realpathSync(resolved);
+  } catch {
+    normalized = resolved;
+  }
+  normalizeCache.set(cwd, normalized);
+  return normalized;
+}
+
+export function sameCwd(a: string, b: string): boolean {
+  return normalizeCwd(a) === normalizeCwd(b);
+}

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,8 @@ import { InlineMessageComponent } from "./ui/inline-message.ts";
 import { getAskTimeoutMs, loadConfig, type IntercomConfig } from "./config.ts";
 import type { SessionInfo, Message, Attachment } from "./types.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
+import { resolve as resolvePath } from "node:path";
+import { sameCwd } from "./cwd.ts";
 
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
@@ -1430,6 +1432,8 @@ Use this to communicate findings, request help, or coordinate work with other se
 
 Usage:
   intercom({ action: "list" })                    → List active sessions
+  intercom({ action: "list-cwd" })                → List sessions in the current working directory
+  intercom({ action: "list-cwd", cwd: "/path" })  → List sessions in a specific directory
   intercom({ action: "send", to: "session-name", message: "..." })  → Send message
   intercom({ action: "ask", to: "session-name", message: "..." })   → Ask and wait for reply
   intercom({ action: "reply", message: "..." })                      → Reply to the active/single pending ask
@@ -1439,8 +1443,8 @@ Usage:
       "Use to coordinate with other local pi sessions: list peers, send updates, ask for help, or check intercom connectivity.",
 
     parameters: Type.Object({
-      action: StringEnum(["list", "send", "ask", "reply", "pending", "status"] as const, {
-        description: "Action: 'list', 'send', 'ask', 'reply', 'pending', or 'status'",
+      action: StringEnum(["list", "list-cwd", "send", "ask", "reply", "pending", "status"] as const, {
+        description: "Action: 'list', 'list-cwd', 'send', 'ask', 'reply', 'pending', or 'status'",
       }),
       to: Type.Optional(Type.String({
         description: "Target session name or ID (for 'send', 'ask', or disambiguating 'reply')",
@@ -1457,6 +1461,9 @@ Usage:
       replyTo: Type.Optional(Type.String({
         description: "Message ID to reply to (for threading or responding to an 'ask')",
       })),
+      cwd: Type.Optional(Type.String({
+        description: "Working directory filter for 'list-cwd' (absolute, or relative to the current session's cwd; '.' means the current cwd). Defaults to the current session's cwd.",
+      })),
     }),
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -1472,7 +1479,7 @@ Usage:
 
       syncPresenceIdentity(ctx.sessionManager.getSessionId());
 
-      const { action, to, message, attachments, replyTo } = params;
+      const { action, to, message, attachments, replyTo, cwd } = params;
 
       switch (action) {
         case "list": {
@@ -1493,6 +1500,59 @@ Usage:
             const otherSection = otherSessions.length === 0
               ? "**Other sessions:**\nNo other sessions connected."
               : `**Other sessions:**\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
+
+            return {
+              content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],
+              details: {},
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Failed to list sessions: ${getErrorMessage(error)}` }],
+              details: { error: true },
+            };
+          }
+        }
+
+        case "list-cwd": {
+          try {
+            const mySessionId = connectedClient.sessionId;
+            const sessions = await connectedClient.listSessions();
+            const currentSession = sessions.find(s => s.id === mySessionId);
+
+            if (!currentSession) {
+              return {
+                content: [{ type: "text", text: "Current session is missing from intercom session list." }],
+                details: { error: true },
+              };
+            }
+
+            // Default to the current session's cwd; an explicit `cwd` overrides
+            // (relative paths resolved against it, "." meaning the current cwd).
+            const filterCwd = cwd && cwd !== "."
+              ? resolvePath(currentSession.cwd, cwd)
+              : currentSession.cwd;
+
+            const otherSessions = sessions.filter(
+              s => s.id !== mySessionId && sameCwd(s.cwd, filterCwd),
+            );
+
+            // Fail loud: filtering by a directory with no peers while the
+            // session's OWN cwd has some otherwise reads as a misleading empty
+            // result (common when a caller passes a guessed parent cwd).
+            let emptyNote = "No other sessions in this directory.";
+            if (otherSessions.length === 0 && !sameCwd(filterCwd, currentSession.cwd)) {
+              const here = sessions.filter(
+                s => s.id !== mySessionId && sameCwd(s.cwd, currentSession.cwd),
+              ).length;
+              if (here > 0) {
+                emptyNote += ` Your session's cwd is ${currentSession.cwd} (${here} peer${here === 1 ? "" : "s"} there) — call list-cwd without a cwd argument to list them.`;
+              }
+            }
+
+            const currentSection = `**Current session:**\n${formatSessionListRow(currentSession, currentSession.cwd, true)}`;
+            const otherSection = otherSessions.length === 0
+              ? `**Other sessions (cwd: ${filterCwd}):**\n${emptyNote}`
+              : `**Other sessions (cwd: ${filterCwd}):**\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
 
             return {
               content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts cwd.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"


### PR DESCRIPTION
## What

Adds an `intercom({ action: "list-cwd" })` action that lists only the sessions sharing the caller's working directory — the scoped-discovery default an orchestrator usually wants — while `list` stays all-directories. An optional `cwd` narrows to a specific directory (absolute, or relative to the caller's cwd; `"."` means the current cwd).

## Why

When several pi sessions run on one machine across different projects, `list` returns every peer regardless of directory. A coordinating agent almost always wants just the peers in the current working tree.

Doing that with a raw `s.cwd === currentCwd` string match is subtly wrong — it hides genuine same-directory peers whose cwd string differs only by:

- a trailing slash (`/work` vs `/work/`),
- a `.` / `..` segment, or
- a symlink (on macOS `/tmp` ↔ `/private/tmp`, or any symlinked project root).

So the new `cwd.ts` normalizes both sides before comparing — `resolve()` for the lexical variants and `realpathSync()` for symlinks (best-effort, with a graceful fallback if the directory no longer exists; memoized since the set of distinct cwds is small and stable).

Small robustness touch: if you filter by a directory that has no peers while your *own* cwd does (easy to do by passing a guessed parent path), the empty result points back to your real cwd and its peer count instead of a silently misleading "no sessions".

## Scope

Purely additive — a new action mirroring `list`, reusing the existing `formatSessionListRow` and result conventions. Zero behavior change to `list` / `send` / `ask` / `reply` / `pending` / `status`.

## Design note

I chose a separate `list-cwd` action over adding a `cwd` filter to `list`, for explicitness and back-compat (existing `list` callers and output are untouched, and the intent reads clearly at the call site). Happy to refactor into a `list` filter instead if you'd prefer a single action.

## Tests

New `cwd.test.ts` covers `normalizeCwd` / `sameCwd`: trailing slash, lexical `.`/`..` collapse, symlink resolution (real fixture), and the missing-dir fallback. Full suite green (96/96, including the 5 new).
