### PR TITLE
feat: broadcast per-session context-window usage via presence

### DIFF
--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -547,6 +547,39 @@ class IntercomBroker {
               changed = true;
             }
           }
+          // Context-usage fields: a number updates, an explicit null CLEARS (the
+          // value is unknown right after a compaction — delete rather than carry
+          // the stale-high value forward), undefined leaves the field untouched.
+          if (clientMessage.contextPct !== undefined) {
+            if (clientMessage.contextPct === null) {
+              if (session.info.contextPct !== undefined) { delete session.info.contextPct; changed = true; }
+            } else if (typeof clientMessage.contextPct !== "number") {
+              throw new Error("Invalid presence contextPct");
+            } else if (session.info.contextPct !== clientMessage.contextPct) {
+              session.info.contextPct = clientMessage.contextPct;
+              changed = true;
+            }
+          }
+          if (clientMessage.contextTokens !== undefined) {
+            if (clientMessage.contextTokens === null) {
+              if (session.info.contextTokens !== undefined) { delete session.info.contextTokens; changed = true; }
+            } else if (typeof clientMessage.contextTokens !== "number") {
+              throw new Error("Invalid presence contextTokens");
+            } else if (session.info.contextTokens !== clientMessage.contextTokens) {
+              session.info.contextTokens = clientMessage.contextTokens;
+              changed = true;
+            }
+          }
+          if (clientMessage.contextWindow !== undefined) {
+            if (clientMessage.contextWindow === null) {
+              if (session.info.contextWindow !== undefined) { delete session.info.contextWindow; changed = true; }
+            } else if (typeof clientMessage.contextWindow !== "number") {
+              throw new Error("Invalid presence contextWindow");
+            } else if (session.info.contextWindow !== clientMessage.contextWindow) {
+              session.info.contextWindow = clientMessage.contextWindow;
+              changed = true;
+            }
+          }
           const now = Date.now();
           session.info.lastActivity = now;
           if (changed || now - session.lastPresenceBroadcastAt >= PRESENCE_HEARTBEAT_MS) {

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -113,6 +113,12 @@ function isSessionInfo(value: unknown): value is SessionInfo {
     return false;
   }
 
+  for (const key of ["contextPct", "contextTokens", "contextWindow"] as const) {
+    if (session[key] !== undefined && typeof session[key] !== "number") {
+      return false;
+    }
+  }
+
   return session.trustedLocal === undefined || typeof session.trustedLocal === "boolean";
 }
 
@@ -565,7 +571,7 @@ export class IntercomClient extends EventEmitter {
     }
   }
 
-  updatePresence(updates: { name?: string; status?: string; model?: string }): void {
+  updatePresence(updates: { name?: string; status?: string; model?: string; contextPct?: number | null; contextTokens?: number | null; contextWindow?: number | null }): void {
     if (this.disconnecting) {
       return;
     }

--- a/format-context.test.ts
+++ b/format-context.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatTokenCount, formatContextUsage } from "./format-context.ts";
+import type { SessionInfo } from "./types.ts";
+
+const base: SessionInfo = { id: "s1", cwd: "/w", model: "m", pid: 1, startedAt: 0, lastActivity: 0 };
+
+test("formatTokenCount compacts thousands", () => {
+  assert.equal(formatTokenCount(0), "0");
+  assert.equal(formatTokenCount(999), "999");
+  assert.equal(formatTokenCount(1432), "1.4k");
+  assert.equal(formatTokenCount(144000), "144k");
+  assert.equal(formatTokenCount(200000), "200k");
+});
+
+test("formatContextUsage renders percent + token detail when all known", () => {
+  assert.equal(
+    formatContextUsage({ ...base, contextPct: 72, contextTokens: 144000, contextWindow: 200000 }),
+    " · 72% ctx (144k/200k)",
+  );
+});
+
+test("formatContextUsage shows percent only when token counts are absent", () => {
+  assert.equal(formatContextUsage({ ...base, contextPct: 30 }), " · 30% ctx");
+});
+
+test("formatContextUsage renders nothing when percent is unknown (never a stale %)", () => {
+  assert.equal(formatContextUsage(base), "");
+  // Tokens present but no percent (e.g. right after a compaction) still renders nothing.
+  assert.equal(formatContextUsage({ ...base, contextTokens: 100, contextWindow: 200 }), "");
+});

--- a/format-context.ts
+++ b/format-context.ts
@@ -1,0 +1,32 @@
+import type { SessionInfo } from "./types.ts";
+
+// Compact token count for display: 1432 -> "1.4k", 144000 -> "144k". Keeps list
+// rows short while staying legible.
+export function formatTokenCount(tokens: number): string {
+  if (tokens < 1000) {
+    return String(Math.max(0, Math.round(tokens)));
+  }
+  const k = tokens / 1000;
+  const value = k >= 100 ? String(Math.round(k)) : k.toFixed(1).replace(/\.0$/, "");
+  return `${value}k`;
+}
+
+// Render a session's context-window usage to sit beside its model, e.g.
+// " · 72% ctx (144k/200k)". The token detail is appended only when both counts
+// are known. Unknown percent (e.g. right after a compaction, before the next
+// assistant response) renders nothing, so a frozen value is never shown as a
+// stale percentage.
+export function formatContextUsage(session: SessionInfo): string {
+  if (typeof session.contextPct !== "number") {
+    return "";
+  }
+  let out = ` · ${session.contextPct}% ctx`;
+  if (
+    typeof session.contextTokens === "number"
+    && typeof session.contextWindow === "number"
+    && session.contextWindow > 0
+  ) {
+    out += ` (${formatTokenCount(session.contextTokens)}/${formatTokenCount(session.contextWindow)})`;
+  }
+  return out;
+}

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { InlineMessageComponent } from "./ui/inline-message.ts";
 import { getAskTimeoutMs, loadConfig, type IntercomConfig } from "./config.ts";
 import type { SessionInfo, Message, Attachment } from "./types.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
+import { formatContextUsage } from "./format-context.ts";
 
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
@@ -402,7 +403,7 @@ function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: 
   const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `• ${name} (${shortSessionId(session.id)}) — ${session.cwd} (${session.model})${suffix}`;
+  return `• ${name} (${shortSessionId(session.id)}) — ${session.cwd} (${session.model}${formatContextUsage(session)})${suffix}`;
 }
 function previewText(value: unknown, maxLength = 72): string | undefined {
   if (typeof value !== "string") {
@@ -581,13 +582,33 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       status: currentStatus(),
     };
   }
+  // Snapshot the live session's context-window usage for presence. getContextUsage()
+  // (stock SDK) reports { tokens, contextWindow, percent }, with tokens/percent null
+  // right after a compaction (before the next assistant response). We emit null in
+  // that case to CLEAR a peer's stale value rather than freeze the old percentage.
+  // Feature-detected so an older runtime without getContextUsage() just omits it.
+  function currentContextUsage(): { contextPct?: number | null; contextTokens?: number | null; contextWindow?: number } {
+    const usage = getLiveContext()?.getContextUsage?.();
+    if (!usage) {
+      return {};
+    }
+    const result: { contextPct?: number | null; contextTokens?: number | null; contextWindow?: number } = {
+      contextPct: typeof usage.percent === "number" && Number.isFinite(usage.percent) ? Math.round(usage.percent) : null,
+      contextTokens: typeof usage.tokens === "number" && Number.isFinite(usage.tokens) ? usage.tokens : null,
+    };
+    if (typeof usage.contextWindow === "number" && usage.contextWindow > 0) {
+      result.contextWindow = usage.contextWindow;
+    }
+    return result;
+  }
+
   function syncPresenceIdentity(sessionId: string): void {
     if (!client || !getLiveContext()) {
       return;
     }
     const identity = buildPresenceIdentity(pi, sessionId);
     lastPresenceName = identity.name;
-    client.updatePresence({ ...identity, status: currentStatus() });
+    client.updatePresence({ ...identity, status: currentStatus(), ...currentContextUsage() });
   }
   function startNamePoll(): void {
     clearNamePollTimer();
@@ -617,7 +638,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     if (!client || !currentSessionId || !getLiveContext()) {
       return;
     }
-    client.updatePresence({ status: currentStatus() });
+    // context% rides the status heartbeat so peers see live usage at turn boundaries.
+    client.updatePresence({ status: currentStatus(), ...currentContextUsage() });
   }
   function currentSessionTargetMatches(to: string, resolvedTo?: string | null, activeClient?: IntercomClient): boolean {
     const targets = new Set<string>();

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -1862,3 +1862,33 @@ test("async ask can be replied to later from the single pending ask fallback", {
     await cleanup();
   }
 });
+
+test("presence carries context usage to peers, and an explicit null clears a stale value", { concurrency: false }, async () => {
+  // Peers should see each other's live context-window usage without a separate
+  // query, and a post-compaction null must CLEAR the value rather than leave a
+  // stale-high percentage frozen in the list.
+  const { planner, orchestrator, cleanup } = await setupClients();
+  try {
+    planner.updatePresence({ contextPct: 50, contextTokens: 100000, contextWindow: 200000 });
+    // Flush barrier: a round-trip on planner's OWN socket guarantees the broker
+    // processed the presence (FIFO per socket) before the peer probes.
+    await planner.send(orchestrator.sessionId!, { text: "flush" });
+    let sessions = await orchestrator.listSessions();
+    let p = sessions.find(s => s.id === planner.sessionId);
+    assert.equal(p?.contextPct, 50);
+    assert.equal(p?.contextTokens, 100000);
+    assert.equal(p?.contextWindow, 200000);
+
+    // Post-compaction: null contextPct/tokens must CLEAR (not freeze the old %).
+    planner.updatePresence({ contextPct: null, contextTokens: null });
+    await planner.send(orchestrator.sessionId!, { text: "flush" });
+    sessions = await orchestrator.listSessions();
+    p = sessions.find(s => s.id === planner.sessionId);
+    assert.equal(p?.contextPct, undefined, "null contextPct must CLEAR the field, not freeze the old value");
+    assert.equal(p?.contextTokens, undefined);
+    // contextWindow (the denominator, not nulled here) is retained.
+    assert.equal(p?.contextWindow, 200000);
+  } finally {
+    await cleanup();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts format-context.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/types.ts
+++ b/types.ts
@@ -9,6 +9,14 @@ export interface SessionInfo {
   status?: string;
   peerUid?: number;
   trustedLocal?: boolean;
+  /** Live context-window usage, pushed via presence from the source session's
+   *  getContextUsage(). contextPct is 0..100 (rounded); contextTokens /
+   *  contextWindow are raw token counts. All optional: unknown right after a
+   *  compaction (before the next assistant response), when no model is selected,
+   *  or on older clients that never report it. */
+  contextPct?: number;
+  contextTokens?: number;
+  contextWindow?: number;
 }
 
 export interface Message {
@@ -37,7 +45,12 @@ export type ClientMessage =
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }
   | { type: "cancel_ask"; messageId: string }
-  | { type: "presence"; name?: string; status?: string; model?: string };
+  // presence carries optional context-usage fields so peers see each session's
+  // live context% without a separate query. contextPct/contextTokens/contextWindow
+  // accept null as an explicit CLEAR signal (post-compaction the value is unknown
+  // until the next assistant response); the broker deletes the field rather than
+  // carrying the stale value forward.
+  | { type: "presence"; name?: string; status?: string; model?: string; contextPct?: number | null; contextTokens?: number | null; contextWindow?: number | null };
 
 export type BrokerMessage =
   | { type: "registered"; sessionId: string }


### PR DESCRIPTION
## What

Sessions now broadcast their live context-window usage (percent + token counts) on the existing presence heartbeat, so `list` shows each peer's context fill next to its model — e.g. `(claude-opus · 72% ctx (144k/200k))`. An orchestrator coordinating several sessions can spot a near-full peer at a glance, without a separate query.

## Why

When you're driving multiple pi sessions, which peers are close to their context limit is exactly the signal you want when deciding who to hand the next task to (or who to compact). Today that means switching to each session; this surfaces it inline in the peer list.

## How

- Source: `ctx.getContextUsage()` (stock SDK — `{ tokens, contextWindow, percent }`), feature-detected so an older runtime without it simply omits the fields.
- `SessionInfo` and the `presence` message gain optional `contextPct` / `contextTokens` / `contextWindow`, pushed on the existing presence syncs (identity + status heartbeat).
- Rendered in `formatSessionListRow` beside the model.

## Semantics

- **Protocol-additive / backward compatible:** the fields are optional; an older client that never reports them just renders nothing. Zero behavior change to existing actions.
- **null = CLEAR:** right after a compaction the value is unknown (before the next assistant response). The source then emits `null`, and the broker DELETES the field rather than carrying the stale-high percentage forward — so a just-compacted peer never shows a misleading high `%`.
- **Unknown percent renders nothing:** a frozen value is never displayed as a stale `%`.

## Tests

- `format-context.test.ts` — token compaction (`1.4k` / `144k`) and the render states (percent+tokens / percent-only / nothing-when-unknown).
- An integration test proving presence carries usage to a peer, and that a subsequent `null` CLEARS the value rather than freezing the old one.

Full suite green (96/96, including the new tests).
