### PR TITLE
Add intercom contact ID shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Press **Alt+M** or type `/intercom` to open the session list overlay:
 2. **Compose message** — Write your message in the compose overlay
 3. **Send** — Press Enter to send, Escape to cancel
 
+Press **Alt+I** or run `/intercom-id` to copy a short handoff snippet for the current session. The snippet includes the stable intercom session ID so another agent can message this session even when names are duplicated.
+
 ### From the Agent
 
 The agent can list sessions and send messages using the `intercom` tool. Tool calls and results render as compact transcript rows so send/ask/reply flows are easy to scan. For common patterns like planner-worker delegation, the bundled `pi-intercom` skill provides copy-paste ready examples:
@@ -353,6 +355,7 @@ Only registered in sessions where `pi-subagents` supplied the required child bri
 | Key | Action |
 |-----|--------|
 | Alt+M | Open session list overlay |
+| Alt+I | Copy this session's intercom contact target, falling back to editor insert |
 | ↑/↓ | Navigate session list |
 | Enter | Select session / Send message |
 | Escape | Cancel / Close overlay |

--- a/clipboard.test.ts
+++ b/clipboard.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { setTimeout as delay } from "node:timers/promises";
+
+const { copyTextToClipboard } = await import("./index.ts");
+
+async function readEventually(file: string, timeoutMs = 1000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return readFileSync(file, "utf8");
+    } catch (error) {
+      lastError = error;
+      await delay(10);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(`Timed out reading ${file}`);
+}
+
+test("copyTextToClipboard handles wl-copy helpers that daemonize", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "pi-intercom-clipboard-"));
+  const outFile = path.join(dir, "clipboard.txt");
+  const helper = path.join(dir, "wl-copy");
+  const previousPath = process.env.PATH;
+  const previousWayland = process.env.WAYLAND_DISPLAY;
+  const previousDisplay = process.env.DISPLAY;
+  const previousOut = process.env.PI_INTERCOM_FAKE_CLIPBOARD_OUT;
+
+  try {
+    writeFileSync(helper, "#!/bin/sh\ncat > \"$PI_INTERCOM_FAKE_CLIPBOARD_OUT\"\n(sleep 3) &\nexit 0\n", { mode: 0o755 });
+    process.env.PATH = `${dir}${path.delimiter}${previousPath ?? ""}`;
+    process.env.WAYLAND_DISPLAY = "wayland-test";
+    delete process.env.DISPLAY;
+    process.env.PI_INTERCOM_FAKE_CLIPBOARD_OUT = outFile;
+
+    const start = Date.now();
+    const result = copyTextToClipboard("handoff text");
+
+    assert.deepEqual(result, { ok: true, method: "wl-copy" });
+    assert.ok(Date.now() - start < 500, "wl-copy should not block on daemonized descendants");
+    assert.equal(await readEventually(outFile), "handoff text");
+  } finally {
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+    if (previousWayland === undefined) delete process.env.WAYLAND_DISPLAY;
+    else process.env.WAYLAND_DISPLAY = previousWayland;
+    if (previousDisplay === undefined) delete process.env.DISPLAY;
+    else process.env.DISPLAY = previousDisplay;
+    if (previousOut === undefined) delete process.env.PI_INTERCOM_FAKE_CLIPBOARD_OUT;
+    else process.env.PI_INTERCOM_FAKE_CLIPBOARD_OUT = previousOut;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
+import { spawn, spawnSync } from "child_process";
 import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
 import { IntercomClient } from "./broker/client.ts";
@@ -417,6 +418,83 @@ function previewText(value: unknown, maxLength = 72): string | undefined {
 function firstTextContent(result: { content?: Array<{ type: string; text?: string }> }): string {
   return result.content?.find((item) => item.type === "text" && typeof item.text === "string")?.text?.replace(/\*\*/g, "") ?? "";
 }
+
+export function chooseContactTarget(currentSession: SessionInfo, sessions: SessionInfo[]): { target: string; name?: string; id: string; duplicateName: boolean } {
+  const duplicates = duplicateSessionNames(sessions);
+  const name = currentSession.name?.trim() || undefined;
+  const duplicateName = Boolean(name && duplicates.has(name.toLowerCase()));
+  return {
+    target: name && !duplicateName ? name : currentSession.id,
+    ...(name ? { name } : {}),
+    id: currentSession.id,
+    duplicateName,
+  };
+}
+
+export function formatContactInstruction(contact: { target: string; id: string; name?: string; duplicateName?: boolean }): string {
+  return `Intercom send ID: ${contact.id}`;
+}
+
+interface ClipboardCopyResult {
+  ok: boolean;
+  method?: string;
+  error?: string;
+}
+
+function runDetachedClipboardCommand(command: string, args: string[], text: string): ClipboardCopyResult {
+  const found = spawnSync("which", [command], { stdio: "ignore", timeout: 1000 });
+  if (found.status !== 0) return { ok: false, error: `${command} not found` };
+
+  try {
+    const proc = spawn(command, args, { stdio: ["pipe", "ignore", "ignore"] });
+    proc.stdin.on("error", () => {
+      // Ignore EPIPE if the clipboard helper exits early.
+    });
+    proc.stdin.write(text);
+    proc.stdin.end();
+    proc.unref();
+    return { ok: true, method: command };
+  } catch (error) {
+    return { ok: false, error: getErrorMessage(error) };
+  }
+}
+
+function runClipboardCommand(command: string, args: string[], text: string): ClipboardCopyResult {
+  if (command === "wl-copy") return runDetachedClipboardCommand(command, args, text);
+
+  const result = spawnSync(command, args, {
+    input: text,
+    encoding: "utf8",
+    timeout: 2000,
+    stdio: ["pipe", "ignore", "pipe"],
+  });
+  if (result.status === 0) return { ok: true, method: command };
+  if (result.error) return { ok: false, error: result.error.message };
+  return { ok: false, error: result.stderr?.toString().trim() || `${command} exited ${result.status}` };
+}
+
+export function copyTextToClipboard(text: string): ClipboardCopyResult {
+  const candidates: Array<[string, string[]]> = [];
+  if (process.platform === "darwin") candidates.push(["pbcopy", []]);
+  else if (process.platform === "win32") candidates.push(["clip.exe", []]);
+  else {
+    if (process.env.WAYLAND_DISPLAY) candidates.push(["wl-copy", []]);
+    if (process.env.DISPLAY) {
+      candidates.push(["xclip", ["-selection", "clipboard"]]);
+      candidates.push(["xsel", ["--clipboard", "--input"]]);
+    }
+    candidates.push(["clip.exe", []]);
+  }
+
+  let lastError = "No clipboard command available";
+  for (const [command, args] of candidates) {
+    const result = runClipboardCommand(command, args, text);
+    if (result.ok) return result;
+    lastError = result.error ?? lastError;
+  }
+  return { ok: false, error: lastError };
+}
+
 function getNamePollMs(): number {
   const configured = process.env[NAME_POLL_MS_ENV];
   if (configured !== undefined) {
@@ -1805,6 +1883,65 @@ Usage:
     },
   } as any);
 
+  async function resolveCurrentContact(ctx: ExtensionContext, generation = runtimeGeneration): Promise<{ target: string; name?: string; id: string; duplicateName: boolean } | undefined> {
+    let contactClient: IntercomClient;
+    try {
+      contactClient = await ensureConnected("overlay");
+    } catch (error) {
+      notifyIfLive(ctx, `Intercom unavailable: ${getErrorMessage(error)}`, "error", generation);
+      return undefined;
+    }
+    if (!getLiveContext(ctx, generation)) return undefined;
+    syncPresenceIdentity(ctx.sessionManager.getSessionId());
+    try {
+      const sessions = await contactClient.listSessions();
+      const currentSession = sessions.find(s => s.id === contactClient.sessionId);
+      if (!currentSession) {
+        return { target: contactClient.sessionId, id: contactClient.sessionId, duplicateName: false };
+      }
+      return chooseContactTarget(currentSession, sessions);
+    } catch (error) {
+      notifyIfLive(ctx, `Failed to read intercom id: ${getErrorMessage(error)}`, "error", generation);
+      return undefined;
+    }
+  }
+
+  function insertIntoEditor(ctx: ExtensionContext, text: string): void {
+    const existing = ctx.ui.getEditorText?.() ?? "";
+    const next = existing.trim() ? `${existing.trimEnd()}\n\n${text}` : text;
+    ctx.ui.setEditorText(next);
+  }
+
+  async function showIntercomId(ctx: ExtensionContext, mode: "copy" | "insert" = "copy"): Promise<void> {
+    const generation = runtimeGeneration;
+    const liveContext = getLiveContext(ctx, generation);
+    if (!liveContext) return;
+    const contact = await resolveCurrentContact(liveContext, generation);
+    if (!contact || !getLiveContext(liveContext, generation)) return;
+    const instruction = formatContactInstruction(contact);
+    if (mode === "insert") {
+      if (!liveContext.hasUI) {
+        notifyIfLive(liveContext, `Intercom target: ${contact.target}`, "info", generation);
+        return;
+      }
+      insertIntoEditor(liveContext, instruction);
+      notifyIfLive(liveContext, `Inserted intercom contact target for another agent: ${contact.target}`, "info", generation);
+      return;
+    }
+
+    const copied = copyTextToClipboard(instruction);
+    if (copied.ok) {
+      notifyIfLive(liveContext, `Copied intercom contact target for another agent: ${contact.target}`, "info", generation);
+      return;
+    }
+    if (liveContext.hasUI) {
+      insertIntoEditor(liveContext, instruction);
+      notifyIfLive(liveContext, `Clipboard unavailable; inserted intercom contact target for another agent: ${contact.target}`, "warning", generation);
+      return;
+    }
+    notifyIfLive(liveContext, `Intercom target: ${contact.target}`, "info", generation);
+  }
+
   async function openIntercomOverlay(ctx: ExtensionContext): Promise<void> {
     const overlayGeneration = runtimeGeneration;
     const liveContext = getLiveContext(ctx, overlayGeneration);
@@ -1879,8 +2016,21 @@ Usage:
     handler: async (_args, ctx) => openIntercomOverlay(ctx),
   });
 
+  pi.registerCommand("intercom-id", {
+    description: "Copy this session's intercom contact target for another agent. Use /intercom-id insert to put the handoff snippet in the editor.",
+    handler: async (args, ctx) => {
+      const mode = args.trim().toLowerCase();
+      await showIntercomId(ctx, mode === "insert" || mode === "editor" ? "insert" : "copy");
+    },
+  });
+
   pi.registerShortcut("alt+m", {
     description: "Open session intercom",
     handler: async (ctx) => openIntercomOverlay(ctx),
+  });
+
+  pi.registerShortcut("alt+i", {
+    description: "Copy this session's intercom contact target for another agent, falling back to editor insert",
+    handler: async (ctx) => showIntercomId(ctx, "copy"),
   });
 }

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -25,10 +25,24 @@ const previousUserProfile = process.env.USERPROFILE;
 process.env.HOME = sharedHomeDir;
 process.env.USERPROFILE = sharedHomeDir;
 const { IntercomClient } = await import("./broker/client.ts");
+const { chooseContactTarget, formatContactInstruction } = await import("./index.ts");
 process.on("exit", () => {
   process.env.HOME = previousHome;
   process.env.USERPROFILE = previousUserProfile;
   rmSync(sharedHomeDir, { recursive: true, force: true });
+});
+
+test("intercom contact id prefers unique session names and falls back to ids for duplicates", () => {
+  const current: SessionInfo = { id: "session-1", name: "main-dialog", cwd: "/tmp/project", model: "model", pid: 1, startedAt: 1, lastActivity: 2, status: "idle" };
+  const other: SessionInfo = { ...current, id: "session-2", name: "worker" };
+  assert.deepEqual(chooseContactTarget(current, [current, other]), { target: "main-dialog", name: "main-dialog", id: "session-1", duplicateName: false });
+
+  const duplicate = { ...other, name: "main-dialog" };
+  const fallback = chooseContactTarget(current, [current, duplicate]);
+  assert.equal(fallback.target, "session-1");
+  assert.equal(fallback.duplicateName, true);
+  assert.equal(formatContactInstruction(fallback), "Intercom send ID: session-1");
+  assert.equal(formatContactInstruction(chooseContactTarget(current, [current, other])), "Intercom send ID: session-1");
 });
 
 async function waitForBrokerReady(broker: ChildProcessWithoutNullStreams): Promise<void> {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts clipboard.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"


### PR DESCRIPTION
## Summary
- add /intercom-id and Alt+I to copy this session's stable intercom contact ID
- fall back to inserting the handoff snippet when clipboard copy is unavailable
- cover duplicate-name targeting and wl-copy daemonizing behavior in tests

## Tests
- npx tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts clipboard.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts