### PR TITLE
fix: stabilize reply and supervisor routing

### DIFF
--- a/broker/paths.test.ts
+++ b/broker/paths.test.ts
@@ -27,9 +27,10 @@ test("getAgentDirPath honors PI_CODING_AGENT_DIR", () => {
 });
 
 test("getAgentDirPath resolves relative PI_CODING_AGENT_DIR values from the caller cwd", () => {
+  const cwd = join(tmpdir(), "workspace", "project");
   assert.equal(
-    getAgentDirPath({ PI_CODING_AGENT_DIR: "relative-agent" }, "/home/rcroh", "/workspace/project"),
-    join("/workspace/project", "relative-agent"),
+    getAgentDirPath({ PI_CODING_AGENT_DIR: "relative-agent" }, "/home/rcroh", cwd),
+    join(cwd, "relative-agent"),
   );
 });
 

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ const SUBAGENT_RUN_ID_ENV = "PI_SUBAGENT_RUN_ID";
 const SUBAGENT_CHILD_AGENT_ENV = "PI_SUBAGENT_CHILD_AGENT";
 const SUBAGENT_CHILD_INDEX_ENV = "PI_SUBAGENT_CHILD_INDEX";
 const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
+const SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV = "PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR";
 
 interface ChildOrchestratorMetadata {
   orchestratorTarget: string;
@@ -451,6 +452,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   const activeTools = new Map<string, string>();
   const replyTracker = new ReplyTracker();
   const pendingIdleMessages: InboundMessageEntry[] = [];
+  function dismissIncomingAsk(messageId: string): void {
+    replyTracker.dismissPendingAsk(messageId);
+    const queuedIndex = pendingIdleMessages.findIndex((entry) => entry.message.id === messageId);
+    if (queuedIndex >= 0) pendingIdleMessages.splice(queuedIndex, 1);
+  }
   let inboundFlushTimer: NodeJS.Timeout | null = null;
   let replyWaiter: {
     from: string;
@@ -746,7 +752,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
                 replyTo: message.id,
               });
               if (result.delivered && getLiveContext(liveContext, messageGeneration)) {
-                replyTracker.markReplied(message.id);
+                dismissIncomingAsk(message.id);
               }
             } catch {
               // Best-effort reply; keep the busy non-interactive session running either way.
@@ -1160,7 +1166,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   });
 
   const childOrchestratorMetadata = readChildOrchestratorMetadata();
-  if (childOrchestratorMetadata) {
+  const nativeSupervisorChannelAvailable = Boolean(process.env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV]?.trim());
+  if (childOrchestratorMetadata && !nativeSupervisorChannelAvailable) {
     pi.registerTool({
       name: "contact_supervisor",
       label: "Contact Supervisor",
@@ -1553,7 +1560,7 @@ Usage:
               timestamp: Date.now(),
             });
             if (replyTo) {
-              replyTracker.markReplied(replyTo);
+              dismissIncomingAsk(replyTo);
             }
             return {
               content: [{ type: "text", text: `Message sent to ${to}` }],
@@ -1696,14 +1703,14 @@ Usage:
             if (!result.delivered) {
               const errorText = result.reason ?? "Session may not exist or has disconnected.";
               if (result.reason === "Session not found") {
-                replyTracker.dismissPendingAsk(target.message.id);
+                dismissIncomingAsk(target.message.id);
               }
               return {
                 content: [{ type: "text", text: `Reply to "${target.from.name || target.from.id}" was not delivered: ${errorText}` }],
                 details: { messageId: result.id, delivered: false, reason: result.reason },
               };
             }
-            replyTracker.markReplied(target.message.id);
+            dismissIncomingAsk(target.message.id);
             pi.appendEntry("intercom_sent", {
               to: target.from.name || target.from.id,
               message: { text: message, replyTo: target.message.id },

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { EventEmitter, once } from "node:events";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { ReplyTracker } from "./reply-tracker.ts";
 import type { Message, SessionInfo } from "./types.ts";
 
@@ -18,6 +18,7 @@ const childEnvKeys = [
   "PI_SUBAGENT_CHILD_AGENT",
   "PI_SUBAGENT_CHILD_INDEX",
   "PI_SUBAGENT_INTERCOM_SESSION_NAME",
+  "PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR",
 ] as const;
 const sharedHomeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-home-"));
 const previousHome = process.env.HOME;
@@ -25,13 +26,17 @@ const previousUserProfile = process.env.USERPROFILE;
 process.env.HOME = sharedHomeDir;
 process.env.USERPROFILE = sharedHomeDir;
 const { IntercomClient } = await import("./broker/client.ts");
+const { getTsxCliPath } = await import("./broker/spawn.ts");
 process.on("exit", () => {
   process.env.HOME = previousHome;
   process.env.USERPROFILE = previousUserProfile;
   rmSync(sharedHomeDir, { recursive: true, force: true });
 });
 
-async function waitForBrokerReady(broker: ChildProcessWithoutNullStreams): Promise<void> {
+async function waitForBrokerReady(broker: ChildProcess): Promise<void> {
+  const stdout = broker.stdout;
+  if (!stdout) throw new Error("Broker stdout is unavailable");
+
   const ready = new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
       cleanup();
@@ -49,11 +54,11 @@ async function waitForBrokerReady(broker: ChildProcessWithoutNullStreams): Promi
     };
     const cleanup = () => {
       clearTimeout(timeout);
-      broker.stdout.off("data", onStdout);
+      stdout.off("data", onStdout);
       broker.off("exit", onExit);
     };
 
-    broker.stdout.on("data", onStdout);
+    stdout.on("data", onStdout);
     broker.once("exit", onExit);
   });
 
@@ -69,6 +74,7 @@ async function withChildOrchestratorEnv<T>(metadata: {
   agent?: string;
   index?: string;
   sessionName?: string;
+  supervisorChannelDir?: string;
 }, fn: () => T | Promise<T>): Promise<T> {
   const previous = new Map<string, string | undefined>();
   for (const key of childEnvKeys) {
@@ -83,6 +89,7 @@ async function withChildOrchestratorEnv<T>(metadata: {
   if (metadata.agent !== undefined) process.env.PI_SUBAGENT_CHILD_AGENT = metadata.agent;
   if (metadata.index !== undefined) process.env.PI_SUBAGENT_CHILD_INDEX = metadata.index;
   if (metadata.sessionName !== undefined) process.env.PI_SUBAGENT_INTERCOM_SESSION_NAME = metadata.sessionName;
+  if (metadata.supervisorChannelDir !== undefined) process.env.PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR = metadata.supervisorChannelDir;
   try {
     return await fn();
   } finally {
@@ -194,7 +201,7 @@ function createExtensionHarness(sessionName: string | (() => string) = "child-wo
       }
     },
     async emitLifecycleResults(event: string, payload: unknown = {}, eventContext: unknown = ctx) {
-      const results = [];
+      const results: unknown[] = [];
       for (const handler of lifecycleHandlers.get(event) ?? []) {
         results.push(await handler(payload, eventContext));
       }
@@ -242,9 +249,8 @@ test("opt-in TCP broker requires endpoint state for health and registration", { 
   const { readFileSync } = await import("node:fs");
   const { createMessageReader, writeMessage } = await import("./broker/framing.ts");
   const agentDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-tcp-agent-"));
-  const broker = spawn("npx", [
-    "--no-install",
-    "tsx",
+  const broker = spawn(process.execPath, [
+    getTsxCliPath(),
     "-e",
     "Object.defineProperty(process, 'platform', { value: 'win32' }); import('./broker/broker.ts').catch((error) => { console.error(error); process.exit(1); });",
   ], {
@@ -354,7 +360,7 @@ test("opt-in TCP broker requires endpoint state for health and registration", { 
 });
 
 async function setupClients() {
-  const broker = spawn("npx", ["--no-install", "tsx", path.join(repoDir, "broker", "broker.ts")], {
+  const broker = spawn(process.execPath, [getTsxCliPath(), path.join(repoDir, "broker", "broker.ts")], {
     cwd: repoDir,
     env: { ...process.env, HOME: sharedHomeDir, USERPROFILE: sharedHomeDir },
     stdio: ["ignore", "pipe", "pipe"],
@@ -700,7 +706,7 @@ test("old stable-ID socket cannot mutate the replacement session", { concurrency
 });
 
 test("stable-ID replacement clears old ask edges and ignores stale cancels", { concurrency: false }, async () => {
-  const { planner, orchestrator, cleanup } = await setupClients();
+  const { orchestrator, cleanup } = await setupClients();
   const first = await connectRawRegistered("replaceable-asker-id", "replaceable-asker-old");
   const replacement = new IntercomClient();
 
@@ -1034,6 +1040,49 @@ test("busy interactive sessions idle-gate top-level asks without aborting", { co
   }
 });
 
+test("replied idle-gated asks are discarded before delivery", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { planner, cleanup } = await setupClients();
+  let idle = false;
+  const harness = createExtensionHarness("reply-while-busy-worker", {
+    hasUI: true,
+    isIdle: () => idle,
+  });
+
+  try {
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    const worker = await waitForSessionByName(planner, "reply-while-busy-worker");
+
+    const askId = "reply-while-busy-ask";
+    const replyReceived = waitForReply(planner, askId);
+    assert.equal((await planner.send(worker.id, {
+      messageId: askId,
+      text: "Can you answer before this turn ends?",
+      expectsReply: true,
+    })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(harness.sentMessages.length, 0);
+
+    const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
+    const result = await intercomTool.execute("reply-while-busy", {
+      action: "reply",
+      message: "Answered during the current turn.",
+      replyTo: askId,
+    }, new AbortController().signal, undefined, harness.ctx);
+    assert.equal(result.details?.delivered, true);
+    assert.equal((await replyReceived).message.replyTo, askId);
+
+    idle = true;
+    await harness.emitLifecycle("agent_end");
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    assert.equal(harness.sentMessages.length, 0);
+  } finally {
+    await harness.emitLifecycle("session_shutdown");
+    await cleanup();
+  }
+});
+
 test("deferred startup connect is cancelled on shutdown", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
@@ -1188,6 +1237,18 @@ test("supervisor tool registers only when child metadata is present", async () =
     const supervisorTool = harness.tools.find((tool) => tool.name === "contact_supervisor");
     assert.match(JSON.stringify(supervisorTool?.parameters), /interview_request/);
     assert.match(JSON.stringify(supervisorTool?.parameters), /questions/);
+  });
+
+  await withChildOrchestratorEnv({
+    orchestratorTarget: "orchestrator",
+    runId: "78f659a3",
+    agent: "worker",
+    index: "0",
+    supervisorChannelDir: path.join(sharedHomeDir, "native-supervisor-channel"),
+  }, () => {
+    const harness = createExtensionHarness();
+    piIntercomExtension(harness.pi as never);
+    assert.deepEqual(harness.tools.map((tool) => tool.name), ["intercom"]);
   });
 });
 

--- a/reply-tracker.test.ts
+++ b/reply-tracker.test.ts
@@ -54,6 +54,17 @@ test("reply with to resolves matching pending ask", () => {
   assert.equal(tracker.resolveReplyTarget({ to: "planner-id" }, 1002).message.id, "ask-1");
 });
 
+test("explicit to overrides the current turn context", () => {
+  const tracker = new ReplyTracker();
+  const current = tracker.recordIncomingMessage(createSession("planner-id", "planner"), createMessage("ask-1", "First"), 1000);
+  tracker.recordIncomingMessage(createSession("reviewer-id", "reviewer"), createMessage("ask-2", "Second"), 1001);
+  tracker.queueTurnContext(current);
+  tracker.beginTurn(1002);
+
+  assert.equal(tracker.resolveReplyTarget({ to: "reviewer" }, 1003).message.id, "ask-2");
+  assert.throws(() => tracker.resolveReplyTarget({ to: "missing" }, 1003), /No pending ask from/);
+});
+
 test("replyTo resolves the exact pending ask", () => {
   const tracker = new ReplyTracker();
   tracker.recordIncomingMessage(createSession("planner-id", "planner"), createMessage("ask-1", "First"), 1000);

--- a/reply-tracker.ts
+++ b/reply-tracker.ts
@@ -63,28 +63,25 @@ export class ReplyTracker {
       return target;
     }
 
-    if (this.currentTurnContext) {
-      return this.currentTurnContext;
-    }
-
     const pending = Array.from(this.pendingAsks.values());
-    if (pending.length === 1) {
-      return pending[0]!;
-    }
-
     if (options.to) {
       const matches = pending.filter((context) => matchesPendingSender(context, options.to!));
       if (matches.length === 1) {
         return matches[0]!;
       }
       if (matches.length > 1) {
-        throw new Error(`Multiple pending asks from \"${options.to}\" — use the sender session ID instead.`);
+        throw new Error(`Multiple pending asks from "${options.to}" — use the sender session ID instead.`);
       }
-      if (pending.length > 1) {
-        throw new Error(`No pending ask from \"${options.to}\"`);
-      }
+      throw new Error(`No pending ask from "${options.to}"`);
     }
 
+    if (this.currentTurnContext) {
+      return this.currentTurnContext;
+    }
+
+    if (pending.length === 1) {
+      return pending[0]!;
+    }
     if (pending.length === 0) {
       throw new Error("No active intercom context to reply to");
     }


### PR DESCRIPTION
## Summary

- make explicit reply selectors take priority over ambient turn context
- remove answered asks from the idle-delivery queue so they cannot trigger a stale follow-up turn
- let `pi-subagents` own `contact_supervisor` when its native supervisor channel is available
- make the broker integration harness and relative-path fixture portable on Windows

## Root cause

`ReplyTracker.resolveReplyTarget()` checked `currentTurnContext` before an explicit `to`, so a reply could be sent to the wrong pending sender. Separately, answering an ask cleared `ReplyTracker` but left the same ask in `pendingIdleMessages`, allowing it to be delivered later.

Since `pi-subagents` 0.33.0, delegated children can receive a native supervisor channel identified by `PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR`. `pi-intercom` still registered its broker-backed `contact_supervisor` first, preventing the native, parent-session-scoped implementation from registering.

The Windows test runner also could not spawn the `npx` command shim directly, and one path fixture assumed POSIX absolute-path behavior.

## Behavior after this change

- precedence is `replyTo` -> `to` -> current turn -> single pending ask
- every successful/stale dismissal removes the ask from both reply tracking and idle delivery
- `pi-intercom` keeps the regular `intercom` tool, but leaves `contact_supervisor` to the native channel when that capability signal is present; the existing broker-backed fallback remains unchanged otherwise
- integration brokers launch through `process.execPath` and the already-resolved `tsx` CLI on every platform

## Validation

Windows 11, Node 22.20.0:

```text
npm test
# tests 93
# pass 91
# fail 0
# skipped 2
```

The two skips are the existing Unix permission tests. I also loaded this branch alongside `pi-subagents` 0.34.0 and verified the final tool set is `intercom` from pi-intercom plus native `contact_supervisor`, with no duplicate registration.

`git diff --check` passes.
