### PR TITLE
Align session-id copy with prefix addressing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -862,7 +862,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     const lowerName = nameOrId.toLowerCase();
     const byName = sessions.filter(s => s.name?.toLowerCase() === lowerName);
     if (byName.length > 1) {
-      throw new Error(`Multiple sessions named "${nameOrId}" are connected. Use the session ID instead.`);
+      const ids = byName.map(s => shortSessionId(s.id)).join(", ");
+      throw new Error(`Multiple sessions named "${nameOrId}" are connected. Address one by the id shown in parentheses by "list" (${ids}).`);
     }
     if (byName.length === 1) {
       return byName[0]!.id;
@@ -1428,10 +1429,14 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     description: `Send a message to another pi session running on this machine.
 Use this to communicate findings, request help, or coordinate work with other sessions.
 
+Target a session by name, full session ID, or the short id shown in parentheses
+by "list" (a leading prefix of the ID is enough). Prefer the short id when two
+sessions share a name.
+
 Usage:
   intercom({ action: "list" })                    → List active sessions
-  intercom({ action: "send", to: "session-name", message: "..." })  → Send message
-  intercom({ action: "ask", to: "session-name", message: "..." })   → Ask and wait for reply
+  intercom({ action: "send", to: "name-or-id", message: "..." })  → Send message
+  intercom({ action: "ask", to: "name-or-id", message: "..." })   → Ask and wait for reply
   intercom({ action: "reply", message: "..." })                      → Reply to the active/single pending ask
   intercom({ action: "pending" })                                      → List unresolved inbound asks
   intercom({ action: "status" })                  → Show connection status`,
@@ -1443,7 +1448,7 @@ Usage:
         description: "Action: 'list', 'send', 'ask', 'reply', 'pending', or 'status'",
       }),
       to: Type.Optional(Type.String({
-        description: "Target session name or ID (for 'send', 'ask', or disambiguating 'reply')",
+        description: "Target session: name, full session ID, or the short id shown in parentheses by 'list' (a leading ID prefix resolves). For 'send', 'ask', or disambiguating 'reply'.",
       })),
       message: Type.Optional(Type.String({
         description: "Message to send (for 'send', 'ask', or 'reply' action)",

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -818,6 +818,35 @@ test("intercom tool prefers exact names over ID prefixes", { concurrency: false 
   }
 });
 
+test("intercom tool points at the short id when names collide", { concurrency: false }, async () => {
+  const { cleanup } = await setupClients();
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const twinA = new IntercomClient();
+  const twinB = new IntercomClient();
+  const harness = createExtensionHarness("collision-sender");
+
+  try {
+    await twinA.connect({ name: "twin", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, "aaaa1111-session");
+    await twinB.connect({ name: "twin", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, "bbbb2222-session");
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+
+    const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
+    const result = await intercomTool.execute("send-twin", { action: "send", to: "twin", message: "which one?" }, new AbortController().signal, undefined, harness.ctx);
+
+    assert.equal(result.details?.error, true);
+    const text = result.content.map((part) => (part as { text?: string }).text ?? "").join("");
+    assert.match(text, /parentheses/);
+    assert.match(text, /aaaa1111/);
+    assert.match(text, /bbbb2222/);
+    await harness.emitLifecycle("session_shutdown");
+  } finally {
+    await twinA.disconnect().catch(() => undefined);
+    await twinB.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
 test("intercom tool renders compact call and result rows", async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const harness = createExtensionHarness();


### PR DESCRIPTION
## What

Align the intercom tool's human/agent-facing copy with how session addressing actually resolves.

`list` renders every session as `name (shortId)` (the leading 8 chars of the session ID). `resolveSessionTarget` already accepts a leading ID prefix, so that short id *is* a valid target - but nothing told the caller that:

- the duplicate-name error said `Use the session ID instead.` while `list` only ever shows the short id, so the caller had no addressable identifier;
- the tool `description` and the `to` param help only mentioned "name or ID".

Agents (and humans) hit this whenever two sessions share a name: name-addressing throws, the only visible id looks un-addressable, and `send`/`ask` fail in a loop.

## Change

- Duplicate-name error now points at the short ids shown by `list`, e.g.
  `Multiple sessions named "twin" are connected. Address one by the id shown in parentheses by "list" (aaaa1111, bbbb2222).`
- Tool `description` + `to` param document name / full ID / short-id-prefix as valid targets.
- Test asserting the collision error names both short ids.

No behavior change to `resolveSessionTarget` - prefix resolution already existed on `main`; this makes the surface copy match it.

## Test

`npm test` - 92 pass.
