### PR TITLE
fix: improve inline message theme hierarchy

### DIFF
--- a/test/inline-message.test.ts
+++ b/test/inline-message.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
 
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { InlineMessageComponent } from "../ui/inline-message.ts";
@@ -76,4 +77,108 @@ test("collapsed inline intercom messages keep preview, reply hint, and expand ke
   assert.match(rendered, /To reply: intercom/);
   assert.match(rendered, /Ctrl\+O/);
   assert.match(rendered, /1 attachment/);
+});
+
+const roleCodes = {
+  accent: 31,
+  toolTitle: 32,
+  text: 33,
+  muted: 34,
+  dim: 35,
+} as const;
+
+function styledTheme(calls: string[] = []) {
+  return {
+    fg(name: keyof typeof roleCodes, text: string): string {
+      calls.push(name);
+      return `\u001b[${roleCodes[name]}m${text}\u001b[0m`;
+    },
+  };
+}
+
+test("inline message colors follow the tool-title, text, muted-border, and dim-metadata hierarchy", () => {
+  const calls: string[] = [];
+  const component = new InlineMessageComponent(
+    from,
+    {
+      ...message,
+      replyTo: "parent-message-id",
+      content: {
+        text: "Body copy",
+        attachments: [{ type: "snippet", name: "note.txt", content: "details" }],
+      },
+    },
+    styledTheme(calls) as any,
+    "intercom reply",
+  );
+
+  const lines = component.render(72);
+  const rendered = lines.join("\n");
+
+  assert.match(lines[0], /^\u001b\[34m╭\u001b\[0m\u001b\[32m 📨 From:/);
+  assert.match(rendered, /\u001b\[34m│\u001b\[0m\u001b\[33mBody copy\u001b\[0m/);
+  assert.match(rendered, /\u001b\[35m ↩ To reply: intercom reply\u001b\[0m/);
+  assert.match(rendered, /\u001b\[35m 📎 note\.txt\u001b\[0m/);
+  assert.match(rendered, /\u001b\[35m ↳ Reply to parent-m\u001b\[0m/);
+  assert.match(lines.at(-1)!, /^\u001b\[34m╰─+╯\u001b\[0m$/);
+  assert.ok(calls.includes("toolTitle"));
+  assert.ok(calls.includes("text"));
+  assert.ok(calls.includes("muted"));
+  assert.ok(calls.includes("dim"));
+  assert.ok(!calls.includes("accent"));
+});
+
+test("collapsed inline messages preserve the same hierarchy without accent", () => {
+  const calls: string[] = [];
+  const component = new InlineMessageComponent(from, message, styledTheme(calls) as any, "intercom reply", undefined, true);
+
+  const rendered = component.render(72).join("\n");
+
+  assert.match(rendered, /\u001b\[32m 📨 From:/);
+  assert.match(rendered, /\u001b\[33mThis is a long message/);
+  assert.match(rendered, /\u001b\[35m ↩ To reply:/);
+  assert.ok(!calls.includes("accent"));
+});
+
+test("semantic styling remains ANSI- and Unicode-width safe", () => {
+  const unicodeFrom = { ...from, name: "送信者🛰️", cwd: "/tmp/計画" };
+  const unicodeMessage = {
+    ...message,
+    content: { text: "\u001b[36m色付き本文\u001b[0m with emoji 🧪 and a long Unicode tail 計画計画計画" },
+  };
+  const component = new InlineMessageComponent(unicodeFrom, unicodeMessage, styledTheme() as any, "返信 📨");
+
+  for (const width of [18, 31, 52]) {
+    const lines = component.render(width);
+    assert.ok(lines.length > 0);
+    for (const line of lines) {
+      assert.equal(visibleWidth(line), width, `${width}: ${stripVTControlCharacters(line)}`);
+    }
+  }
+});
+
+test("inline messages pick up mutable theme proxy changes on rerender", () => {
+  const palette: Record<string, number> = { ...roleCodes };
+  const mutableTheme = new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (property !== "fg") return undefined;
+        return (name: string, text: string) => `\u001b[${palette[name]}m${text}\u001b[0m`;
+      },
+    },
+  );
+  const component = new InlineMessageComponent(from, message, mutableTheme as any);
+
+  const before = component.render(72).join("\n");
+  palette.toolTitle = 96;
+  palette.text = 97;
+  palette.muted = 90;
+  const after = component.render(72).join("\n");
+
+  assert.match(before, /\u001b\[32m 📨 From:/);
+  assert.match(after, /\u001b\[96m 📨 From:/);
+  assert.match(after, /\u001b\[97mThis is a long message/);
+  assert.match(after, /\u001b\[90m╭/);
+  assert.notEqual(before, after);
 });

--- a/ui/inline-message.ts
+++ b/ui/inline-message.ts
@@ -41,13 +41,21 @@ export class InlineMessageComponent implements Component {
     const header = ` 📨 From: ${senderName} (${this.from.cwd}) `;
     const headerText = truncateToWidth(this.collapsed ? `${header} Ctrl+O expands ` : header, bodyWidth, "");
     const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
-    lines.push(this.theme.fg("accent", `╭${headerText}${borderChar.repeat(headerPadding)}╮`));
+    lines.push(
+      this.theme.fg("muted", "╭") +
+        this.theme.fg("toolTitle", headerText) +
+        this.theme.fg("muted", `${borderChar.repeat(headerPadding)}╮`),
+    );
+
+    const frameLine = (content: string): string => {
+      const text = truncateToWidth(content, bodyWidth, "");
+      const padding = Math.max(0, bodyWidth - visibleWidth(text));
+      return this.theme.fg("muted", "│") + text + this.theme.fg("muted", `${" ".repeat(padding)}│`);
+    };
 
     if (this.collapsed) {
       const preview = (this.bodyText || this.message.content.text).replace(/\s+/g, " ").trim();
-      const previewText = truncateToWidth(preview, bodyWidth, "");
-      const previewPadding = Math.max(0, bodyWidth - visibleWidth(previewText));
-      lines.push(this.theme.fg("accent", `│${previewText}${" ".repeat(previewPadding)}│`));
+      lines.push(frameLine(this.theme.fg("text", preview)));
 
       const meta: string[] = [];
       if (this.replyCommand) meta.push(`↩ To reply: ${this.replyCommand}`);
@@ -58,49 +66,37 @@ export class InlineMessageComponent implements Component {
       if (this.message.replyTo && !this.message.expectsReply) meta.push(`↳ Reply to ${this.message.replyTo.slice(0, 8)}`);
       meta.push("Ctrl+O to expand");
 
-      const metaText = truncateToWidth(this.theme.fg("dim", ` ${meta.join(" · ")}`), bodyWidth, "");
-      const metaPadding = Math.max(0, bodyWidth - visibleWidth(metaText));
-      lines.push(this.theme.fg("accent", `│${metaText}${" ".repeat(metaPadding)}│`));
-      lines.push(this.theme.fg("accent", `╰${borderChar.repeat(bodyWidth)}╯`));
+      lines.push(frameLine(this.theme.fg("dim", ` ${meta.join(" · ")}`)));
+      lines.push(this.theme.fg("muted", `╰${borderChar.repeat(bodyWidth)}╯`));
       return lines;
     }
 
     const contentLines = wrapTextWithAnsi(this.bodyText || this.message.content.text, bodyWidth);
     for (const line of contentLines) {
-      const text = truncateToWidth(line, bodyWidth, "");
-      const padding = Math.max(0, bodyWidth - visibleWidth(text));
-      lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
+      lines.push(frameLine(this.theme.fg("text", line)));
     }
 
     if (this.replyCommand) {
-      lines.push(this.theme.fg("accent", `│${" ".repeat(bodyWidth)}│`));
+      lines.push(frameLine(""));
       const replyLines = wrapTextWithAnsi(this.theme.fg("dim", ` ↩ To reply: ${this.replyCommand}`), bodyWidth);
       for (const line of replyLines) {
-        const text = truncateToWidth(line, bodyWidth, "");
-        const padding = Math.max(0, bodyWidth - visibleWidth(text));
-        lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
+        lines.push(frameLine(line));
       }
     }
 
     if (this.message.content.attachments?.length) {
-      lines.push(this.theme.fg("accent", `│${" ".repeat(bodyWidth)}│`));
+      lines.push(frameLine(""));
       for (const att of this.message.content.attachments) {
-        const label = this.theme.fg("dim", ` 📎 ${att.name}`);
-        const text = truncateToWidth(label, bodyWidth, "");
-        const padding = Math.max(0, bodyWidth - visibleWidth(text));
-        lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
+        lines.push(frameLine(this.theme.fg("dim", ` 📎 ${att.name}`)));
       }
     }
 
     if (this.message.replyTo && !this.message.expectsReply) {
-      lines.push(this.theme.fg("accent", `│${" ".repeat(bodyWidth)}│`));
-      const reply = this.theme.fg("dim", ` ↳ Reply to ${this.message.replyTo.slice(0, 8)}`);
-      const text = truncateToWidth(reply, bodyWidth, "");
-      const padding = Math.max(0, bodyWidth - visibleWidth(text));
-      lines.push(this.theme.fg("accent", `│${text}${" ".repeat(padding)}│`));
+      lines.push(frameLine(""));
+      lines.push(frameLine(this.theme.fg("dim", ` ↳ Reply to ${this.message.replyTo.slice(0, 8)}`)));
     }
 
-    lines.push(this.theme.fg("accent", `╰${borderChar.repeat(bodyWidth)}╯`));
+    lines.push(this.theme.fg("muted", `╰${borderChar.repeat(bodyWidth)}╯`));
 
     return lines;
   }


### PR DESCRIPTION
## Summary
- style inline message headers, bodies, borders, and metadata with distinct semantic theme roles
- preserve ANSI/Unicode width safety while removing whole-line accent styling
- add hierarchy and mutable-theme-proxy regression coverage

## Test plan
- `PI_CODING_AGENT_DIR=/tmp/pi-intercom-upstream-test bun run test`
- `git diff --check`