### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-29
+
 ### Changed
 - Documented `PI_INTERCOM_ASK_TIMEOUT_MS` for configurable ask/supervisor timeouts. Thanks to wiansapu for issue #14.
 - Clarified session addressing copy so the short IDs shown by `list` are documented as usable prefixes. Thanks to Grant Hutchins for PR #66.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-intercom",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary

Prepares the 0.7.0 release by bumping `package.json` and moving the current Unreleased changelog entries into a dated `0.7.0` section.

## Validation

- `npm test` — 98/98 passed
- `git diff --check`
- `npm pack --dry-run`

Release authority was granted for #61 and #67.