### PR TITLE
feat: add cwd-scoped lists and context presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Added
 - Added opt-in restart-stable intercom session IDs via `PI_INTERCOM_STABLE_ID` or `stableId` in `config.json`. Thanks to iRonin for issue #39.
 - Added `/intercom-id` to insert a stable handoff snippet for the current session into the editor. Thanks to dataforxyz for PR #60.
+- Added `intercom({ action: "list-cwd" })` to list peers scoped to the same working directory. Thanks to iRonin for PR #58.
+- Added live context-window usage to session presence and list output. Thanks to iRonin for PR #59.
 
 ## [0.7.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ The agent can list sessions and send messages using the `intercom` tool. Tool ca
 // List active sessions
 intercom({ action: "list" })
 // → **Current session:**
-// → • executor (20d43841) — ~/projects/api (claude-sonnet-4) [self, idle]
+// → • executor (20d43841) — ~/projects/api (claude-sonnet-4 · 42% ctx) [self, idle]
 // → **Other sessions:**
 // → • research (6332faab) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
+
+// List only peers in the same working directory
+intercom({ action: "list-cwd" })
 
 // Send a message
 intercom({ action: "send", to: "research", message: "Check if UserService.validate() handles null" })

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -547,6 +547,39 @@ class IntercomBroker {
               changed = true;
             }
           }
+          // Context-usage fields: a number updates, an explicit null CLEARS (the
+          // value is unknown right after a compaction — delete rather than carry
+          // the stale-high value forward), undefined leaves the field untouched.
+          if (clientMessage.contextPct !== undefined) {
+            if (clientMessage.contextPct === null) {
+              if (session.info.contextPct !== undefined) { delete session.info.contextPct; changed = true; }
+            } else if (typeof clientMessage.contextPct !== "number") {
+              throw new Error("Invalid presence contextPct");
+            } else if (session.info.contextPct !== clientMessage.contextPct) {
+              session.info.contextPct = clientMessage.contextPct;
+              changed = true;
+            }
+          }
+          if (clientMessage.contextTokens !== undefined) {
+            if (clientMessage.contextTokens === null) {
+              if (session.info.contextTokens !== undefined) { delete session.info.contextTokens; changed = true; }
+            } else if (typeof clientMessage.contextTokens !== "number") {
+              throw new Error("Invalid presence contextTokens");
+            } else if (session.info.contextTokens !== clientMessage.contextTokens) {
+              session.info.contextTokens = clientMessage.contextTokens;
+              changed = true;
+            }
+          }
+          if (clientMessage.contextWindow !== undefined) {
+            if (clientMessage.contextWindow === null) {
+              if (session.info.contextWindow !== undefined) { delete session.info.contextWindow; changed = true; }
+            } else if (typeof clientMessage.contextWindow !== "number") {
+              throw new Error("Invalid presence contextWindow");
+            } else if (session.info.contextWindow !== clientMessage.contextWindow) {
+              session.info.contextWindow = clientMessage.contextWindow;
+              changed = true;
+            }
+          }
           const now = Date.now();
           session.info.lastActivity = now;
           if (changed || now - session.lastPresenceBroadcastAt >= PRESENCE_HEARTBEAT_MS) {

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -113,6 +113,12 @@ function isSessionInfo(value: unknown): value is SessionInfo {
     return false;
   }
 
+  for (const key of ["contextPct", "contextTokens", "contextWindow"] as const) {
+    if (session[key] !== undefined && typeof session[key] !== "number") {
+      return false;
+    }
+  }
+
   return session.trustedLocal === undefined || typeof session.trustedLocal === "boolean";
 }
 
@@ -565,7 +571,7 @@ export class IntercomClient extends EventEmitter {
     }
   }
 
-  updatePresence(updates: { name?: string; status?: string; model?: string }): void {
+  updatePresence(updates: { name?: string; status?: string; model?: string; contextPct?: number | null; contextTokens?: number | null; contextWindow?: number | null }): void {
     if (this.disconnecting) {
       return;
     }

--- a/cwd.test.ts
+++ b/cwd.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync, mkdirSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { normalizeCwd, sameCwd } from "./cwd.ts";
+
+test("sameCwd collapses a trailing slash", () => {
+  assert.equal(sameCwd("/usr/local", "/usr/local/"), true);
+});
+
+test("sameCwd collapses lexical '.' and '..' segments", () => {
+  assert.equal(sameCwd("/usr/local/../local/./bin", "/usr/local/bin"), true);
+});
+
+test("sameCwd treats genuinely different directories as different", () => {
+  assert.equal(sameCwd("/usr/local", "/usr/lib"), false);
+});
+
+test("sameCwd collapses a symlink to its real target", () => {
+  const base = mkdtempSync(join(tmpdir(), "cwd-symlink-"));
+  try {
+    const real = join(base, "real");
+    const link = join(base, "link");
+    mkdirSync(real);
+    symlinkSync(real, link);
+    // Reached via the symlink vs its canonical path — must compare equal.
+    assert.equal(sameCwd(link, real), true);
+    // And normalizeCwd resolves the link to the real path.
+    assert.equal(normalizeCwd(link), realpathSync(real));
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("normalizeCwd falls back to the resolved path for a nonexistent dir", () => {
+  // realpathSync throws for a missing dir; normalizeCwd must still collapse the
+  // lexical variants rather than throw.
+  assert.equal(normalizeCwd("/no/such/dir/../dir"), "/no/such/dir");
+});

--- a/cwd.ts
+++ b/cwd.ts
@@ -1,0 +1,31 @@
+import { resolve } from "node:path";
+import { realpathSync } from "node:fs";
+
+// Normalize a cwd for same-directory comparison. A raw string match ("a === b")
+// hides genuine same-directory peers when two cwd strings differ only by a
+// trailing slash, a "."/".." segment, or a symlink (e.g. macOS /tmp <->
+// /private/tmp). resolve() collapses the lexical variants; realpathSync()
+// collapses symlinks (best-effort: falls back to the resolved path if the
+// directory no longer exists). Memoized — the set of distinct cwd strings is
+// small and stable, so repeat comparisons are free after warmup.
+const normalizeCache = new Map<string, string>();
+
+export function normalizeCwd(cwd: string): string {
+  const cached = normalizeCache.get(cwd);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const resolved = resolve(cwd);
+  let normalized: string;
+  try {
+    normalized = realpathSync(resolved);
+  } catch {
+    normalized = resolved;
+  }
+  normalizeCache.set(cwd, normalized);
+  return normalized;
+}
+
+export function sameCwd(a: string, b: string): boolean {
+  return normalizeCwd(a) === normalizeCwd(b);
+}

--- a/format-context.test.ts
+++ b/format-context.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatTokenCount, formatContextUsage } from "./format-context.ts";
+import type { SessionInfo } from "./types.ts";
+
+const base: SessionInfo = { id: "s1", cwd: "/w", model: "m", pid: 1, startedAt: 0, lastActivity: 0 };
+
+test("formatTokenCount compacts thousands", () => {
+  assert.equal(formatTokenCount(0), "0");
+  assert.equal(formatTokenCount(999), "999");
+  assert.equal(formatTokenCount(1432), "1.4k");
+  assert.equal(formatTokenCount(144000), "144k");
+  assert.equal(formatTokenCount(200000), "200k");
+});
+
+test("formatContextUsage renders percent + token detail when all known", () => {
+  assert.equal(
+    formatContextUsage({ ...base, contextPct: 72, contextTokens: 144000, contextWindow: 200000 }),
+    " · 72% ctx (144k/200k)",
+  );
+});
+
+test("formatContextUsage shows percent only when token counts are absent", () => {
+  assert.equal(formatContextUsage({ ...base, contextPct: 30 }), " · 30% ctx");
+});
+
+test("formatContextUsage renders nothing when percent is unknown (never a stale %)", () => {
+  assert.equal(formatContextUsage(base), "");
+  // Tokens present but no percent (e.g. right after a compaction) still renders nothing.
+  assert.equal(formatContextUsage({ ...base, contextTokens: 100, contextWindow: 200 }), "");
+});

--- a/format-context.ts
+++ b/format-context.ts
@@ -1,0 +1,32 @@
+import type { SessionInfo } from "./types.ts";
+
+// Compact token count for display: 1432 -> "1.4k", 144000 -> "144k". Keeps list
+// rows short while staying legible.
+export function formatTokenCount(tokens: number): string {
+  if (tokens < 1000) {
+    return String(Math.max(0, Math.round(tokens)));
+  }
+  const k = tokens / 1000;
+  const value = k >= 100 ? String(Math.round(k)) : k.toFixed(1).replace(/\.0$/, "");
+  return `${value}k`;
+}
+
+// Render a session's context-window usage to sit beside its model, e.g.
+// " · 72% ctx (144k/200k)". The token detail is appended only when both counts
+// are known. Unknown percent (e.g. right after a compaction, before the next
+// assistant response) renders nothing, so a frozen value is never shown as a
+// stale percentage.
+export function formatContextUsage(session: SessionInfo): string {
+  if (typeof session.contextPct !== "number") {
+    return "";
+  }
+  let out = ` · ${session.contextPct}% ctx`;
+  if (
+    typeof session.contextTokens === "number"
+    && typeof session.contextWindow === "number"
+    && session.contextWindow > 0
+  ) {
+    out += ` (${formatTokenCount(session.contextTokens)}/${formatTokenCount(session.contextWindow)})`;
+  }
+  return out;
+}

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import type { SessionInfo, Message, Attachment } from "./types.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
 import { resolve as resolvePath } from "node:path";
 import { sameCwd } from "./cwd.ts";
+import { formatContextUsage } from "./format-context.ts";
 
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
@@ -412,7 +413,7 @@ function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: 
   const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `• ${name} (${shortSessionId(session.id)}) — ${session.cwd} (${session.model})${suffix}`;
+  return `• ${name} (${shortSessionId(session.id)}) — ${session.cwd} (${session.model}${formatContextUsage(session)})${suffix}`;
 }
 function previewText(value: unknown, maxLength = 72): string | undefined {
   if (typeof value !== "string") {
@@ -597,13 +598,33 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       status: currentStatus(),
     };
   }
+  // Snapshot the live session's context-window usage for presence. getContextUsage()
+  // (stock SDK) reports { tokens, contextWindow, percent }, with tokens/percent null
+  // right after a compaction (before the next assistant response). We emit null in
+  // that case to CLEAR a peer's stale value rather than freeze the old percentage.
+  // Feature-detected so an older runtime without getContextUsage() just omits it.
+  function currentContextUsage(): { contextPct?: number | null; contextTokens?: number | null; contextWindow?: number } {
+    const usage = getLiveContext()?.getContextUsage?.();
+    if (!usage) {
+      return {};
+    }
+    const result: { contextPct?: number | null; contextTokens?: number | null; contextWindow?: number } = {
+      contextPct: typeof usage.percent === "number" && Number.isFinite(usage.percent) ? Math.round(usage.percent) : null,
+      contextTokens: typeof usage.tokens === "number" && Number.isFinite(usage.tokens) ? usage.tokens : null,
+    };
+    if (typeof usage.contextWindow === "number" && usage.contextWindow > 0) {
+      result.contextWindow = usage.contextWindow;
+    }
+    return result;
+  }
+
   function syncPresenceIdentity(sessionId: string): void {
     if (!client || !getLiveContext()) {
       return;
     }
     const identity = buildPresenceIdentity(pi, currentIntercomSessionId ?? sessionId);
     lastPresenceName = identity.name;
-    client.updatePresence({ ...identity, status: currentStatus() });
+    client.updatePresence({ ...identity, status: currentStatus(), ...currentContextUsage() });
   }
   function startNamePoll(): void {
     clearNamePollTimer();
@@ -633,7 +654,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     if (!client || !currentSessionId || !getLiveContext()) {
       return;
     }
-    client.updatePresence({ status: currentStatus() });
+    // context% rides the status heartbeat so peers see live usage at turn boundaries.
+    client.updatePresence({ status: currentStatus(), ...currentContextUsage() });
   }
   function currentSessionTargetMatches(to: string, resolvedTo?: string | null, activeClient?: IntercomClient): boolean {
     const targets = new Set<string>();

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,8 @@ import { InlineMessageComponent } from "./ui/inline-message.ts";
 import { getAskTimeoutMs, loadConfig, type IntercomConfig } from "./config.ts";
 import type { SessionInfo, Message, Attachment } from "./types.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
+import { resolve as resolvePath } from "node:path";
+import { sameCwd } from "./cwd.ts";
 
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
@@ -1453,6 +1455,8 @@ sessions share a name.
 
 Usage:
   intercom({ action: "list" })                    → List active sessions
+  intercom({ action: "list-cwd" })                → List sessions in the current working directory
+  intercom({ action: "list-cwd", cwd: "/path" })  → List sessions in a specific directory
   intercom({ action: "send", to: "name-or-id", message: "..." })  → Send message
   intercom({ action: "ask", to: "name-or-id", message: "..." })   → Ask and wait for reply
   intercom({ action: "reply", message: "..." })                      → Reply to the active/single pending ask
@@ -1462,8 +1466,8 @@ Usage:
       "Use to coordinate with other local pi sessions: list peers, send updates, ask for help, or check intercom connectivity.",
 
     parameters: Type.Object({
-      action: StringEnum(["list", "send", "ask", "reply", "pending", "status"] as const, {
-        description: "Action: 'list', 'send', 'ask', 'reply', 'pending', or 'status'",
+      action: StringEnum(["list", "list-cwd", "send", "ask", "reply", "pending", "status"] as const, {
+        description: "Action: 'list', 'list-cwd', 'send', 'ask', 'reply', 'pending', or 'status'",
       }),
       to: Type.Optional(Type.String({
         description: "Target session: name, full session ID, or the short id shown in parentheses by 'list' (a leading ID prefix resolves). For 'send', 'ask', or disambiguating 'reply'.",
@@ -1480,6 +1484,9 @@ Usage:
       replyTo: Type.Optional(Type.String({
         description: "Message ID to reply to (for threading or responding to an 'ask')",
       })),
+      cwd: Type.Optional(Type.String({
+        description: "Working directory filter for 'list-cwd' (absolute, or relative to the current session's cwd; '.' means the current cwd). Defaults to the current session's cwd.",
+      })),
     }),
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -1495,7 +1502,7 @@ Usage:
 
       syncPresenceIdentity(ctx.sessionManager.getSessionId());
 
-      const { action, to, message, attachments, replyTo } = params;
+      const { action, to, message, attachments, replyTo, cwd } = params;
 
       switch (action) {
         case "list": {
@@ -1516,6 +1523,59 @@ Usage:
             const otherSection = otherSessions.length === 0
               ? "**Other sessions:**\nNo other sessions connected."
               : `**Other sessions:**\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
+
+            return {
+              content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],
+              details: {},
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Failed to list sessions: ${getErrorMessage(error)}` }],
+              details: { error: true },
+            };
+          }
+        }
+
+        case "list-cwd": {
+          try {
+            const mySessionId = connectedClient.sessionId;
+            const sessions = await connectedClient.listSessions();
+            const currentSession = sessions.find(s => s.id === mySessionId);
+
+            if (!currentSession) {
+              return {
+                content: [{ type: "text", text: "Current session is missing from intercom session list." }],
+                details: { error: true },
+              };
+            }
+
+            // Default to the current session's cwd; an explicit `cwd` overrides
+            // (relative paths resolved against it, "." meaning the current cwd).
+            const filterCwd = cwd && cwd !== "."
+              ? resolvePath(currentSession.cwd, cwd)
+              : currentSession.cwd;
+
+            const otherSessions = sessions.filter(
+              s => s.id !== mySessionId && sameCwd(s.cwd, filterCwd),
+            );
+
+            // Fail loud: filtering by a directory with no peers while the
+            // session's OWN cwd has some otherwise reads as a misleading empty
+            // result (common when a caller passes a guessed parent cwd).
+            let emptyNote = "No other sessions in this directory.";
+            if (otherSessions.length === 0 && !sameCwd(filterCwd, currentSession.cwd)) {
+              const here = sessions.filter(
+                s => s.id !== mySessionId && sameCwd(s.cwd, currentSession.cwd),
+              ).length;
+              if (here > 0) {
+                emptyNote += ` Your session's cwd is ${currentSession.cwd} (${here} peer${here === 1 ? "" : "s"} there) — call list-cwd without a cwd argument to list them.`;
+              }
+            }
+
+            const currentSection = `**Current session:**\n${formatSessionListRow(currentSession, currentSession.cwd, true)}`;
+            const otherSection = otherSessions.length === 0
+              ? `**Other sessions (cwd: ${filterCwd}):**\n${emptyNote}`
+              : `**Other sessions (cwd: ${filterCwd}):**\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
 
             return {
               content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -2002,3 +2002,33 @@ test("async ask can be replied to later from the single pending ask fallback", {
     await cleanup();
   }
 });
+
+test("presence carries context usage to peers, and an explicit null clears a stale value", { concurrency: false }, async () => {
+  // Peers should see each other's live context-window usage without a separate
+  // query, and a post-compaction null must CLEAR the value rather than leave a
+  // stale-high percentage frozen in the list.
+  const { planner, orchestrator, cleanup } = await setupClients();
+  try {
+    planner.updatePresence({ contextPct: 50, contextTokens: 100000, contextWindow: 200000 });
+    // Flush barrier: a round-trip on planner's OWN socket guarantees the broker
+    // processed the presence (FIFO per socket) before the peer probes.
+    await planner.send(orchestrator.sessionId!, { text: "flush" });
+    let sessions = await orchestrator.listSessions();
+    let p = sessions.find(s => s.id === planner.sessionId);
+    assert.equal(p?.contextPct, 50);
+    assert.equal(p?.contextTokens, 100000);
+    assert.equal(p?.contextWindow, 200000);
+
+    // Post-compaction: null contextPct/tokens must CLEAR (not freeze the old %).
+    planner.updatePresence({ contextPct: null, contextTokens: null });
+    await planner.send(orchestrator.sessionId!, { text: "flush" });
+    sessions = await orchestrator.listSessions();
+    p = sessions.find(s => s.id === planner.sessionId);
+    assert.equal(p?.contextPct, undefined, "null contextPct must CLEAR the field, not freeze the old value");
+    assert.equal(p?.contextTokens, undefined);
+    // contextWindow (the denominator, not nulled here) is retained.
+    assert.equal(p?.contextWindow, 200000);
+  } finally {
+    await cleanup();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "index.ts",
     "types.ts",
     "config.ts",
+    "cwd.ts",
     "reply-tracker.ts",
     "broker/**/*.ts",
     "ui/**/*.ts",
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts cwd.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "types.ts",
     "config.ts",
     "cwd.ts",
+    "format-context.ts",
     "reply-tracker.ts",
     "broker/**/*.ts",
     "ui/**/*.ts",
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts cwd.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/types.ts
+++ b/types.ts
@@ -9,6 +9,14 @@ export interface SessionInfo {
   status?: string;
   peerUid?: number;
   trustedLocal?: boolean;
+  /** Live context-window usage, pushed via presence from the source session's
+   *  getContextUsage(). contextPct is 0..100 (rounded); contextTokens /
+   *  contextWindow are raw token counts. All optional: unknown right after a
+   *  compaction (before the next assistant response), when no model is selected,
+   *  or on older clients that never report it. */
+  contextPct?: number;
+  contextTokens?: number;
+  contextWindow?: number;
 }
 
 export interface Message {
@@ -37,7 +45,12 @@ export type ClientMessage =
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }
   | { type: "cancel_ask"; messageId: string }
-  | { type: "presence"; name?: string; status?: string; model?: string };
+  // presence carries optional context-usage fields so peers see each session's
+  // live context% without a separate query. contextPct/contextTokens/contextWindow
+  // accept null as an explicit CLEAR signal (post-compaction the value is unknown
+  // until the next assistant response); the broker deletes the field rather than
+  // carrying the stale value forward.
+  | { type: "presence"; name?: string; status?: string; model?: string; contextPct?: number | null; contextTokens?: number | null; contextWindow?: number | null };
 
 export type BrokerMessage =
   | { type: "registered"; sessionId: string }


### PR DESCRIPTION
## Summary

Maintainer takeover for the approved #58/#59 backlog lane:

- rebases `list-cwd` onto current main
- adds context-window usage to session presence and list output
- fixes package contents by including the new runtime files
- reconciles the test script and docs

Credit: thanks to iRonin for PR #58 and PR #59.

## Validation

- `npm test` — 111/111 passed
- `git diff --check`
- `npm pack --dry-run`