### PR TITLE
feat: add silent extension bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 - Added `/intercom-id` to insert a stable handoff snippet for the current session into the editor. Thanks to dataforxyz for PR #60.
 - Added `intercom({ action: "list-cwd" })` to list peers scoped to the same working directory. Thanks to iRonin for PR #58.
 - Added live context-window usage to session presence and list output. Thanks to iRonin for PR #59.
+- Added a silent namespaced extension bus for non-conversational extension coordination. Thanks to Kieran Bond for PR #69.
 
 ## [0.7.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ The broker:
 - rejects stale owner-only writes
 - stores at most 64 KiB of opaque, revisioned state per namespace
 
-`channel.publish()` accepts payloads up to 16 KiB. `channel.commitState()` uses compare-and-swap against the last observed revision. Clients connected to an older broker see the channel as unsupported and do not send extension operations.
+`channel.publish()` accepts payloads up to 16 KiB. `channel.commitState()` uses compare-and-swap against the last observed revision. Capabilities registered after the broker connection is established are synchronized without reconnecting. Clients connected to an older broker see the channel as unsupported and do not send extension operations.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,43 @@ Pi-intercom publishes live session status automatically. Sessions register as `i
 
 By default, runtime state and config live under `~/.pi/agent/intercom`. If Pi is launched with `PI_CODING_AGENT_DIR`, pi-intercom uses `$PI_CODING_AGENT_DIR/intercom` instead, including `config.json`, broker PID/lock files, sockets, and launcher state.
 
+## Extension channels
+
+Other Pi extensions can use intercom's broker for bounded, non-conversational coordination. Extension-channel traffic never calls `pi.sendMessage()`, never enters a session transcript, and never starts an agent turn.
+
+Register during `session_start` so intercom includes the capability in its deferred broker registration:
+
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  INTERCOM_EXTENSION_REGISTER_EVENT,
+  type IntercomExtensionChannel,
+} from "pi-intercom/extension-api.ts";
+
+export default function (pi: ExtensionAPI) {
+  let channel: IntercomExtensionChannel | undefined;
+
+  pi.on("session_start", () => {
+    pi.events.emit(INTERCOM_EXTENSION_REGISTER_EVENT, {
+      namespace: "example/v1",
+      ownerEligible: true,
+      onReady: (value: IntercomExtensionChannel) => { channel = value; },
+      onEvent: (event: unknown) => { /* owner, state, peer, or payload event */ },
+    });
+  });
+}
+```
+
+The broker:
+
+- advertises `extension-bus-v1` through feature negotiation
+- routes payloads only to sessions advertising the same namespace
+- elects one owner per namespace and changes its epoch after socket replacement
+- rejects stale owner-only writes
+- stores at most 64 KiB of opaque, revisioned state per namespace
+
+`channel.publish()` accepts payloads up to 16 KiB. `channel.commitState()` uses compare-and-swap against the last observed revision. Clients connected to an older broker see the channel as unsupported and do not send extension operations.
+
 ## How It Works
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ The broker:
 - rejects stale owner-only writes
 - stores at most 64 KiB of opaque, revisioned state per namespace
 
-`channel.publish()` accepts payloads up to 16 KiB. `channel.commitState()` uses compare-and-swap against the last observed revision. Capabilities registered after the broker connection is established are synchronized without reconnecting. Clients connected to an older broker see the channel as unsupported and do not send extension operations.
+`channel.publish()` accepts payloads up to 16 KiB. A `capable` broadcast includes the sender, so consumers must not blindly republish messages they receive. `channel.commitState()` uses compare-and-swap against the last observed revision. Capabilities registered after the broker connection is established are synchronized without reconnecting. Clients connected to an older broker see the channel as unsupported and do not send extension operations.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,43 @@ Pi-intercom publishes live session status automatically. Sessions register as `i
 
 By default, runtime state and config live under `~/.pi/agent/intercom`. If Pi is launched with `PI_CODING_AGENT_DIR`, pi-intercom uses `$PI_CODING_AGENT_DIR/intercom` instead, including `config.json`, broker PID/lock files, sockets, and launcher state.
 
+## Extension channels
+
+Other Pi extensions can use intercom's broker for bounded, non-conversational coordination. Extension-channel traffic never calls `pi.sendMessage()`, never enters a session transcript, and never starts an agent turn.
+
+Register during `session_start` so intercom includes the capability in its deferred broker registration:
+
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  INTERCOM_EXTENSION_REGISTER_EVENT,
+  type IntercomExtensionChannel,
+} from "pi-intercom/extension-api.ts";
+
+export default function (pi: ExtensionAPI) {
+  let channel: IntercomExtensionChannel | undefined;
+
+  pi.on("session_start", () => {
+    pi.events.emit(INTERCOM_EXTENSION_REGISTER_EVENT, {
+      namespace: "example/v1",
+      ownerEligible: true,
+      onReady: (value: IntercomExtensionChannel) => { channel = value; },
+      onEvent: (event: unknown) => { /* owner, state, peer, or payload event */ },
+    });
+  });
+}
+```
+
+The broker:
+
+- advertises `extension-bus-v1` through feature negotiation
+- routes payloads only to sessions advertising the same namespace
+- elects one owner per namespace and changes its epoch after socket replacement
+- rejects stale owner-only writes
+- stores at most 64 KiB of opaque, revisioned state per namespace
+
+`channel.publish()` accepts payloads up to 16 KiB. A `capable` broadcast includes the sender, so consumers must not blindly republish messages they receive. `channel.commitState()` uses compare-and-swap against the last observed revision. Capabilities registered after the broker connection is established are synchronized without reconnecting. Clients connected to an older broker see the channel as unsupported and do not send extension operations.
+
 ## How It Works
 
 ```mermaid

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -15,7 +15,9 @@ import {
   type BrokerConnectTarget,
 } from "./paths.ts";
 import { getAskTimeoutMs } from "../config.ts";
-import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration } from "../types.ts";
+import { EXTENSION_BUS_FEATURE } from "../types.ts";
+import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration, ExtensionCapability } from "../types.ts";
+import { ExtensionStateManager } from "./extension-state.ts";
 
 const INTERCOM_DIR = getIntercomDirPath();
 const LISTEN_TARGET = getBrokerListenTarget();
@@ -28,11 +30,30 @@ const REGISTRATION_TIMEOUT_MS = 1000;
 const RATE_LIMIT_CAPACITY = 240;
 const RATE_LIMIT_REFILL_PER_SECOND = 120;
 const PRESENCE_HEARTBEAT_MS = 1000;
+const MAX_EXTENSIONS_PER_SESSION = 32;
+const MAX_EXTENSION_MESSAGE_BYTES = 16 * 1024;
+const MAX_EXTENSION_STATE_BYTES = 64 * 1024;
+
+function serializedPayloadSize(payload: unknown): number | null {
+  try {
+    const json = JSON.stringify(payload);
+    return json === undefined ? null : Buffer.byteLength(json, "utf8");
+  } catch {
+    return null;
+  }
+}
 
 interface ConnectedSession {
   socket: net.Socket;
   info: SessionInfo;
   lastPresenceBroadcastAt: number;
+  extensions?: ExtensionCapability[];
+}
+
+interface NamespaceOwner {
+  sessionId: string;
+  socket: net.Socket;
+  epoch: string;
 }
 
 interface ConnectionState {
@@ -137,9 +158,12 @@ class IntercomBroker {
   private server: net.Server;
   private shutdownTimer: NodeJS.Timeout | null = null;
   private readonly askTimeoutMs = getAskTimeoutMs();
+  private namespaceOwners = new Map<string, NamespaceOwner>();
+  private extensionStateManager: ExtensionStateManager;
 
   constructor() {
     ensureIntercomRuntimeDir(INTERCOM_DIR);
+    this.extensionStateManager = new ExtensionStateManager(INTERCOM_DIR);
     if (typeof LISTEN_TARGET === "string" && process.platform !== "win32") {
       try {
         unlinkSync(LISTEN_TARGET);
@@ -243,6 +267,7 @@ class IntercomBroker {
           this.sessions.delete(sessionId);
           this.clearAskEdgesForSession(sessionId);
           this.broadcast({ type: "session_left", sessionId }, sessionId);
+          this.recomputeNamespaceOwners();
           this.scheduleShutdownCheck();
         }
       }
@@ -373,15 +398,57 @@ class IntercomBroker {
           ...(session.status !== undefined ? { status: session.status } : {}),
           trustedLocal: typeof LISTEN_TARGET === "string" && process.platform !== "win32",
         };
-        this.sessions.set(id, { socket, info, lastPresenceBroadcastAt: Date.now() });
+
+        // Validate and store extension capabilities
+        const extensions = session.extensions;
+        if (extensions !== undefined) {
+          if (!Array.isArray(extensions) || extensions.length > MAX_EXTENSIONS_PER_SESSION) {
+            throw new Error(`Invalid extensions field (maximum ${MAX_EXTENSIONS_PER_SESSION})`);
+          }
+          for (const ext of extensions) {
+            if (!this.validateExtensionCapability(ext)) {
+              throw new Error(`Invalid extension capability: ${JSON.stringify(ext)}`);
+            }
+          }
+        }
+
+        this.sessions.set(id, {
+          socket,
+          info,
+          lastPresenceBroadcastAt: Date.now(),
+          extensions,
+        });
         
         if (this.shutdownTimer) {
           clearTimeout(this.shutdownTimer);
           this.shutdownTimer = null;
         }
 
-        writeMessage(socket, { type: "registered", sessionId: id });
+        // This must be the first broker message. Older clients ignore the
+        // additive features field; newer clients use it to avoid sending
+        // extension operations to an older broker.
+        writeMessage(socket, {
+          type: "registered",
+          sessionId: id,
+          features: [EXTENSION_BUS_FEATURE],
+        });
         this.broadcast({ type: "session_joined", session: info }, id);
+
+        this.recomputeNamespaceOwners();
+
+        if (extensions) {
+          for (const ext of extensions) {
+            const state = this.extensionStateManager.loadState(ext.namespace);
+            if (state) {
+              writeMessage(socket, {
+                type: "extension_state",
+                namespace: ext.namespace,
+                revision: state.revision,
+                payload: state.payload,
+              });
+            }
+          }
+        }
         break;
       }
 
@@ -394,6 +461,7 @@ class IntercomBroker {
           this.sessions.delete(currentId);
           this.clearAskEdgesForSession(currentId);
           this.broadcast({ type: "session_left", sessionId: currentId }, currentId);
+          this.recomputeNamespaceOwners();
           this.scheduleShutdownCheck();
         }
         setId(null);
@@ -557,6 +625,16 @@ class IntercomBroker {
         break;
       }
 
+      case "extension_publish": {
+        this.handleExtensionPublish(socket, currentId, clientMessage);
+        break;
+      }
+
+      case "extension_state_commit": {
+        this.handleExtensionStateCommit(socket, currentId, clientMessage);
+        break;
+      }
+
       default:
         throw new Error(`Unknown client message type: ${clientMessage.type}`);
     }
@@ -599,6 +677,354 @@ class IntercomBroker {
     for (const [id, session] of this.sessions) {
       if (id !== exclude) {
         writeMessage(session.socket, msg);
+      }
+    }
+  }
+
+  private validateExtensionCapability(cap: unknown): cap is ExtensionCapability {
+    if (typeof cap !== "object" || cap === null) {
+      return false;
+    }
+    const c = cap as Record<string, unknown>;
+    if (typeof c.namespace !== "string" || typeof c.ownerEligible !== "boolean") {
+      return false;
+    }
+    return this.validateNamespace(c.namespace);
+  }
+
+  private validateNamespace(ns: string): boolean {
+    // ^[a-z0-9][a-z0-9._/-]{0,63}$
+    if (ns.length === 0 || ns.length > 64) {
+      return false;
+    }
+    if (!/^[a-z0-9]/.test(ns)) {
+      return false;
+    }
+    if (!/^[a-z0-9][a-z0-9._/-]*$/.test(ns)) {
+      return false;
+    }
+    return true;
+  }
+
+  private recomputeNamespaceOwners(): void {
+    const namespaces = new Set(this.namespaceOwners.keys());
+    for (const session of this.sessions.values()) {
+      for (const extension of session.extensions ?? []) {
+        namespaces.add(extension.namespace);
+      }
+    }
+
+    // For each namespace, elect owner by (startedAt, sessionId).
+    for (const namespace of namespaces) {
+      const candidates: Array<{ sessionId: string; session: ConnectedSession }> = [];
+      for (const [sessionId, session] of this.sessions) {
+        if (session.extensions) {
+          const hasNamespace = session.extensions.some(
+            (ext) => ext.namespace === namespace && ext.ownerEligible
+          );
+          if (hasNamespace) {
+            candidates.push({ sessionId, session });
+          }
+        }
+      }
+
+      if (candidates.length === 0) {
+        if (this.namespaceOwners.delete(namespace)) {
+          for (const session of this.sessions.values()) {
+            const isCapable = session.extensions?.some((extension) => extension.namespace === namespace);
+            if (isCapable) {
+              writeMessage(session.socket, { type: "extension_owner", namespace });
+            }
+          }
+        }
+        continue;
+      }
+
+      // Sort by startedAt, then sessionId
+      candidates.sort((a, b) => {
+        if (a.session.info.startedAt !== b.session.info.startedAt) {
+          return a.session.info.startedAt - b.session.info.startedAt;
+        }
+        return a.sessionId.localeCompare(b.sessionId);
+      });
+
+      const winner = candidates[0];
+      const existing = this.namespaceOwners.get(namespace);
+
+      // Check if owner changed or socket changed
+      const ownerChanged = !existing || existing.sessionId !== winner.sessionId;
+      const socketChanged = existing && existing.socket !== winner.session.socket;
+
+      if (ownerChanged || socketChanged) {
+        // Generate new epoch
+        const epoch = randomUUID();
+        this.namespaceOwners.set(namespace, {
+          sessionId: winner.sessionId,
+          socket: winner.session.socket,
+          epoch,
+        });
+
+        // Broadcast owner change to all capable sessions
+        for (const session of this.sessions.values()) {
+          if (session.extensions?.length) {
+            const isCapable = session.extensions.some((ext) => ext.namespace === namespace);
+            if (isCapable) {
+              writeMessage(session.socket, {
+                type: "extension_owner",
+                namespace,
+                ownerId: winner.sessionId,
+                ownerEpoch: epoch,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private handleExtensionPublish(
+    socket: net.Socket,
+    currentId: string | null,
+    msg: Record<string, unknown>
+  ): void {
+    if (!currentId) {
+      throw new Error("Received extension_publish before register");
+    }
+
+    const session = this.sessions.get(currentId);
+    if (!session || session.socket !== socket) {
+      writeMessage(socket, { type: "error", error: "Session not found" });
+      return;
+    }
+
+    if (!session.extensions?.length) {
+      writeMessage(socket, { type: "error", error: "Session has not advertised extension capability" });
+      return;
+    }
+
+    const namespace = msg.namespace;
+    const audience = msg.audience;
+    const ownerOnly = msg.ownerOnly === true;
+    const ownerEpoch = msg.ownerEpoch;
+    const payload = msg.payload;
+
+    if (typeof namespace !== "string" || !this.validateNamespace(namespace)) {
+      writeMessage(socket, { type: "error", error: "Invalid namespace" });
+      return;
+    }
+
+    if (audience !== "owner" && audience !== "capable") {
+      writeMessage(socket, { type: "error", error: "Invalid audience" });
+      return;
+    }
+
+    const payloadSize = serializedPayloadSize(payload);
+    if (payloadSize === null || payloadSize > MAX_EXTENSION_MESSAGE_BYTES) {
+      writeMessage(socket, { type: "error", error: "Invalid extension payload or payload exceeds 16 KiB limit" });
+      return;
+    }
+
+    // Verify sender has capability for this namespace
+    const hasCapability = session.extensions?.some((ext) => ext.namespace === namespace);
+    if (!hasCapability) {
+      writeMessage(socket, { type: "error", error: "Sender does not have capability for this namespace" });
+      return;
+    }
+
+    const owner = this.namespaceOwners.get(namespace);
+    if (!owner) {
+      writeMessage(socket, { type: "error", error: "No owner for this namespace" });
+      return;
+    }
+
+    // For owner-only messages, validate exact socket and epoch
+    if (ownerOnly) {
+      if (typeof ownerEpoch !== "string") {
+        writeMessage(socket, { type: "error", error: "ownerEpoch required for owner-only messages" });
+        return;
+      }
+      if (currentId !== owner.sessionId || socket !== owner.socket || ownerEpoch !== owner.epoch) {
+        writeMessage(socket, { type: "error", error: "Owner validation failed" });
+        return;
+      }
+    }
+
+    // Route message to appropriate audience
+    for (const [recipientId, recipientSession] of this.sessions) {
+      if (!recipientSession.extensions?.length) {
+        continue;
+      }
+
+      const isCapable = recipientSession.extensions.some((ext) => ext.namespace === namespace);
+      if (!isCapable) {
+        continue;
+      }
+
+      const shouldReceive =
+        audience === "capable" ||
+        (audience === "owner" &&
+          recipientId === owner.sessionId &&
+          recipientSession.socket === owner.socket);
+
+      if (shouldReceive) {
+        writeMessage(recipientSession.socket, {
+          type: "extension_message",
+          namespace,
+          fromSessionId: currentId,
+          ownerId: owner.sessionId,
+          ownerEpoch: owner.epoch,
+          payload,
+        });
+      }
+    }
+  }
+
+  private handleExtensionStateCommit(
+    socket: net.Socket,
+    currentId: string | null,
+    msg: Record<string, unknown>
+  ): void {
+    if (!currentId) {
+      throw new Error("Received extension_state_commit before register");
+    }
+
+    const session = this.sessions.get(currentId);
+    if (!session || session.socket !== socket) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace: String(msg.namespace || ""),
+        committed: false,
+        revision: 0,
+        reason: "Session not found",
+      });
+      return;
+    }
+
+    if (!session.extensions?.length) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace: String(msg.namespace || ""),
+        committed: false,
+        revision: 0,
+        reason: "Session has not advertised extension capability",
+      });
+      return;
+    }
+
+    const namespace = msg.namespace;
+    const ownerEpoch = msg.ownerEpoch;
+    const expectedRevision = msg.expectedRevision;
+    const payload = msg.payload;
+
+    if (typeof namespace !== "string" || !this.validateNamespace(namespace)) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace: String(namespace),
+        committed: false,
+        revision: 0,
+        reason: "Invalid namespace",
+      });
+      return;
+    }
+
+    if (typeof ownerEpoch !== "string") {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Invalid ownerEpoch",
+      });
+      return;
+    }
+
+    if (typeof expectedRevision !== "number" || !Number.isSafeInteger(expectedRevision) || expectedRevision < 0) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Invalid expectedRevision",
+      });
+      return;
+    }
+
+    const payloadSize = serializedPayloadSize(payload);
+    if (payloadSize === null || payloadSize > MAX_EXTENSION_STATE_BYTES) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Invalid extension state or payload exceeds 64 KiB limit",
+      });
+      return;
+    }
+
+    // Verify sender has capability for this namespace
+    const hasCapability = session.extensions?.some((ext) => ext.namespace === namespace);
+    if (!hasCapability) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Sender does not have capability for this namespace",
+      });
+      return;
+    }
+
+    const owner = this.namespaceOwners.get(namespace);
+    if (!owner) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "No owner for this namespace",
+      });
+      return;
+    }
+
+    // Validate owner, socket, and epoch
+    if (currentId !== owner.sessionId || socket !== owner.socket || ownerEpoch !== owner.epoch) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Owner validation failed",
+      });
+      return;
+    }
+
+    const result = this.extensionStateManager.commitState(namespace, expectedRevision, payload);
+
+    // Send result to committer
+    writeMessage(socket, {
+      type: "extension_state_result",
+      namespace,
+      committed: result.committed,
+      revision: result.revision,
+      reason: result.reason,
+    });
+
+    // If committed, broadcast new state to all capable sessions
+    if (result.committed) {
+      for (const recipientSession of this.sessions.values()) {
+        if (!recipientSession.extensions?.length) {
+          continue;
+        }
+
+        const isCapable = recipientSession.extensions.some((ext) => ext.namespace === namespace);
+        if (isCapable) {
+          writeMessage(recipientSession.socket, {
+            type: "extension_state",
+            namespace,
+            revision: result.revision,
+            payload,
+          });
+        }
       }
     }
   }

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -47,6 +47,7 @@ interface ConnectedSession {
   socket: net.Socket;
   info: SessionInfo;
   lastPresenceBroadcastAt: number;
+  ownerOrder: number;
   extensions?: ExtensionCapability[];
 }
 
@@ -159,6 +160,7 @@ class IntercomBroker {
   private shutdownTimer: NodeJS.Timeout | null = null;
   private readonly askTimeoutMs = getAskTimeoutMs();
   private namespaceOwners = new Map<string, NamespaceOwner>();
+  private nextOwnerOrder = 1;
   private extensionStateManager: ExtensionStateManager;
 
   constructor() {
@@ -415,6 +417,7 @@ class IntercomBroker {
           socket,
           info,
           lastPresenceBroadcastAt: Date.now(),
+          ownerOrder: previous?.ownerOrder ?? this.nextOwnerOrder++,
           extensions,
         });
         
@@ -784,10 +787,12 @@ class IntercomBroker {
         continue;
       }
 
-      // Sort by startedAt, then sessionId
+      // Use broker-owned registration order so clients cannot seize authority
+      // by backdating their advertised session start time. Stable-ID socket
+      // replacements preserve the original order.
       candidates.sort((a, b) => {
-        if (a.session.info.startedAt !== b.session.info.startedAt) {
-          return a.session.info.startedAt - b.session.info.startedAt;
+        if (a.session.ownerOrder !== b.session.ownerOrder) {
+          return a.session.ownerOrder - b.session.ownerOrder;
         }
         return a.sessionId.localeCompare(b.sessionId);
       });

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -438,6 +438,12 @@ class IntercomBroker {
 
         if (extensions) {
           for (const ext of extensions) {
+            const owner = this.namespaceOwners.get(ext.namespace);
+            writeMessage(socket, {
+              type: "extension_owner",
+              namespace: ext.namespace,
+              ...(owner ? { ownerId: owner.sessionId, ownerEpoch: owner.epoch } : {}),
+            });
             const state = this.extensionStateManager.loadState(ext.namespace);
             if (state) {
               writeMessage(socket, {
@@ -465,6 +471,45 @@ class IntercomBroker {
           this.scheduleShutdownCheck();
         }
         setId(null);
+        break;
+      }
+
+      case "extension_capabilities_update": {
+        if (!currentId) {
+          throw new Error("Received extension_capabilities_update before register");
+        }
+        const session = this.sessions.get(currentId);
+        if (!session || session.socket !== socket) {
+          throw new Error("Extension capability session not found");
+        }
+        const extensions = clientMessage.extensions;
+        if (!Array.isArray(extensions) || extensions.length > MAX_EXTENSIONS_PER_SESSION) {
+          throw new Error(`Invalid extensions field (maximum ${MAX_EXTENSIONS_PER_SESSION})`);
+        }
+        for (const extension of extensions) {
+          if (!this.validateExtensionCapability(extension)) {
+            throw new Error(`Invalid extension capability: ${JSON.stringify(extension)}`);
+          }
+        }
+        session.extensions = extensions;
+        this.recomputeNamespaceOwners();
+        for (const extension of extensions) {
+          const owner = this.namespaceOwners.get(extension.namespace);
+          writeMessage(socket, {
+            type: "extension_owner",
+            namespace: extension.namespace,
+            ...(owner ? { ownerId: owner.sessionId, ownerEpoch: owner.epoch } : {}),
+          });
+          const state = this.extensionStateManager.loadState(extension.namespace);
+          if (state) {
+            writeMessage(socket, {
+              type: "extension_state",
+              namespace: extension.namespace,
+              revision: state.revision,
+              payload: state.payload,
+            });
+          }
+        }
         break;
       }
 

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -375,6 +375,19 @@ class IntercomBroker {
           }
           id = clientMessage.sessionId;
         }
+        const session = clientMessage.session;
+        const extensions = session.extensions;
+        if (extensions !== undefined) {
+          if (!Array.isArray(extensions) || extensions.length > MAX_EXTENSIONS_PER_SESSION) {
+            throw new Error(`Invalid extensions field (maximum ${MAX_EXTENSIONS_PER_SESSION})`);
+          }
+          for (const extension of extensions) {
+            if (!this.validateExtensionCapability(extension)) {
+              throw new Error(`Invalid extension capability: ${JSON.stringify(extension)}`);
+            }
+          }
+        }
+
         const previous = this.sessions.get(id);
         if (!previous && this.sessions.size >= MAX_SESSIONS) {
           writeMessage(socket, { type: "error", error: "Too many registered intercom sessions" });
@@ -386,7 +399,6 @@ class IntercomBroker {
           previous.socket.end();
         }
         setId(id);
-        const session = clientMessage.session;
         const info: SessionInfo = {
           id,
           ...(session.name !== undefined ? { name: session.name } : {}),
@@ -398,19 +410,6 @@ class IntercomBroker {
           ...(session.status !== undefined ? { status: session.status } : {}),
           trustedLocal: typeof LISTEN_TARGET === "string" && process.platform !== "win32",
         };
-
-        // Validate and store extension capabilities
-        const extensions = session.extensions;
-        if (extensions !== undefined) {
-          if (!Array.isArray(extensions) || extensions.length > MAX_EXTENSIONS_PER_SESSION) {
-            throw new Error(`Invalid extensions field (maximum ${MAX_EXTENSIONS_PER_SESSION})`);
-          }
-          for (const ext of extensions) {
-            if (!this.validateExtensionCapability(ext)) {
-              throw new Error(`Invalid extension capability: ${JSON.stringify(ext)}`);
-            }
-          }
-        }
 
         this.sessions.set(id, {
           socket,

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -876,13 +876,13 @@ class IntercomBroker {
     }
 
     const owner = this.namespaceOwners.get(namespace);
-    if (!owner) {
+    if ((audience === "owner" || ownerOnly) && !owner) {
       writeMessage(socket, { type: "error", error: "No owner for this namespace" });
       return;
     }
 
     // For owner-only messages, validate exact socket and epoch
-    if (ownerOnly) {
+    if (ownerOnly && owner) {
       if (typeof ownerEpoch !== "string") {
         writeMessage(socket, { type: "error", error: "ownerEpoch required for owner-only messages" });
         return;
@@ -906,7 +906,7 @@ class IntercomBroker {
 
       const shouldReceive =
         audience === "capable" ||
-        (audience === "owner" &&
+        (audience === "owner" && owner !== undefined &&
           recipientId === owner.sessionId &&
           recipientSession.socket === owner.socket);
 
@@ -915,8 +915,7 @@ class IntercomBroker {
           type: "extension_message",
           namespace,
           fromSessionId: currentId,
-          ownerId: owner.sessionId,
-          ownerEpoch: owner.epoch,
+          ...(owner ? { ownerId: owner.sessionId, ownerEpoch: owner.epoch } : {}),
           payload,
         });
       }

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -18,6 +18,7 @@ import { getAskTimeoutMs } from "../config.ts";
 import { EXTENSION_BUS_FEATURE } from "../types.ts";
 import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration, ExtensionCapability } from "../types.ts";
 import { ExtensionStateManager } from "./extension-state.ts";
+import { assertNoLiveBroker } from "./runtime-claim.ts";
 
 const INTERCOM_DIR = getIntercomDirPath();
 const LISTEN_TARGET = getBrokerListenTarget();
@@ -165,6 +166,7 @@ class IntercomBroker {
 
   constructor() {
     ensureIntercomRuntimeDir(INTERCOM_DIR);
+    assertNoLiveBroker(PID_PATH);
     this.extensionStateManager = new ExtensionStateManager(INTERCOM_DIR);
     if (typeof LISTEN_TARGET === "string" && process.platform !== "win32") {
       try {

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -15,7 +15,10 @@ import {
   type BrokerConnectTarget,
 } from "./paths.ts";
 import { getAskTimeoutMs } from "../config.ts";
-import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration } from "../types.ts";
+import { EXTENSION_BUS_FEATURE } from "../types.ts";
+import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration, ExtensionCapability } from "../types.ts";
+import { ExtensionStateManager } from "./extension-state.ts";
+import { assertNoLiveBroker } from "./runtime-claim.ts";
 
 const INTERCOM_DIR = getIntercomDirPath();
 const LISTEN_TARGET = getBrokerListenTarget();
@@ -28,11 +31,31 @@ const REGISTRATION_TIMEOUT_MS = 1000;
 const RATE_LIMIT_CAPACITY = 240;
 const RATE_LIMIT_REFILL_PER_SECOND = 120;
 const PRESENCE_HEARTBEAT_MS = 1000;
+const MAX_EXTENSIONS_PER_SESSION = 32;
+const MAX_EXTENSION_MESSAGE_BYTES = 16 * 1024;
+const MAX_EXTENSION_STATE_BYTES = 64 * 1024;
+
+function serializedPayloadSize(payload: unknown): number | null {
+  try {
+    const json = JSON.stringify(payload);
+    return json === undefined ? null : Buffer.byteLength(json, "utf8");
+  } catch {
+    return null;
+  }
+}
 
 interface ConnectedSession {
   socket: net.Socket;
   info: SessionInfo;
   lastPresenceBroadcastAt: number;
+  ownerOrder: number;
+  extensions?: ExtensionCapability[];
+}
+
+interface NamespaceOwner {
+  sessionId: string;
+  socket: net.Socket;
+  epoch: string;
 }
 
 interface ConnectionState {
@@ -137,9 +160,14 @@ class IntercomBroker {
   private server: net.Server;
   private shutdownTimer: NodeJS.Timeout | null = null;
   private readonly askTimeoutMs = getAskTimeoutMs();
+  private namespaceOwners = new Map<string, NamespaceOwner>();
+  private nextOwnerOrder = 1;
+  private extensionStateManager: ExtensionStateManager;
 
   constructor() {
     ensureIntercomRuntimeDir(INTERCOM_DIR);
+    assertNoLiveBroker(PID_PATH);
+    this.extensionStateManager = new ExtensionStateManager(INTERCOM_DIR);
     if (typeof LISTEN_TARGET === "string" && process.platform !== "win32") {
       try {
         unlinkSync(LISTEN_TARGET);
@@ -243,6 +271,7 @@ class IntercomBroker {
           this.sessions.delete(sessionId);
           this.clearAskEdgesForSession(sessionId);
           this.broadcast({ type: "session_left", sessionId }, sessionId);
+          this.recomputeNamespaceOwners();
           this.scheduleShutdownCheck();
         }
       }
@@ -350,6 +379,19 @@ class IntercomBroker {
           }
           id = clientMessage.sessionId;
         }
+        const session = clientMessage.session;
+        const extensions = session.extensions;
+        if (extensions !== undefined) {
+          if (!Array.isArray(extensions) || extensions.length > MAX_EXTENSIONS_PER_SESSION) {
+            throw new Error(`Invalid extensions field (maximum ${MAX_EXTENSIONS_PER_SESSION})`);
+          }
+          for (const extension of extensions) {
+            if (!this.validateExtensionCapability(extension)) {
+              throw new Error(`Invalid extension capability: ${JSON.stringify(extension)}`);
+            }
+          }
+        }
+
         const previous = this.sessions.get(id);
         if (!previous && this.sessions.size >= MAX_SESSIONS) {
           writeMessage(socket, { type: "error", error: "Too many registered intercom sessions" });
@@ -361,7 +403,6 @@ class IntercomBroker {
           previous.socket.end();
         }
         setId(id);
-        const session = clientMessage.session;
         const info: SessionInfo = {
           id,
           ...(session.name !== undefined ? { name: session.name } : {}),
@@ -373,15 +414,51 @@ class IntercomBroker {
           ...(session.status !== undefined ? { status: session.status } : {}),
           trustedLocal: typeof LISTEN_TARGET === "string" && process.platform !== "win32",
         };
-        this.sessions.set(id, { socket, info, lastPresenceBroadcastAt: Date.now() });
+
+        this.sessions.set(id, {
+          socket,
+          info,
+          lastPresenceBroadcastAt: Date.now(),
+          ownerOrder: previous?.ownerOrder ?? this.nextOwnerOrder++,
+          extensions,
+        });
         
         if (this.shutdownTimer) {
           clearTimeout(this.shutdownTimer);
           this.shutdownTimer = null;
         }
 
-        writeMessage(socket, { type: "registered", sessionId: id });
+        // This must be the first broker message. Older clients ignore the
+        // additive features field; newer clients use it to avoid sending
+        // extension operations to an older broker.
+        writeMessage(socket, {
+          type: "registered",
+          sessionId: id,
+          features: [EXTENSION_BUS_FEATURE],
+        });
         this.broadcast({ type: "session_joined", session: info }, id);
+
+        this.recomputeNamespaceOwners();
+
+        if (extensions) {
+          for (const ext of extensions) {
+            const owner = this.namespaceOwners.get(ext.namespace);
+            writeMessage(socket, {
+              type: "extension_owner",
+              namespace: ext.namespace,
+              ...(owner ? { ownerId: owner.sessionId, ownerEpoch: owner.epoch } : {}),
+            });
+            const state = this.extensionStateManager.loadState(ext.namespace);
+            if (state) {
+              writeMessage(socket, {
+                type: "extension_state",
+                namespace: ext.namespace,
+                revision: state.revision,
+                payload: state.payload,
+              });
+            }
+          }
+        }
         break;
       }
 
@@ -394,9 +471,49 @@ class IntercomBroker {
           this.sessions.delete(currentId);
           this.clearAskEdgesForSession(currentId);
           this.broadcast({ type: "session_left", sessionId: currentId }, currentId);
+          this.recomputeNamespaceOwners();
           this.scheduleShutdownCheck();
         }
         setId(null);
+        break;
+      }
+
+      case "extension_capabilities_update": {
+        if (!currentId) {
+          throw new Error("Received extension_capabilities_update before register");
+        }
+        const session = this.sessions.get(currentId);
+        if (!session || session.socket !== socket) {
+          throw new Error("Extension capability session not found");
+        }
+        const extensions = clientMessage.extensions;
+        if (!Array.isArray(extensions) || extensions.length > MAX_EXTENSIONS_PER_SESSION) {
+          throw new Error(`Invalid extensions field (maximum ${MAX_EXTENSIONS_PER_SESSION})`);
+        }
+        for (const extension of extensions) {
+          if (!this.validateExtensionCapability(extension)) {
+            throw new Error(`Invalid extension capability: ${JSON.stringify(extension)}`);
+          }
+        }
+        session.extensions = extensions;
+        this.recomputeNamespaceOwners();
+        for (const extension of extensions) {
+          const owner = this.namespaceOwners.get(extension.namespace);
+          writeMessage(socket, {
+            type: "extension_owner",
+            namespace: extension.namespace,
+            ...(owner ? { ownerId: owner.sessionId, ownerEpoch: owner.epoch } : {}),
+          });
+          const state = this.extensionStateManager.loadState(extension.namespace);
+          if (state) {
+            writeMessage(socket, {
+              type: "extension_state",
+              namespace: extension.namespace,
+              revision: state.revision,
+              payload: state.payload,
+            });
+          }
+        }
         break;
       }
 
@@ -590,6 +707,16 @@ class IntercomBroker {
         break;
       }
 
+      case "extension_publish": {
+        this.handleExtensionPublish(socket, currentId, clientMessage);
+        break;
+      }
+
+      case "extension_state_commit": {
+        this.handleExtensionStateCommit(socket, currentId, clientMessage);
+        break;
+      }
+
       default:
         throw new Error(`Unknown client message type: ${clientMessage.type}`);
     }
@@ -632,6 +759,355 @@ class IntercomBroker {
     for (const [id, session] of this.sessions) {
       if (id !== exclude) {
         writeMessage(session.socket, msg);
+      }
+    }
+  }
+
+  private validateExtensionCapability(cap: unknown): cap is ExtensionCapability {
+    if (typeof cap !== "object" || cap === null) {
+      return false;
+    }
+    const c = cap as Record<string, unknown>;
+    if (typeof c.namespace !== "string" || typeof c.ownerEligible !== "boolean") {
+      return false;
+    }
+    return this.validateNamespace(c.namespace);
+  }
+
+  private validateNamespace(ns: string): boolean {
+    // ^[a-z0-9][a-z0-9._/-]{0,63}$
+    if (ns.length === 0 || ns.length > 64) {
+      return false;
+    }
+    if (!/^[a-z0-9]/.test(ns)) {
+      return false;
+    }
+    if (!/^[a-z0-9][a-z0-9._/-]*$/.test(ns)) {
+      return false;
+    }
+    return true;
+  }
+
+  private recomputeNamespaceOwners(): void {
+    const namespaces = new Set(this.namespaceOwners.keys());
+    for (const session of this.sessions.values()) {
+      for (const extension of session.extensions ?? []) {
+        namespaces.add(extension.namespace);
+      }
+    }
+
+    // For each namespace, elect owner by (startedAt, sessionId).
+    for (const namespace of namespaces) {
+      const candidates: Array<{ sessionId: string; session: ConnectedSession }> = [];
+      for (const [sessionId, session] of this.sessions) {
+        if (session.extensions) {
+          const hasNamespace = session.extensions.some(
+            (ext) => ext.namespace === namespace && ext.ownerEligible
+          );
+          if (hasNamespace) {
+            candidates.push({ sessionId, session });
+          }
+        }
+      }
+
+      if (candidates.length === 0) {
+        if (this.namespaceOwners.delete(namespace)) {
+          for (const session of this.sessions.values()) {
+            const isCapable = session.extensions?.some((extension) => extension.namespace === namespace);
+            if (isCapable) {
+              writeMessage(session.socket, { type: "extension_owner", namespace });
+            }
+          }
+        }
+        continue;
+      }
+
+      // Use broker-owned registration order so clients cannot seize authority
+      // by backdating their advertised session start time. Stable-ID socket
+      // replacements preserve the original order.
+      candidates.sort((a, b) => {
+        if (a.session.ownerOrder !== b.session.ownerOrder) {
+          return a.session.ownerOrder - b.session.ownerOrder;
+        }
+        return a.sessionId.localeCompare(b.sessionId);
+      });
+
+      const winner = candidates[0];
+      const existing = this.namespaceOwners.get(namespace);
+
+      // Check if owner changed or socket changed
+      const ownerChanged = !existing || existing.sessionId !== winner.sessionId;
+      const socketChanged = existing && existing.socket !== winner.session.socket;
+
+      if (ownerChanged || socketChanged) {
+        // Generate new epoch
+        const epoch = randomUUID();
+        this.namespaceOwners.set(namespace, {
+          sessionId: winner.sessionId,
+          socket: winner.session.socket,
+          epoch,
+        });
+
+        // Broadcast owner change to all capable sessions
+        for (const session of this.sessions.values()) {
+          if (session.extensions?.length) {
+            const isCapable = session.extensions.some((ext) => ext.namespace === namespace);
+            if (isCapable) {
+              writeMessage(session.socket, {
+                type: "extension_owner",
+                namespace,
+                ownerId: winner.sessionId,
+                ownerEpoch: epoch,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private handleExtensionPublish(
+    socket: net.Socket,
+    currentId: string | null,
+    msg: Record<string, unknown>
+  ): void {
+    if (!currentId) {
+      throw new Error("Received extension_publish before register");
+    }
+
+    const session = this.sessions.get(currentId);
+    if (!session || session.socket !== socket) {
+      writeMessage(socket, { type: "error", error: "Session not found" });
+      return;
+    }
+
+    if (!session.extensions?.length) {
+      writeMessage(socket, { type: "error", error: "Session has not advertised extension capability" });
+      return;
+    }
+
+    const namespace = msg.namespace;
+    const audience = msg.audience;
+    const ownerOnly = msg.ownerOnly === true;
+    const ownerEpoch = msg.ownerEpoch;
+    const payload = msg.payload;
+
+    if (typeof namespace !== "string" || !this.validateNamespace(namespace)) {
+      writeMessage(socket, { type: "error", error: "Invalid namespace" });
+      return;
+    }
+
+    if (audience !== "owner" && audience !== "capable") {
+      writeMessage(socket, { type: "error", error: "Invalid audience" });
+      return;
+    }
+
+    const payloadSize = serializedPayloadSize(payload);
+    if (payloadSize === null || payloadSize > MAX_EXTENSION_MESSAGE_BYTES) {
+      writeMessage(socket, { type: "error", error: "Invalid extension payload or payload exceeds 16 KiB limit" });
+      return;
+    }
+
+    // Verify sender has capability for this namespace
+    const hasCapability = session.extensions?.some((ext) => ext.namespace === namespace);
+    if (!hasCapability) {
+      writeMessage(socket, { type: "error", error: "Sender does not have capability for this namespace" });
+      return;
+    }
+
+    const owner = this.namespaceOwners.get(namespace);
+    if ((audience === "owner" || ownerOnly) && !owner) {
+      writeMessage(socket, { type: "error", error: "No owner for this namespace" });
+      return;
+    }
+
+    // For owner-only messages, validate exact socket and epoch
+    if (ownerOnly && owner) {
+      if (typeof ownerEpoch !== "string") {
+        writeMessage(socket, { type: "error", error: "ownerEpoch required for owner-only messages" });
+        return;
+      }
+      if (currentId !== owner.sessionId || socket !== owner.socket || ownerEpoch !== owner.epoch) {
+        writeMessage(socket, { type: "error", error: "Owner validation failed" });
+        return;
+      }
+    }
+
+    // Route message to appropriate audience
+    for (const [recipientId, recipientSession] of this.sessions) {
+      if (!recipientSession.extensions?.length) {
+        continue;
+      }
+
+      const isCapable = recipientSession.extensions.some((ext) => ext.namespace === namespace);
+      if (!isCapable) {
+        continue;
+      }
+
+      const shouldReceive =
+        audience === "capable" ||
+        (audience === "owner" && owner !== undefined &&
+          recipientId === owner.sessionId &&
+          recipientSession.socket === owner.socket);
+
+      if (shouldReceive) {
+        writeMessage(recipientSession.socket, {
+          type: "extension_message",
+          namespace,
+          fromSessionId: currentId,
+          ...(owner ? { ownerId: owner.sessionId, ownerEpoch: owner.epoch } : {}),
+          payload,
+        });
+      }
+    }
+  }
+
+  private handleExtensionStateCommit(
+    socket: net.Socket,
+    currentId: string | null,
+    msg: Record<string, unknown>
+  ): void {
+    if (!currentId) {
+      throw new Error("Received extension_state_commit before register");
+    }
+
+    const session = this.sessions.get(currentId);
+    if (!session || session.socket !== socket) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace: String(msg.namespace || ""),
+        committed: false,
+        revision: 0,
+        reason: "Session not found",
+      });
+      return;
+    }
+
+    if (!session.extensions?.length) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace: String(msg.namespace || ""),
+        committed: false,
+        revision: 0,
+        reason: "Session has not advertised extension capability",
+      });
+      return;
+    }
+
+    const namespace = msg.namespace;
+    const ownerEpoch = msg.ownerEpoch;
+    const expectedRevision = msg.expectedRevision;
+    const payload = msg.payload;
+
+    if (typeof namespace !== "string" || !this.validateNamespace(namespace)) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace: String(namespace),
+        committed: false,
+        revision: 0,
+        reason: "Invalid namespace",
+      });
+      return;
+    }
+
+    if (typeof ownerEpoch !== "string") {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Invalid ownerEpoch",
+      });
+      return;
+    }
+
+    if (typeof expectedRevision !== "number" || !Number.isSafeInteger(expectedRevision) || expectedRevision < 0) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Invalid expectedRevision",
+      });
+      return;
+    }
+
+    const payloadSize = serializedPayloadSize(payload);
+    if (payloadSize === null || payloadSize > MAX_EXTENSION_STATE_BYTES) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Invalid extension state or payload exceeds 64 KiB limit",
+      });
+      return;
+    }
+
+    // Verify sender has capability for this namespace
+    const hasCapability = session.extensions?.some((ext) => ext.namespace === namespace);
+    if (!hasCapability) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Sender does not have capability for this namespace",
+      });
+      return;
+    }
+
+    const owner = this.namespaceOwners.get(namespace);
+    if (!owner) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "No owner for this namespace",
+      });
+      return;
+    }
+
+    // Validate owner, socket, and epoch
+    if (currentId !== owner.sessionId || socket !== owner.socket || ownerEpoch !== owner.epoch) {
+      writeMessage(socket, {
+        type: "extension_state_result",
+        namespace,
+        committed: false,
+        revision: this.extensionStateManager.getCurrentRevision(namespace),
+        reason: "Owner validation failed",
+      });
+      return;
+    }
+
+    const result = this.extensionStateManager.commitState(namespace, expectedRevision, payload);
+
+    // Send result to committer
+    writeMessage(socket, {
+      type: "extension_state_result",
+      namespace,
+      committed: result.committed,
+      revision: result.revision,
+      reason: result.reason,
+    });
+
+    // If committed, broadcast new state to all capable sessions
+    if (result.committed) {
+      for (const recipientSession of this.sessions.values()) {
+        if (!recipientSession.extensions?.length) {
+          continue;
+        }
+
+        const isCapable = recipientSession.extensions.some((ext) => ext.namespace === namespace);
+        if (isCapable) {
+          writeMessage(recipientSession.socket, {
+            type: "extension_state",
+            namespace,
+            revision: result.revision,
+            payload,
+          });
+        }
       }
     }
   }

--- a/broker/client.test.ts
+++ b/broker/client.test.ts
@@ -40,6 +40,10 @@ test("malformed extension broker messages are rejected", () => {
   (client as any)._sessionId = "session-1";
 
   assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_owner", namespace: "test/v1", ownerId: "owner" }),
+    /Invalid extension_owner/,
+  );
+  assert.throws(
     () => (client as any).handleBrokerMessage({ type: "extension_message", namespace: "test/v1" }),
     /Invalid extension_message/,
   );

--- a/broker/client.test.ts
+++ b/broker/client.test.ts
@@ -2,6 +2,49 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { IntercomClient } from "./client.ts";
 
+test("validated session lifecycle messages reach broker-message subscribers", () => {
+  const client = new IntercomClient();
+  (client as any)._sessionId = "session-1";
+  const received: unknown[] = [];
+  client.onBrokerMessage((message) => received.push(message));
+  const session = {
+    id: "session-2",
+    cwd: "/test",
+    model: "test",
+    pid: 2,
+    startedAt: 1,
+    lastActivity: 1,
+  };
+
+  (client as any).handleBrokerMessage({ type: "session_joined", session });
+  (client as any).handleBrokerMessage({ type: "presence_update", session });
+  (client as any).handleBrokerMessage({ type: "session_left", sessionId: "session-2" });
+
+  assert.deepEqual(received, [
+    { type: "session_joined", session },
+    { type: "presence_update", session },
+    { type: "session_left", sessionId: "session-2" },
+  ]);
+});
+
+test("malformed extension broker messages are rejected", () => {
+  const client = new IntercomClient();
+  (client as any)._sessionId = "session-1";
+
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_message", namespace: "test/v1" }),
+    /Invalid extension_message/,
+  );
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_state", namespace: "test/v1", revision: -1 }),
+    /Invalid extension_state/,
+  );
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_state_result", namespace: "test/v1", committed: "yes", revision: 1 }),
+    /Invalid extension_state_result/,
+  );
+});
+
 test("cancelAsk ignores synchronous socket write failures", () => {
   const client = new IntercomClient();
   (client as any)._sessionId = "session-1";

--- a/broker/client.test.ts
+++ b/broker/client.test.ts
@@ -44,6 +44,10 @@ test("malformed extension broker messages are rejected", () => {
     /Invalid extension_owner/,
   );
   assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_owner", namespace: "test/v1", ownerEpoch: "epoch" }),
+    /Invalid extension_owner/,
+  );
+  assert.throws(
     () => (client as any).handleBrokerMessage({ type: "extension_message", namespace: "test/v1" }),
     /Invalid extension_message/,
   );

--- a/broker/client.test.ts
+++ b/broker/client.test.ts
@@ -43,6 +43,12 @@ test("malformed extension broker messages are rejected", () => {
     () => (client as any).handleBrokerMessage({ type: "extension_state_result", namespace: "test/v1", committed: "yes", revision: 1 }),
     /Invalid extension_state_result/,
   );
+  assert.doesNotThrow(() => (client as any).handleBrokerMessage({
+    type: "extension_message",
+    namespace: "test/v1",
+    fromSessionId: "session-2",
+    payload: { peerOnly: true },
+  }));
 });
 
 test("cancelAsk ignores synchronous socket write failures", () => {

--- a/broker/client.test.ts
+++ b/broker/client.test.ts
@@ -27,6 +27,14 @@ test("validated session lifecycle messages reach broker-message subscribers", ()
   ]);
 });
 
+test("registered feature negotiation rejects non-string feature entries", () => {
+  const client = new IntercomClient();
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "registered", sessionId: "session-1", features: ["valid", 123] }),
+    /Invalid registered features/,
+  );
+});
+
 test("malformed extension broker messages are rejected", () => {
   const client = new IntercomClient();
   (client as any)._sessionId = "session-1";

--- a/broker/client.test.ts
+++ b/broker/client.test.ts
@@ -2,6 +2,71 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { IntercomClient } from "./client.ts";
 
+test("validated session lifecycle messages reach broker-message subscribers", () => {
+  const client = new IntercomClient();
+  (client as any)._sessionId = "session-1";
+  const received: unknown[] = [];
+  client.onBrokerMessage((message) => received.push(message));
+  const session = {
+    id: "session-2",
+    cwd: "/test",
+    model: "test",
+    pid: 2,
+    startedAt: 1,
+    lastActivity: 1,
+  };
+
+  (client as any).handleBrokerMessage({ type: "session_joined", session });
+  (client as any).handleBrokerMessage({ type: "presence_update", session });
+  (client as any).handleBrokerMessage({ type: "session_left", sessionId: "session-2" });
+
+  assert.deepEqual(received, [
+    { type: "session_joined", session },
+    { type: "presence_update", session },
+    { type: "session_left", sessionId: "session-2" },
+  ]);
+});
+
+test("registered feature negotiation rejects non-string feature entries", () => {
+  const client = new IntercomClient();
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "registered", sessionId: "session-1", features: ["valid", 123] }),
+    /Invalid registered features/,
+  );
+});
+
+test("malformed extension broker messages are rejected", () => {
+  const client = new IntercomClient();
+  (client as any)._sessionId = "session-1";
+
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_owner", namespace: "test/v1", ownerId: "owner" }),
+    /Invalid extension_owner/,
+  );
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_owner", namespace: "test/v1", ownerEpoch: "epoch" }),
+    /Invalid extension_owner/,
+  );
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_message", namespace: "test/v1" }),
+    /Invalid extension_message/,
+  );
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_state", namespace: "test/v1", revision: -1 }),
+    /Invalid extension_state/,
+  );
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "extension_state_result", namespace: "test/v1", committed: "yes", revision: 1 }),
+    /Invalid extension_state_result/,
+  );
+  assert.doesNotThrow(() => (client as any).handleBrokerMessage({
+    type: "extension_message",
+    namespace: "test/v1",
+    fromSessionId: "session-2",
+    payload: { peerOnly: true },
+  }));
+});
+
 test("cancelAsk ignores synchronous socket write failures", () => {
   const client = new IntercomClient();
   (client as any)._sessionId = "session-1";

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -3,7 +3,15 @@ import net from "net";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
 import { getBrokerConnectTarget, type BrokerConnectTarget } from "./paths.ts";
-import type { SessionInfo, Message, Attachment, SessionRegistration } from "../types.ts";
+import { EXTENSION_BUS_FEATURE } from "../types.ts";
+import type {
+  Attachment,
+  BrokerMessage,
+  ClientMessage,
+  Message,
+  SessionInfo,
+  SessionRegistration,
+} from "../types.ts";
 
 interface SendOptions {
   text: string;
@@ -119,6 +127,7 @@ function isSessionInfo(value: unknown): value is SessionInfo {
 export class IntercomClient extends EventEmitter {
   private socket: net.Socket | null = null;
   private _sessionId: string | null = null;
+  private _features = new Set<string>();
   private pendingSends = new Map<string, { resolve: (r: SendResult) => void; reject: (e: Error) => void }>();
   private pendingLists = new Map<string, { resolve: (sessions: SessionInfo[]) => void; reject: (e: Error) => void }>();
   private disconnecting = false;
@@ -137,6 +146,10 @@ export class IntercomClient extends EventEmitter {
 
   get sessionId(): string | null {
     return this._sessionId;
+  }
+
+  supportsFeature(feature: string): boolean {
+    return this._features.has(feature);
   }
 
   isConnected(): boolean {
@@ -223,6 +236,7 @@ export class IntercomClient extends EventEmitter {
           this.socket = null;
         }
         this._sessionId = null;
+        this._features.clear();
         this.disconnectError = null;
         if (connectionEstablished && !wasDisconnecting) {
           this.emit("disconnected", disconnectError);
@@ -313,8 +327,22 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Received duplicate registered message");
         }
 
+        if (
+          brokerMessage.features !== undefined
+          && (!Array.isArray(brokerMessage.features) || !brokerMessage.features.every((feature) => typeof feature === "string"))
+        ) {
+          throw new Error("Invalid registered features");
+        }
+
         this._sessionId = brokerMessage.sessionId;
-        this.emit("_registered", { type: "registered", sessionId: brokerMessage.sessionId });
+        this._features = new Set((brokerMessage.features as string[] | undefined) ?? []);
+        const registered: BrokerMessage = {
+          type: "registered",
+          sessionId: brokerMessage.sessionId,
+          ...(this._features.size > 0 ? { features: [...this._features] } : {}),
+        };
+        this.emit("broker_message", registered);
+        this.emit("_registered", registered);
         break;
       }
 
@@ -417,6 +445,26 @@ export class IntercomClient extends EventEmitter {
         this.emit("error", new Error(brokerMessage.error));
         break;
       }
+
+      case "extension_owner": {
+        if (
+          typeof brokerMessage.namespace !== "string"
+          || (brokerMessage.ownerId !== undefined && typeof brokerMessage.ownerId !== "string")
+          || (brokerMessage.ownerEpoch !== undefined && typeof brokerMessage.ownerEpoch !== "string")
+        ) {
+          throw new Error("Invalid extension_owner message");
+        }
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit("extension_owner", brokerMessage);
+        break;
+      }
+
+      case "extension_message":
+      case "extension_state":
+      case "extension_state_result":
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit(brokerMessage.type, brokerMessage);
+        break;
 
       default:
         throw new Error(`Unknown broker message type: ${brokerMessage.type}`);
@@ -576,5 +624,18 @@ export class IntercomClient extends EventEmitter {
     }
 
     writeMessage(socket, { type: "presence", ...updates });
+  }
+
+  sendExtensionMessage(message: Extract<ClientMessage, { type: "extension_publish" | "extension_state_commit" }>): void {
+    if (!this.supportsFeature(EXTENSION_BUS_FEATURE)) {
+      throw new Error(`Connected broker does not support ${EXTENSION_BUS_FEATURE}`);
+    }
+    const socket = this.requireActiveSocket();
+    writeMessage(socket, message);
+  }
+
+  onBrokerMessage(handler: (message: BrokerMessage) => void): () => void {
+    this.on("broker_message", handler);
+    return () => this.off("broker_message", handler);
   }
 }

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -514,6 +514,12 @@ export class IntercomClient extends EventEmitter {
     });
   }
 
+  updateExtensionCapabilities(extensions: SessionRegistration["extensions"]): void {
+    if (!this.supportsFeature(EXTENSION_BUS_FEATURE)) return;
+    const socket = this.requireActiveSocket();
+    writeMessage(socket, { type: "extension_capabilities_update", extensions: extensions ?? [] });
+  }
+
   listSessions(): Promise<SessionInfo[]> {
     let socket: net.Socket;
     try {

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -412,6 +412,8 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Invalid session_joined message");
         }
 
+        const message: BrokerMessage = { type: "session_joined", session: brokerMessage.session };
+        this.emit("broker_message", message);
         this.emit("session_joined", brokerMessage.session);
         break;
       }
@@ -421,6 +423,8 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Invalid session_left message");
         }
 
+        const message: BrokerMessage = { type: "session_left", sessionId: brokerMessage.sessionId };
+        this.emit("broker_message", message);
         this.emit("session_left", brokerMessage.sessionId);
         break;
       }
@@ -430,6 +434,8 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Invalid presence_update message");
         }
 
+        const message: BrokerMessage = { type: "presence_update", session: brokerMessage.session };
+        this.emit("broker_message", message);
         this.emit("presence_update", brokerMessage.session);
         break;
       }
@@ -459,12 +465,47 @@ export class IntercomClient extends EventEmitter {
         break;
       }
 
-      case "extension_message":
-      case "extension_state":
-      case "extension_state_result":
+      case "extension_message": {
+        if (
+          typeof brokerMessage.namespace !== "string"
+          || typeof brokerMessage.fromSessionId !== "string"
+          || typeof brokerMessage.ownerId !== "string"
+          || typeof brokerMessage.ownerEpoch !== "string"
+        ) {
+          throw new Error("Invalid extension_message");
+        }
         this.emit("broker_message", brokerMessage as BrokerMessage);
-        this.emit(brokerMessage.type, brokerMessage);
+        this.emit("extension_message", brokerMessage);
         break;
+      }
+
+      case "extension_state": {
+        if (
+          typeof brokerMessage.namespace !== "string"
+          || !Number.isSafeInteger(brokerMessage.revision)
+          || Number(brokerMessage.revision) < 0
+        ) {
+          throw new Error("Invalid extension_state");
+        }
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit("extension_state", brokerMessage);
+        break;
+      }
+
+      case "extension_state_result": {
+        if (
+          typeof brokerMessage.namespace !== "string"
+          || typeof brokerMessage.committed !== "boolean"
+          || !Number.isSafeInteger(brokerMessage.revision)
+          || Number(brokerMessage.revision) < 0
+          || (brokerMessage.reason !== undefined && typeof brokerMessage.reason !== "string")
+        ) {
+          throw new Error("Invalid extension_state_result");
+        }
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit("extension_state_result", brokerMessage);
+        break;
+      }
 
       default:
         throw new Error(`Unknown broker message type: ${brokerMessage.type}`);

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -466,11 +466,14 @@ export class IntercomClient extends EventEmitter {
       }
 
       case "extension_message": {
+        const hasOwnerId = typeof brokerMessage.ownerId === "string";
+        const hasOwnerEpoch = typeof brokerMessage.ownerEpoch === "string";
         if (
           typeof brokerMessage.namespace !== "string"
           || typeof brokerMessage.fromSessionId !== "string"
-          || typeof brokerMessage.ownerId !== "string"
-          || typeof brokerMessage.ownerEpoch !== "string"
+          || hasOwnerId !== hasOwnerEpoch
+          || (brokerMessage.ownerId !== undefined && !hasOwnerId)
+          || (brokerMessage.ownerEpoch !== undefined && !hasOwnerEpoch)
         ) {
           throw new Error("Invalid extension_message");
         }

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -453,10 +453,13 @@ export class IntercomClient extends EventEmitter {
       }
 
       case "extension_owner": {
+        const hasOwnerId = typeof brokerMessage.ownerId === "string";
+        const hasOwnerEpoch = typeof brokerMessage.ownerEpoch === "string";
         if (
           typeof brokerMessage.namespace !== "string"
-          || (brokerMessage.ownerId !== undefined && typeof brokerMessage.ownerId !== "string")
-          || (brokerMessage.ownerEpoch !== undefined && typeof brokerMessage.ownerEpoch !== "string")
+          || hasOwnerId !== hasOwnerEpoch
+          || (brokerMessage.ownerId !== undefined && !hasOwnerId)
+          || (brokerMessage.ownerEpoch !== undefined && !hasOwnerEpoch)
         ) {
           throw new Error("Invalid extension_owner message");
         }

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -3,7 +3,15 @@ import net from "net";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
 import { getBrokerConnectTarget, type BrokerConnectTarget } from "./paths.ts";
-import type { SessionInfo, Message, Attachment, SessionRegistration } from "../types.ts";
+import { EXTENSION_BUS_FEATURE } from "../types.ts";
+import type {
+  Attachment,
+  BrokerMessage,
+  ClientMessage,
+  Message,
+  SessionInfo,
+  SessionRegistration,
+} from "../types.ts";
 
 interface SendOptions {
   text: string;
@@ -125,6 +133,7 @@ function isSessionInfo(value: unknown): value is SessionInfo {
 export class IntercomClient extends EventEmitter {
   private socket: net.Socket | null = null;
   private _sessionId: string | null = null;
+  private _features = new Set<string>();
   private pendingSends = new Map<string, { resolve: (r: SendResult) => void; reject: (e: Error) => void }>();
   private pendingLists = new Map<string, { resolve: (sessions: SessionInfo[]) => void; reject: (e: Error) => void }>();
   private disconnecting = false;
@@ -143,6 +152,10 @@ export class IntercomClient extends EventEmitter {
 
   get sessionId(): string | null {
     return this._sessionId;
+  }
+
+  supportsFeature(feature: string): boolean {
+    return this._features.has(feature);
   }
 
   isConnected(): boolean {
@@ -229,6 +242,7 @@ export class IntercomClient extends EventEmitter {
           this.socket = null;
         }
         this._sessionId = null;
+        this._features.clear();
         this.disconnectError = null;
         if (connectionEstablished && !wasDisconnecting) {
           this.emit("disconnected", disconnectError);
@@ -319,8 +333,22 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Received duplicate registered message");
         }
 
+        if (
+          brokerMessage.features !== undefined
+          && (!Array.isArray(brokerMessage.features) || !brokerMessage.features.every((feature) => typeof feature === "string"))
+        ) {
+          throw new Error("Invalid registered features");
+        }
+
         this._sessionId = brokerMessage.sessionId;
-        this.emit("_registered", { type: "registered", sessionId: brokerMessage.sessionId });
+        this._features = new Set((brokerMessage.features as string[] | undefined) ?? []);
+        const registered: BrokerMessage = {
+          type: "registered",
+          sessionId: brokerMessage.sessionId,
+          ...(this._features.size > 0 ? { features: [...this._features] } : {}),
+        };
+        this.emit("broker_message", registered);
+        this.emit("_registered", registered);
         break;
       }
 
@@ -390,6 +418,8 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Invalid session_joined message");
         }
 
+        const message: BrokerMessage = { type: "session_joined", session: brokerMessage.session };
+        this.emit("broker_message", message);
         this.emit("session_joined", brokerMessage.session);
         break;
       }
@@ -399,6 +429,8 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Invalid session_left message");
         }
 
+        const message: BrokerMessage = { type: "session_left", sessionId: brokerMessage.sessionId };
+        this.emit("broker_message", message);
         this.emit("session_left", brokerMessage.sessionId);
         break;
       }
@@ -408,6 +440,8 @@ export class IntercomClient extends EventEmitter {
           throw new Error("Invalid presence_update message");
         }
 
+        const message: BrokerMessage = { type: "presence_update", session: brokerMessage.session };
+        this.emit("broker_message", message);
         this.emit("presence_update", brokerMessage.session);
         break;
       }
@@ -421,6 +455,67 @@ export class IntercomClient extends EventEmitter {
           throw new Error(brokerMessage.error);
         }
         this.emit("error", new Error(brokerMessage.error));
+        break;
+      }
+
+      case "extension_owner": {
+        const hasOwnerId = typeof brokerMessage.ownerId === "string";
+        const hasOwnerEpoch = typeof brokerMessage.ownerEpoch === "string";
+        if (
+          typeof brokerMessage.namespace !== "string"
+          || hasOwnerId !== hasOwnerEpoch
+          || (brokerMessage.ownerId !== undefined && !hasOwnerId)
+          || (brokerMessage.ownerEpoch !== undefined && !hasOwnerEpoch)
+        ) {
+          throw new Error("Invalid extension_owner message");
+        }
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit("extension_owner", brokerMessage);
+        break;
+      }
+
+      case "extension_message": {
+        const hasOwnerId = typeof brokerMessage.ownerId === "string";
+        const hasOwnerEpoch = typeof brokerMessage.ownerEpoch === "string";
+        if (
+          typeof brokerMessage.namespace !== "string"
+          || typeof brokerMessage.fromSessionId !== "string"
+          || hasOwnerId !== hasOwnerEpoch
+          || (brokerMessage.ownerId !== undefined && !hasOwnerId)
+          || (brokerMessage.ownerEpoch !== undefined && !hasOwnerEpoch)
+        ) {
+          throw new Error("Invalid extension_message");
+        }
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit("extension_message", brokerMessage);
+        break;
+      }
+
+      case "extension_state": {
+        if (
+          typeof brokerMessage.namespace !== "string"
+          || !Number.isSafeInteger(brokerMessage.revision)
+          || Number(brokerMessage.revision) < 0
+        ) {
+          throw new Error("Invalid extension_state");
+        }
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit("extension_state", brokerMessage);
+        break;
+      }
+
+      case "extension_state_result": {
+        if (
+          typeof brokerMessage.namespace !== "string"
+          || typeof brokerMessage.committed !== "boolean"
+          || !Number.isSafeInteger(brokerMessage.revision)
+          || Number(brokerMessage.revision) < 0
+          || (brokerMessage.reason !== undefined && typeof brokerMessage.reason !== "string")
+        ) {
+          throw new Error("Invalid extension_state_result");
+        }
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit("extension_state_result", brokerMessage);
         break;
       }
 
@@ -470,6 +565,12 @@ export class IntercomClient extends EventEmitter {
         socket.destroy();
       }
     });
+  }
+
+  updateExtensionCapabilities(extensions: SessionRegistration["extensions"]): void {
+    if (!this.supportsFeature(EXTENSION_BUS_FEATURE)) return;
+    const socket = this.requireActiveSocket();
+    writeMessage(socket, { type: "extension_capabilities_update", extensions: extensions ?? [] });
   }
 
   listSessions(): Promise<SessionInfo[]> {
@@ -582,5 +683,18 @@ export class IntercomClient extends EventEmitter {
     }
 
     writeMessage(socket, { type: "presence", ...updates });
+  }
+
+  sendExtensionMessage(message: Extract<ClientMessage, { type: "extension_publish" | "extension_state_commit" }>): void {
+    if (!this.supportsFeature(EXTENSION_BUS_FEATURE)) {
+      throw new Error(`Connected broker does not support ${EXTENSION_BUS_FEATURE}`);
+    }
+    const socket = this.requireActiveSocket();
+    writeMessage(socket, message);
+  }
+
+  onBrokerMessage(handler: (message: BrokerMessage) => void): () => void {
+    this.on("broker_message", handler);
+    return () => this.off("broker_message", handler);
   }
 }

--- a/broker/extension-state.ts
+++ b/broker/extension-state.ts
@@ -1,0 +1,186 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  copyFileSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+const MAX_STATE_BYTES = 64 * 1024;
+
+export interface StateEnvelope {
+  formatVersion: 1;
+  namespace: string;
+  revision: number;
+  updatedAt: number;
+  payloadSha256: string;
+  payload: unknown;
+}
+
+export interface StateCommitResult {
+  committed: boolean;
+  revision: number;
+  reason?: string;
+  payload?: unknown;
+}
+
+function serializePayload(payload: unknown): string | null {
+  try {
+    const json = JSON.stringify(payload);
+    if (json === undefined || Buffer.byteLength(json, "utf8") > MAX_STATE_BYTES) {
+      return null;
+    }
+    return json;
+  } catch {
+    return null;
+  }
+}
+
+function payloadHash(payloadJson: string): string {
+  return createHash("sha256").update(payloadJson).digest("hex");
+}
+
+export class ExtensionStateManager {
+  private readonly states = new Map<string, { revision: number; payload: unknown }>();
+  private readonly stateDir: string;
+
+  constructor(runtimeDir: string) {
+    this.stateDir = join(runtimeDir, "extension-state");
+    mkdirSync(this.stateDir, { recursive: true, mode: 0o700 });
+  }
+
+  private statePath(namespace: string): string {
+    const hash = createHash("sha256").update(namespace).digest("hex");
+    return join(this.stateDir, `${hash}.json`);
+  }
+
+  private backupPath(namespace: string): string {
+    return `${this.statePath(namespace)}.bak`;
+  }
+
+  private readEnvelope(filePath: string, namespace: string): StateEnvelope | null {
+    if (!existsSync(filePath)) return null;
+
+    try {
+      const content = readFileSync(filePath, "utf8");
+      const value: unknown = JSON.parse(content);
+      if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+      const envelope = value as Record<string, unknown>;
+      if (
+        envelope.formatVersion !== 1
+        || envelope.namespace !== namespace
+        || !Number.isSafeInteger(envelope.revision)
+        || (envelope.revision as number) < 0
+        || typeof envelope.updatedAt !== "number"
+        || typeof envelope.payloadSha256 !== "string"
+      ) {
+        return null;
+      }
+
+      const payloadJson = serializePayload(envelope.payload);
+      if (payloadJson === null || payloadHash(payloadJson) !== envelope.payloadSha256) {
+        return null;
+      }
+
+      return envelope as unknown as StateEnvelope;
+    } catch {
+      return null;
+    }
+  }
+
+  loadState(namespace: string): { revision: number; payload: unknown } | null {
+    const cached = this.states.get(namespace);
+    if (cached) return cached;
+
+    const envelope = this.readEnvelope(this.statePath(namespace), namespace)
+      ?? this.readEnvelope(this.backupPath(namespace), namespace);
+    if (!envelope) return null;
+
+    const state = { revision: envelope.revision, payload: envelope.payload };
+    this.states.set(namespace, state);
+    return state;
+  }
+
+  commitState(namespace: string, expectedRevision: number, payload: unknown): StateCommitResult {
+    const payloadJson = serializePayload(payload);
+    const current = this.loadState(namespace);
+    const currentRevision = current?.revision ?? 0;
+
+    if (payloadJson === null) {
+      return {
+        committed: false,
+        revision: currentRevision,
+        reason: "Invalid extension state or payload exceeds 64 KiB limit",
+      };
+    }
+    if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 0) {
+      return { committed: false, revision: currentRevision, reason: "Invalid expected revision" };
+    }
+    if (expectedRevision !== currentRevision) {
+      return {
+        committed: false,
+        revision: currentRevision,
+        reason: "Revision mismatch",
+        ...(current ? { payload: current.payload } : {}),
+      };
+    }
+
+    const envelope: StateEnvelope = {
+      formatVersion: 1,
+      namespace,
+      revision: currentRevision + 1,
+      updatedAt: Date.now(),
+      payloadSha256: payloadHash(payloadJson),
+      payload,
+    };
+    const statePath = this.statePath(namespace);
+    const backupPath = this.backupPath(namespace);
+    const tempPath = `${statePath}.tmp.${process.pid}.${randomUUID()}`;
+
+    try {
+      writeFileSync(tempPath, JSON.stringify(envelope), { mode: 0o600 });
+      const file = openSync(tempPath, "r");
+      try {
+        fsyncSync(file);
+      } finally {
+        closeSync(file);
+      }
+
+      if (this.readEnvelope(statePath, namespace)) {
+        copyFileSync(statePath, backupPath);
+      }
+      renameSync(tempPath, statePath);
+
+      try {
+        const directory = openSync(dirname(statePath), "r");
+        try {
+          fsyncSync(directory);
+        } finally {
+          closeSync(directory);
+        }
+      } catch {
+        // Directory fsync is unavailable on some platforms.
+      }
+
+      const state = { revision: envelope.revision, payload };
+      this.states.set(namespace, state);
+      return { committed: true, revision: envelope.revision };
+    } catch {
+      return { committed: false, revision: currentRevision, reason: "Failed to persist extension state" };
+    } finally {
+      rmSync(tempPath, { force: true });
+    }
+  }
+
+  getCurrentRevision(namespace: string): number {
+    return this.loadState(namespace)?.revision ?? 0;
+  }
+}

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -121,6 +121,15 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
 
     const now = Date.now();
     await owner.connect(registration("owner", now - 1000, true), "owner-id");
+
+    const invalidReplacement = new IntercomClient();
+    await assert.rejects(invalidReplacement.connect({
+      ...registration("invalid-replacement", now),
+      extensions: [{ namespace: "Invalid Namespace", ownerEligible: true }],
+    }, "owner-id"));
+    assert.equal((await owner.listSessions()).some((session) => session.id === "owner-id"), true);
+    await invalidReplacement.disconnect().catch(() => undefined);
+
     await peer.connect(registration("peer", now, false), "peer-id");
     await legacy.connect(registration("legacy", now), "legacy-id");
     await late.connect(registration("late", now + 1), "late-id");

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -102,23 +102,28 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     const owner = new IntercomClient();
     const peer = new IntercomClient();
     const legacy = new IntercomClient();
-    clients.push(owner, peer, legacy);
+    const late = new IntercomClient();
+    clients.push(owner, peer, legacy, late);
 
     const ownerMessages: BrokerMessage[] = [];
     const peerMessages: BrokerMessage[] = [];
     const legacyMessages: BrokerMessage[] = [];
+    const lateMessages: BrokerMessage[] = [];
     const ownerErrors: Error[] = [];
     owner.onBrokerMessage((message) => ownerMessages.push(message));
     peer.onBrokerMessage((message) => peerMessages.push(message));
     legacy.onBrokerMessage((message) => legacyMessages.push(message));
+    late.onBrokerMessage((message) => lateMessages.push(message));
     owner.on("error", (error) => ownerErrors.push(error));
     peer.on("error", () => {});
     legacy.on("error", () => {});
+    late.on("error", () => {});
 
     const now = Date.now();
     await owner.connect(registration("owner", now - 1000, true), "owner-id");
     await peer.connect(registration("peer", now, false), "peer-id");
     await legacy.connect(registration("legacy", now), "legacy-id");
+    await late.connect(registration("late", now + 1), "late-id");
 
     assert.equal(owner.supportsFeature("extension-bus-v1"), true);
     assert.equal(legacy.supportsFeature("extension-bus-v1"), true, "new broker advertises support even to clients without capabilities");
@@ -127,6 +132,14 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     assert.equal(ownerEvent.type, "extension_owner");
     assert.equal(ownerEvent.ownerId, "owner-id");
     assert.ok(ownerEvent.ownerEpoch);
+    const peerOwnerEvent = await waitFor(peerMessages, (message) => message.type === "extension_owner");
+    assert.equal(peerOwnerEvent.type, "extension_owner");
+    assert.equal(peerOwnerEvent.ownerId, "owner-id");
+
+    late.updateExtensionCapabilities([{ namespace: "test/v1", ownerEligible: false }]);
+    const lateOwnerEvent = await waitFor(lateMessages, (message) => message.type === "extension_owner");
+    assert.equal(lateOwnerEvent.type, "extension_owner");
+    assert.equal(lateOwnerEvent.ownerId, "owner-id");
 
     owner.sendExtensionMessage({
       type: "extension_publish",
@@ -139,6 +152,9 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     const received = await waitFor(peerMessages, (message) => message.type === "extension_message");
     assert.equal(received.type, "extension_message");
     assert.deepEqual(received.payload, { kind: "assignment" });
+    const lateReceived = await waitFor(lateMessages, (message) => message.type === "extension_message");
+    assert.equal(lateReceived.type, "extension_message");
+    assert.deepEqual(lateReceived.payload, { kind: "assignment" });
     await new Promise((resolve) => setTimeout(resolve, 50));
     assert.equal(legacyMessages.some((message) => message.type === "extension_message"), false);
 

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -166,6 +166,7 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     assert.equal(lateOwnerEvent.ownerId, "owner-id", "backdated client must not seize namespace ownership");
     late.updateExtensionCapabilities([{ namespace: "test/v1", ownerEligible: false }]);
 
+    legacy.updateExtensionCapabilities([{ namespace: "other/v1", ownerEligible: false }]);
     legacy.sendExtensionMessage({
       type: "extension_publish",
       namespace: "test/v1",
@@ -176,7 +177,7 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     while (Date.now() < unauthorizedDeadline && legacyErrors.length === 0) {
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
-    assert.match(legacyErrors[0]?.message ?? "", /has not advertised extension capability/);
+    assert.match(legacyErrors[0]?.message ?? "", /does not have capability for this namespace/);
     legacy.sendExtensionMessage({
       type: "extension_state_commit",
       namespace: "test/v1",
@@ -190,7 +191,7 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     );
     assert.equal(unauthorizedState.type, "extension_state_result");
     assert.equal(unauthorizedState.committed, false);
-    assert.match(unauthorizedState.reason ?? "", /has not advertised extension capability/);
+    assert.match(unauthorizedState.reason ?? "", /does not have capability for this namespace/);
 
     owner.sendExtensionMessage({
       type: "extension_publish",

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -1,0 +1,386 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { BrokerMessage, SessionRegistration } from "../types.ts";
+import { IntercomClient } from "./client.ts";
+import { ExtensionStateManager } from "./extension-state.ts";
+
+const repoDir = process.cwd();
+
+function registration(name: string, startedAt: number, ownerEligible?: boolean): SessionRegistration {
+  return {
+    name,
+    cwd: "/test",
+    model: "test-model",
+    pid: process.pid,
+    startedAt,
+    lastActivity: Date.now(),
+    ...(ownerEligible === undefined
+      ? {}
+      : { extensions: [{ namespace: "test/v1", ownerEligible }] }),
+  };
+}
+
+async function waitFor(
+  messages: BrokerMessage[],
+  predicate: (message: BrokerMessage) => boolean,
+  timeoutMs = 3000,
+): Promise<BrokerMessage> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const message = messages.find(predicate);
+    if (message) return message;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for broker message");
+}
+
+async function startBroker(agentDir: string): Promise<ChildProcessWithoutNullStreams> {
+  const broker = spawn(
+    process.execPath,
+    [path.join(repoDir, "node_modules", "tsx", "dist", "cli.mjs"), path.join(repoDir, "broker", "broker.ts")],
+    {
+      cwd: repoDir,
+      env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  const ready = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Broker startup timed out")), 10_000);
+    broker.stdout.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("Intercom broker started")) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    broker.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      reject(new Error(`Broker exited before startup (${code ?? signal})`));
+    });
+  });
+  await ready;
+  return broker;
+}
+
+async function stopBroker(broker: ChildProcessWithoutNullStreams): Promise<void> {
+  if (broker.exitCode !== null) return;
+  broker.kill("SIGTERM");
+  await once(broker, "exit");
+}
+
+test("extension bus negotiates, routes, elects an owner, and persists state", { concurrency: false, timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-extension-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const broker = await startBroker(agentDir);
+  const clients: IntercomClient[] = [];
+
+  try {
+    const invalidNamespace = new IntercomClient();
+    await assert.rejects(
+      invalidNamespace.connect({
+        ...registration("invalid", Date.now()),
+        extensions: [{ namespace: "Invalid Namespace", ownerEligible: true }],
+      }),
+    );
+
+    const tooManyExtensions = new IntercomClient();
+    await assert.rejects(
+      tooManyExtensions.connect({
+        ...registration("too-many", Date.now()),
+        extensions: Array.from({ length: 33 }, (_, index) => ({
+          namespace: `test-${index}/v1`,
+          ownerEligible: true,
+        })),
+      }),
+    );
+
+    const owner = new IntercomClient();
+    const peer = new IntercomClient();
+    const legacy = new IntercomClient();
+    const late = new IntercomClient();
+    const peerOnlyA = new IntercomClient();
+    const peerOnlyB = new IntercomClient();
+    clients.push(owner, peer, legacy, late, peerOnlyA, peerOnlyB);
+
+    const ownerMessages: BrokerMessage[] = [];
+    const peerMessages: BrokerMessage[] = [];
+    const legacyMessages: BrokerMessage[] = [];
+    const lateMessages: BrokerMessage[] = [];
+    const peerOnlyBMessages: BrokerMessage[] = [];
+    const ownerErrors: Error[] = [];
+    const legacyErrors: Error[] = [];
+    owner.onBrokerMessage((message) => ownerMessages.push(message));
+    peer.onBrokerMessage((message) => peerMessages.push(message));
+    legacy.onBrokerMessage((message) => legacyMessages.push(message));
+    late.onBrokerMessage((message) => lateMessages.push(message));
+    peerOnlyB.onBrokerMessage((message) => peerOnlyBMessages.push(message));
+    owner.on("error", (error) => ownerErrors.push(error));
+    peer.on("error", () => {});
+    legacy.on("error", (error) => legacyErrors.push(error));
+    late.on("error", () => {});
+    peerOnlyA.on("error", () => {});
+    peerOnlyB.on("error", () => {});
+
+    const now = Date.now();
+    await owner.connect(registration("owner", now - 1000, true), "owner-id");
+
+    const invalidReplacement = new IntercomClient();
+    await assert.rejects(invalidReplacement.connect({
+      ...registration("invalid-replacement", now),
+      extensions: [{ namespace: "Invalid Namespace", ownerEligible: true }],
+    }, "owner-id"));
+    assert.equal((await owner.listSessions()).some((session) => session.id === "owner-id"), true);
+    await invalidReplacement.disconnect().catch(() => undefined);
+
+    await peer.connect(registration("peer", now, false), "peer-id");
+    await legacy.connect(registration("legacy", now), "legacy-id");
+    await late.connect(registration("late", 0), "late-id");
+    await peerOnlyA.connect({
+      ...registration("peer-only-a", now + 2),
+      extensions: [{ namespace: "peer-only/v1", ownerEligible: false }],
+    }, "peer-only-a-id");
+    await peerOnlyB.connect({
+      ...registration("peer-only-b", now + 3),
+      extensions: [{ namespace: "peer-only/v1", ownerEligible: false }],
+    }, "peer-only-b-id");
+
+    assert.equal(owner.supportsFeature("extension-bus-v1"), true);
+    assert.equal(legacy.supportsFeature("extension-bus-v1"), true, "new broker advertises support even to clients without capabilities");
+
+    const ownerEvent = await waitFor(ownerMessages, (message) => message.type === "extension_owner");
+    assert.equal(ownerEvent.type, "extension_owner");
+    assert.equal(ownerEvent.ownerId, "owner-id");
+    assert.ok(ownerEvent.ownerEpoch);
+    const peerOwnerEvent = await waitFor(peerMessages, (message) => message.type === "extension_owner");
+    assert.equal(peerOwnerEvent.type, "extension_owner");
+    assert.equal(peerOwnerEvent.ownerId, "owner-id");
+
+    late.updateExtensionCapabilities([{ namespace: "test/v1", ownerEligible: true }]);
+    const lateOwnerEvent = await waitFor(lateMessages, (message) => message.type === "extension_owner");
+    assert.equal(lateOwnerEvent.type, "extension_owner");
+    assert.equal(lateOwnerEvent.ownerId, "owner-id", "backdated client must not seize namespace ownership");
+    late.updateExtensionCapabilities([{ namespace: "test/v1", ownerEligible: false }]);
+
+    legacy.updateExtensionCapabilities([{ namespace: "other/v1", ownerEligible: false }]);
+    legacy.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      payload: { unauthorized: true },
+    });
+    const unauthorizedDeadline = Date.now() + 3000;
+    while (Date.now() < unauthorizedDeadline && legacyErrors.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.match(legacyErrors[0]?.message ?? "", /does not have capability for this namespace/);
+    legacy.sendExtensionMessage({
+      type: "extension_state_commit",
+      namespace: "test/v1",
+      ownerEpoch: "unauthorized",
+      expectedRevision: 0,
+      payload: {},
+    });
+    const unauthorizedState = await waitFor(
+      legacyMessages,
+      (message) => message.type === "extension_state_result",
+    );
+    assert.equal(unauthorizedState.type, "extension_state_result");
+    assert.equal(unauthorizedState.committed, false);
+    assert.match(unauthorizedState.reason ?? "", /does not have capability for this namespace/);
+
+    owner.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      payload: "x".repeat(16 * 1024),
+    });
+    const oversizedDeadline = Date.now() + 3000;
+    while (Date.now() < oversizedDeadline && !ownerErrors.some((error) => /16 KiB/.test(error.message))) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(ownerErrors.some((error) => /16 KiB/.test(error.message)), true);
+    ownerErrors.length = 0;
+
+    peerOnlyA.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "peer-only/v1",
+      audience: "capable",
+      payload: { kind: "peer-broadcast" },
+    });
+    const peerBroadcast = await waitFor(peerOnlyBMessages, (message) => message.type === "extension_message");
+    assert.equal(peerBroadcast.type, "extension_message");
+    assert.equal(peerBroadcast.ownerId, undefined);
+    assert.equal(peerBroadcast.ownerEpoch, undefined);
+    assert.deepEqual(peerBroadcast.payload, { kind: "peer-broadcast" });
+
+    peer.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "owner",
+      payload: { kind: "owner-target" },
+    });
+    const ownerTarget = await waitFor(
+      ownerMessages,
+      (message) => message.type === "extension_message"
+        && (message.payload as { kind?: string }).kind === "owner-target",
+    );
+    assert.equal(ownerTarget.type, "extension_message");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(
+      peerMessages.some((message) => message.type === "extension_message"
+        && (message.payload as { kind?: string }).kind === "owner-target"),
+      false,
+    );
+
+    owner.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      ownerOnly: true,
+      ownerEpoch: ownerEvent.ownerEpoch,
+      payload: { kind: "assignment" },
+    });
+    const received = await waitFor(peerMessages, (message) => message.type === "extension_message");
+    assert.equal(received.type, "extension_message");
+    assert.deepEqual(received.payload, { kind: "assignment" });
+    const lateReceived = await waitFor(lateMessages, (message) => message.type === "extension_message");
+    assert.equal(lateReceived.type, "extension_message");
+    assert.deepEqual(lateReceived.payload, { kind: "assignment" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(legacyMessages.some((message) => message.type === "extension_message"), false);
+
+    owner.sendExtensionMessage({
+      type: "extension_state_commit",
+      namespace: "test/v1",
+      ownerEpoch: ownerEvent.ownerEpoch!,
+      expectedRevision: 0,
+      payload: { groups: ["alpha"] },
+    });
+    const committed = await waitFor(ownerMessages, (message) => message.type === "extension_state_result");
+    assert.equal(committed.type, "extension_state_result");
+    assert.equal(committed.committed, true);
+    assert.equal(committed.revision, 1);
+    const state = await waitFor(peerMessages, (message) => message.type === "extension_state");
+    assert.equal(state.type, "extension_state");
+    assert.deepEqual(state.payload, { groups: ["alpha"] });
+
+    owner.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      ownerOnly: true,
+      payload: {},
+    });
+    const missingEpochDeadline = Date.now() + 3000;
+    while (Date.now() < missingEpochDeadline && !ownerErrors.some((error) => /ownerEpoch required/.test(error.message))) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(ownerErrors.some((error) => /ownerEpoch required/.test(error.message)), true);
+    ownerErrors.length = 0;
+
+    owner.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      ownerOnly: true,
+      ownerEpoch: "stale",
+      payload: {},
+    });
+    await waitFor(
+      ownerMessages,
+      (message) => message.type === "error" && message.error === "Owner validation failed",
+    ).catch(async () => {
+      const deadline = Date.now() + 3000;
+      while (Date.now() < deadline && ownerErrors.length === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.match(ownerErrors[0]?.message ?? "", /Owner validation failed/);
+      return { type: "error", error: ownerErrors[0]!.message } as BrokerMessage;
+    });
+
+    await owner.disconnect();
+    const noOwner = await waitFor(
+      peerMessages,
+      (message) => message.type === "extension_owner" && message.ownerId === undefined,
+    );
+    assert.equal(noOwner.type, "extension_owner");
+
+    const replacement = new IntercomClient();
+    clients.push(replacement);
+    const replacementMessages: BrokerMessage[] = [];
+    replacement.onBrokerMessage((message) => replacementMessages.push(message));
+    replacement.on("error", () => {});
+    await replacement.connect(registration("replacement", now + 1, true), "owner-id");
+    const replacementOwner = await waitFor(replacementMessages, (message) => message.type === "extension_owner");
+    assert.equal(replacementOwner.type, "extension_owner");
+    assert.notEqual(replacementOwner.ownerEpoch, ownerEvent.ownerEpoch);
+    const restored = await waitFor(replacementMessages, (message) => message.type === "extension_state");
+    assert.equal(restored.type, "extension_state");
+    assert.equal(restored.revision, 1);
+  } finally {
+    await Promise.all(clients.map((client) => client.disconnect().catch(() => undefined)));
+    await stopBroker(broker);
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("extension state compare-and-swap rejects stale and invalid revisions", () => {
+  const runtimeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-state-cas-"));
+  try {
+    const manager = new ExtensionStateManager(runtimeDir);
+    assert.deepEqual(manager.commitState("test/v1", 0, { version: 1 }), { committed: true, revision: 1 });
+    assert.deepEqual(manager.commitState("test/v1", 0, { version: 2 }), {
+      committed: false,
+      revision: 1,
+      reason: "Revision mismatch",
+      payload: { version: 1 },
+    });
+    assert.deepEqual(manager.commitState("test/v1", -1, { version: 2 }), {
+      committed: false,
+      revision: 1,
+      reason: "Invalid expected revision",
+    });
+    assert.deepEqual(manager.commitState("test/v1", 1, { version: 2 }), { committed: true, revision: 2 });
+    assert.deepEqual(manager.commitState("test/v1", 2, "x".repeat(64 * 1024)), {
+      committed: false,
+      revision: 2,
+      reason: "Invalid extension state or payload exceeds 64 KiB limit",
+    });
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    assert.deepEqual(manager.commitState("test/v1", 2, circular), {
+      committed: false,
+      revision: 2,
+      reason: "Invalid extension state or payload exceeds 64 KiB limit",
+    });
+  } finally {
+    rmSync(runtimeDir, { recursive: true, force: true });
+  }
+});
+
+test("extension state falls back to a valid backup", () => {
+  const runtimeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-state-"));
+  try {
+    const manager = new ExtensionStateManager(runtimeDir);
+    assert.equal(manager.commitState("test/v1", 0, { version: 1 }).committed, true);
+    assert.equal(manager.commitState("test/v1", 1, { version: 2 }).committed, true);
+
+    const stateDir = path.join(runtimeDir, "extension-state");
+    const files = readdirSync(stateDir);
+    const primary = files.find((file) => file.endsWith(".json"));
+    assert.ok(primary);
+    writeFileSync(path.join(stateDir, primary!), "corrupt", "utf8");
+
+    const recovered = new ExtensionStateManager(runtimeDir).loadState("test/v1");
+    assert.deepEqual(recovered, { revision: 1, payload: { version: 1 } });
+  } finally {
+    rmSync(runtimeDir, { recursive: true, force: true });
+  }
+});

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -138,7 +138,7 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
 
     await peer.connect(registration("peer", now, false), "peer-id");
     await legacy.connect(registration("legacy", now), "legacy-id");
-    await late.connect(registration("late", now + 1), "late-id");
+    await late.connect(registration("late", 0), "late-id");
     await peerOnlyA.connect({
       ...registration("peer-only-a", now + 2),
       extensions: [{ namespace: "peer-only/v1", ownerEligible: false }],
@@ -159,10 +159,11 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     assert.equal(peerOwnerEvent.type, "extension_owner");
     assert.equal(peerOwnerEvent.ownerId, "owner-id");
 
-    late.updateExtensionCapabilities([{ namespace: "test/v1", ownerEligible: false }]);
+    late.updateExtensionCapabilities([{ namespace: "test/v1", ownerEligible: true }]);
     const lateOwnerEvent = await waitFor(lateMessages, (message) => message.type === "extension_owner");
     assert.equal(lateOwnerEvent.type, "extension_owner");
-    assert.equal(lateOwnerEvent.ownerId, "owner-id");
+    assert.equal(lateOwnerEvent.ownerId, "owner-id", "backdated client must not seize namespace ownership");
+    late.updateExtensionCapabilities([{ namespace: "test/v1", ownerEligible: false }]);
 
     peerOnlyA.sendExtensionMessage({
       type: "extension_publish",

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -177,6 +177,25 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     assert.equal(peerBroadcast.ownerEpoch, undefined);
     assert.deepEqual(peerBroadcast.payload, { kind: "peer-broadcast" });
 
+    peer.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "owner",
+      payload: { kind: "owner-target" },
+    });
+    const ownerTarget = await waitFor(
+      ownerMessages,
+      (message) => message.type === "extension_message"
+        && (message.payload as { kind?: string }).kind === "owner-target",
+    );
+    assert.equal(ownerTarget.type, "extension_message");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(
+      peerMessages.some((message) => message.type === "extension_message"
+        && (message.payload as { kind?: string }).kind === "owner-target"),
+      false,
+    );
+
     owner.sendExtensionMessage({
       type: "extension_publish",
       namespace: "test/v1",
@@ -208,6 +227,20 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     const state = await waitFor(peerMessages, (message) => message.type === "extension_state");
     assert.equal(state.type, "extension_state");
     assert.deepEqual(state.payload, { groups: ["alpha"] });
+
+    owner.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      ownerOnly: true,
+      payload: {},
+    });
+    const missingEpochDeadline = Date.now() + 3000;
+    while (Date.now() < missingEpochDeadline && !ownerErrors.some((error) => /ownerEpoch required/.test(error.message))) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(ownerErrors.some((error) => /ownerEpoch required/.test(error.message)), true);
+    ownerErrors.length = 0;
 
     owner.sendExtensionMessage({
       type: "extension_publish",
@@ -254,6 +287,28 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
     else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
     rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("extension state compare-and-swap rejects stale and invalid revisions", () => {
+  const runtimeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-state-cas-"));
+  try {
+    const manager = new ExtensionStateManager(runtimeDir);
+    assert.deepEqual(manager.commitState("test/v1", 0, { version: 1 }), { committed: true, revision: 1 });
+    assert.deepEqual(manager.commitState("test/v1", 0, { version: 2 }), {
+      committed: false,
+      revision: 1,
+      reason: "Revision mismatch",
+      payload: { version: 1 },
+    });
+    assert.deepEqual(manager.commitState("test/v1", -1, { version: 2 }), {
+      committed: false,
+      revision: 1,
+      reason: "Invalid expected revision",
+    });
+    assert.deepEqual(manager.commitState("test/v1", 1, { version: 2 }), { committed: true, revision: 2 });
+  } finally {
+    rmSync(runtimeDir, { recursive: true, force: true });
   }
 });
 

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -103,21 +103,27 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     const peer = new IntercomClient();
     const legacy = new IntercomClient();
     const late = new IntercomClient();
-    clients.push(owner, peer, legacy, late);
+    const peerOnlyA = new IntercomClient();
+    const peerOnlyB = new IntercomClient();
+    clients.push(owner, peer, legacy, late, peerOnlyA, peerOnlyB);
 
     const ownerMessages: BrokerMessage[] = [];
     const peerMessages: BrokerMessage[] = [];
     const legacyMessages: BrokerMessage[] = [];
     const lateMessages: BrokerMessage[] = [];
+    const peerOnlyBMessages: BrokerMessage[] = [];
     const ownerErrors: Error[] = [];
     owner.onBrokerMessage((message) => ownerMessages.push(message));
     peer.onBrokerMessage((message) => peerMessages.push(message));
     legacy.onBrokerMessage((message) => legacyMessages.push(message));
     late.onBrokerMessage((message) => lateMessages.push(message));
+    peerOnlyB.onBrokerMessage((message) => peerOnlyBMessages.push(message));
     owner.on("error", (error) => ownerErrors.push(error));
     peer.on("error", () => {});
     legacy.on("error", () => {});
     late.on("error", () => {});
+    peerOnlyA.on("error", () => {});
+    peerOnlyB.on("error", () => {});
 
     const now = Date.now();
     await owner.connect(registration("owner", now - 1000, true), "owner-id");
@@ -133,6 +139,14 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     await peer.connect(registration("peer", now, false), "peer-id");
     await legacy.connect(registration("legacy", now), "legacy-id");
     await late.connect(registration("late", now + 1), "late-id");
+    await peerOnlyA.connect({
+      ...registration("peer-only-a", now + 2),
+      extensions: [{ namespace: "peer-only/v1", ownerEligible: false }],
+    }, "peer-only-a-id");
+    await peerOnlyB.connect({
+      ...registration("peer-only-b", now + 3),
+      extensions: [{ namespace: "peer-only/v1", ownerEligible: false }],
+    }, "peer-only-b-id");
 
     assert.equal(owner.supportsFeature("extension-bus-v1"), true);
     assert.equal(legacy.supportsFeature("extension-bus-v1"), true, "new broker advertises support even to clients without capabilities");
@@ -149,6 +163,18 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     const lateOwnerEvent = await waitFor(lateMessages, (message) => message.type === "extension_owner");
     assert.equal(lateOwnerEvent.type, "extension_owner");
     assert.equal(lateOwnerEvent.ownerId, "owner-id");
+
+    peerOnlyA.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "peer-only/v1",
+      audience: "capable",
+      payload: { kind: "peer-broadcast" },
+    });
+    const peerBroadcast = await waitFor(peerOnlyBMessages, (message) => message.type === "extension_message");
+    assert.equal(peerBroadcast.type, "extension_message");
+    assert.equal(peerBroadcast.ownerId, undefined);
+    assert.equal(peerBroadcast.ownerEpoch, undefined);
+    assert.deepEqual(peerBroadcast.payload, { kind: "peer-broadcast" });
 
     owner.sendExtensionMessage({
       type: "extension_publish",

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -113,6 +113,7 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     const lateMessages: BrokerMessage[] = [];
     const peerOnlyBMessages: BrokerMessage[] = [];
     const ownerErrors: Error[] = [];
+    const legacyErrors: Error[] = [];
     owner.onBrokerMessage((message) => ownerMessages.push(message));
     peer.onBrokerMessage((message) => peerMessages.push(message));
     legacy.onBrokerMessage((message) => legacyMessages.push(message));
@@ -120,7 +121,7 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     peerOnlyB.onBrokerMessage((message) => peerOnlyBMessages.push(message));
     owner.on("error", (error) => ownerErrors.push(error));
     peer.on("error", () => {});
-    legacy.on("error", () => {});
+    legacy.on("error", (error) => legacyErrors.push(error));
     late.on("error", () => {});
     peerOnlyA.on("error", () => {});
     peerOnlyB.on("error", () => {});
@@ -164,6 +165,45 @@ test("extension bus negotiates, routes, elects an owner, and persists state", { 
     assert.equal(lateOwnerEvent.type, "extension_owner");
     assert.equal(lateOwnerEvent.ownerId, "owner-id", "backdated client must not seize namespace ownership");
     late.updateExtensionCapabilities([{ namespace: "test/v1", ownerEligible: false }]);
+
+    legacy.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      payload: { unauthorized: true },
+    });
+    const unauthorizedDeadline = Date.now() + 3000;
+    while (Date.now() < unauthorizedDeadline && legacyErrors.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.match(legacyErrors[0]?.message ?? "", /has not advertised extension capability/);
+    legacy.sendExtensionMessage({
+      type: "extension_state_commit",
+      namespace: "test/v1",
+      ownerEpoch: "unauthorized",
+      expectedRevision: 0,
+      payload: {},
+    });
+    const unauthorizedState = await waitFor(
+      legacyMessages,
+      (message) => message.type === "extension_state_result",
+    );
+    assert.equal(unauthorizedState.type, "extension_state_result");
+    assert.equal(unauthorizedState.committed, false);
+    assert.match(unauthorizedState.reason ?? "", /has not advertised extension capability/);
+
+    owner.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      payload: "x".repeat(16 * 1024),
+    });
+    const oversizedDeadline = Date.now() + 3000;
+    while (Date.now() < oversizedDeadline && !ownerErrors.some((error) => /16 KiB/.test(error.message))) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(ownerErrors.some((error) => /16 KiB/.test(error.message)), true);
+    ownerErrors.length = 0;
 
     peerOnlyA.sendExtensionMessage({
       type: "extension_publish",
@@ -307,6 +347,18 @@ test("extension state compare-and-swap rejects stale and invalid revisions", () 
       reason: "Invalid expected revision",
     });
     assert.deepEqual(manager.commitState("test/v1", 1, { version: 2 }), { committed: true, revision: 2 });
+    assert.deepEqual(manager.commitState("test/v1", 2, "x".repeat(64 * 1024)), {
+      committed: false,
+      revision: 2,
+      reason: "Invalid extension state or payload exceeds 64 KiB limit",
+    });
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    assert.deepEqual(manager.commitState("test/v1", 2, circular), {
+      committed: false,
+      revision: 2,
+      reason: "Invalid extension state or payload exceeds 64 KiB limit",
+    });
   } finally {
     rmSync(runtimeDir, { recursive: true, force: true });
   }

--- a/broker/extension.test.ts
+++ b/broker/extension.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { BrokerMessage, SessionRegistration } from "../types.ts";
+import { IntercomClient } from "./client.ts";
+import { ExtensionStateManager } from "./extension-state.ts";
+
+const repoDir = process.cwd();
+
+function registration(name: string, startedAt: number, ownerEligible?: boolean): SessionRegistration {
+  return {
+    name,
+    cwd: "/test",
+    model: "test-model",
+    pid: process.pid,
+    startedAt,
+    lastActivity: Date.now(),
+    ...(ownerEligible === undefined
+      ? {}
+      : { extensions: [{ namespace: "test/v1", ownerEligible }] }),
+  };
+}
+
+async function waitFor(
+  messages: BrokerMessage[],
+  predicate: (message: BrokerMessage) => boolean,
+  timeoutMs = 3000,
+): Promise<BrokerMessage> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const message = messages.find(predicate);
+    if (message) return message;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for broker message");
+}
+
+async function startBroker(agentDir: string): Promise<ChildProcessWithoutNullStreams> {
+  const broker = spawn(
+    process.execPath,
+    [path.join(repoDir, "node_modules", "tsx", "dist", "cli.mjs"), path.join(repoDir, "broker", "broker.ts")],
+    {
+      cwd: repoDir,
+      env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  const ready = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Broker startup timed out")), 10_000);
+    broker.stdout.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("Intercom broker started")) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    broker.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      reject(new Error(`Broker exited before startup (${code ?? signal})`));
+    });
+  });
+  await ready;
+  return broker;
+}
+
+async function stopBroker(broker: ChildProcessWithoutNullStreams): Promise<void> {
+  if (broker.exitCode !== null) return;
+  broker.kill("SIGTERM");
+  await once(broker, "exit");
+}
+
+test("extension bus negotiates, routes, elects an owner, and persists state", { concurrency: false, timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-extension-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const broker = await startBroker(agentDir);
+  const clients: IntercomClient[] = [];
+
+  try {
+    const invalidNamespace = new IntercomClient();
+    await assert.rejects(
+      invalidNamespace.connect({
+        ...registration("invalid", Date.now()),
+        extensions: [{ namespace: "Invalid Namespace", ownerEligible: true }],
+      }),
+    );
+
+    const tooManyExtensions = new IntercomClient();
+    await assert.rejects(
+      tooManyExtensions.connect({
+        ...registration("too-many", Date.now()),
+        extensions: Array.from({ length: 33 }, (_, index) => ({
+          namespace: `test-${index}/v1`,
+          ownerEligible: true,
+        })),
+      }),
+    );
+
+    const owner = new IntercomClient();
+    const peer = new IntercomClient();
+    const legacy = new IntercomClient();
+    clients.push(owner, peer, legacy);
+
+    const ownerMessages: BrokerMessage[] = [];
+    const peerMessages: BrokerMessage[] = [];
+    const legacyMessages: BrokerMessage[] = [];
+    const ownerErrors: Error[] = [];
+    owner.onBrokerMessage((message) => ownerMessages.push(message));
+    peer.onBrokerMessage((message) => peerMessages.push(message));
+    legacy.onBrokerMessage((message) => legacyMessages.push(message));
+    owner.on("error", (error) => ownerErrors.push(error));
+    peer.on("error", () => {});
+    legacy.on("error", () => {});
+
+    const now = Date.now();
+    await owner.connect(registration("owner", now - 1000, true), "owner-id");
+    await peer.connect(registration("peer", now, false), "peer-id");
+    await legacy.connect(registration("legacy", now), "legacy-id");
+
+    assert.equal(owner.supportsFeature("extension-bus-v1"), true);
+    assert.equal(legacy.supportsFeature("extension-bus-v1"), true, "new broker advertises support even to clients without capabilities");
+
+    const ownerEvent = await waitFor(ownerMessages, (message) => message.type === "extension_owner");
+    assert.equal(ownerEvent.type, "extension_owner");
+    assert.equal(ownerEvent.ownerId, "owner-id");
+    assert.ok(ownerEvent.ownerEpoch);
+
+    owner.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      ownerOnly: true,
+      ownerEpoch: ownerEvent.ownerEpoch,
+      payload: { kind: "assignment" },
+    });
+    const received = await waitFor(peerMessages, (message) => message.type === "extension_message");
+    assert.equal(received.type, "extension_message");
+    assert.deepEqual(received.payload, { kind: "assignment" });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(legacyMessages.some((message) => message.type === "extension_message"), false);
+
+    owner.sendExtensionMessage({
+      type: "extension_state_commit",
+      namespace: "test/v1",
+      ownerEpoch: ownerEvent.ownerEpoch!,
+      expectedRevision: 0,
+      payload: { groups: ["alpha"] },
+    });
+    const committed = await waitFor(ownerMessages, (message) => message.type === "extension_state_result");
+    assert.equal(committed.type, "extension_state_result");
+    assert.equal(committed.committed, true);
+    assert.equal(committed.revision, 1);
+    const state = await waitFor(peerMessages, (message) => message.type === "extension_state");
+    assert.equal(state.type, "extension_state");
+    assert.deepEqual(state.payload, { groups: ["alpha"] });
+
+    owner.sendExtensionMessage({
+      type: "extension_publish",
+      namespace: "test/v1",
+      audience: "capable",
+      ownerOnly: true,
+      ownerEpoch: "stale",
+      payload: {},
+    });
+    await waitFor(
+      ownerMessages,
+      (message) => message.type === "error" && message.error === "Owner validation failed",
+    ).catch(async () => {
+      const deadline = Date.now() + 3000;
+      while (Date.now() < deadline && ownerErrors.length === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.match(ownerErrors[0]?.message ?? "", /Owner validation failed/);
+      return { type: "error", error: ownerErrors[0]!.message } as BrokerMessage;
+    });
+
+    await owner.disconnect();
+    const noOwner = await waitFor(
+      peerMessages,
+      (message) => message.type === "extension_owner" && message.ownerId === undefined,
+    );
+    assert.equal(noOwner.type, "extension_owner");
+
+    const replacement = new IntercomClient();
+    clients.push(replacement);
+    const replacementMessages: BrokerMessage[] = [];
+    replacement.onBrokerMessage((message) => replacementMessages.push(message));
+    replacement.on("error", () => {});
+    await replacement.connect(registration("replacement", now + 1, true), "owner-id");
+    const replacementOwner = await waitFor(replacementMessages, (message) => message.type === "extension_owner");
+    assert.equal(replacementOwner.type, "extension_owner");
+    assert.notEqual(replacementOwner.ownerEpoch, ownerEvent.ownerEpoch);
+    const restored = await waitFor(replacementMessages, (message) => message.type === "extension_state");
+    assert.equal(restored.type, "extension_state");
+    assert.equal(restored.revision, 1);
+  } finally {
+    await Promise.all(clients.map((client) => client.disconnect().catch(() => undefined)));
+    await stopBroker(broker);
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("extension state falls back to a valid backup", () => {
+  const runtimeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-state-"));
+  try {
+    const manager = new ExtensionStateManager(runtimeDir);
+    assert.equal(manager.commitState("test/v1", 0, { version: 1 }).committed, true);
+    assert.equal(manager.commitState("test/v1", 1, { version: 2 }).committed, true);
+
+    const stateDir = path.join(runtimeDir, "extension-state");
+    const files = readdirSync(stateDir);
+    const primary = files.find((file) => file.endsWith(".json"));
+    assert.ok(primary);
+    writeFileSync(path.join(stateDir, primary!), "corrupt", "utf8");
+
+    const recovered = new ExtensionStateManager(runtimeDir).loadState("test/v1");
+    assert.deepEqual(recovered, { revision: 1, payload: { version: 1 } });
+  } finally {
+    rmSync(runtimeDir, { recursive: true, force: true });
+  }
+});

--- a/broker/runtime-claim.test.ts
+++ b/broker/runtime-claim.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { assertNoLiveBroker } from "./runtime-claim.ts";
+
+test("broker startup refuses to replace a live broker PID", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "pi-intercom-runtime-"));
+  const pidPath = path.join(directory, "broker.pid");
+  try {
+    writeFileSync(pidPath, `${process.pid}\n`);
+    assert.throws(
+      () => assertNoLiveBroker(pidPath),
+      new RegExp(`Refusing to replace live intercom broker process ${process.pid}`),
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("broker startup tolerates absent, invalid, and stale PID files", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "pi-intercom-runtime-"));
+  const pidPath = path.join(directory, "broker.pid");
+  try {
+    assert.doesNotThrow(() => assertNoLiveBroker(pidPath));
+    writeFileSync(pidPath, "invalid\n");
+    assert.doesNotThrow(() => assertNoLiveBroker(pidPath));
+    writeFileSync(pidPath, "2147483647\n");
+    assert.doesNotThrow(() => assertNoLiveBroker(pidPath));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/broker/runtime-claim.ts
+++ b/broker/runtime-claim.ts
@@ -1,0 +1,21 @@
+import { existsSync, readFileSync } from "node:fs";
+
+export function assertNoLiveBroker(pidPath: string): void {
+  if (!existsSync(pidPath)) return;
+
+  let pid: number;
+  try {
+    pid = Number.parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+  } catch {
+    return;
+  }
+  if (!Number.isSafeInteger(pid) || pid <= 0) return;
+
+  try {
+    process.kill(pid, 0);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    throw error;
+  }
+  throw new Error(`Refusing to replace live intercom broker process ${pid}`);
+}

--- a/extension-api.ts
+++ b/extension-api.ts
@@ -1,0 +1,44 @@
+import type { SessionInfo } from "./types.ts";
+
+export const INTERCOM_EXTENSION_REGISTER_EVENT = "intercom:extension-register";
+export const INTERCOM_EXTENSION_REGISTRY_READY_EVENT = "intercom:extension-registry-ready";
+
+export interface IntercomExtensionOwner {
+  sessionId: string;
+  epoch: string;
+}
+
+export interface IntercomExtensionState {
+  revision: number;
+  payload: unknown;
+}
+
+export type IntercomExtensionEvent =
+  | { type: "connection"; connected: boolean; supported: boolean }
+  | { type: "owner"; owner?: IntercomExtensionOwner }
+  | { type: "message"; fromSessionId: string; owner?: IntercomExtensionOwner; payload: unknown }
+  | { type: "state"; state: IntercomExtensionState }
+  | { type: "state_result"; committed: boolean; revision: number; reason?: string }
+  | { type: "session_joined"; session: SessionInfo }
+  | { type: "session_left"; sessionId: string }
+  | { type: "presence_update"; session: SessionInfo };
+
+export interface IntercomExtensionChannel {
+  readonly namespace: string;
+  snapshot(): {
+    connected: boolean;
+    supported: boolean;
+    owner?: IntercomExtensionOwner;
+    state?: IntercomExtensionState;
+  };
+  publish(payload: unknown, options?: { audience?: "owner" | "capable"; ownerOnly?: boolean }): void;
+  commitState(payload: unknown, expectedRevision?: number): void;
+  listSessions(): Promise<SessionInfo[]>;
+}
+
+export interface IntercomExtensionRegistration {
+  namespace: string;
+  ownerEligible: boolean;
+  onEvent(event: IntercomExtensionEvent): void;
+  onReady(channel: IntercomExtensionChannel): void;
+}

--- a/extension-api.ts
+++ b/extension-api.ts
@@ -1,6 +1,7 @@
 import type { SessionInfo } from "./types.ts";
 
 export const INTERCOM_EXTENSION_REGISTER_EVENT = "intercom:extension-register";
+export const INTERCOM_EXTENSION_REGISTRY_READY_EVENT = "intercom:extension-registry-ready";
 
 export interface IntercomExtensionOwner {
   sessionId: string;

--- a/extension-api.ts
+++ b/extension-api.ts
@@ -1,0 +1,43 @@
+import type { SessionInfo } from "./types.ts";
+
+export const INTERCOM_EXTENSION_REGISTER_EVENT = "intercom:extension-register";
+
+export interface IntercomExtensionOwner {
+  sessionId: string;
+  epoch: string;
+}
+
+export interface IntercomExtensionState {
+  revision: number;
+  payload: unknown;
+}
+
+export type IntercomExtensionEvent =
+  | { type: "connection"; connected: boolean; supported: boolean }
+  | { type: "owner"; owner?: IntercomExtensionOwner }
+  | { type: "message"; fromSessionId: string; owner?: IntercomExtensionOwner; payload: unknown }
+  | { type: "state"; state: IntercomExtensionState }
+  | { type: "state_result"; committed: boolean; revision: number; reason?: string }
+  | { type: "session_joined"; session: SessionInfo }
+  | { type: "session_left"; sessionId: string }
+  | { type: "presence_update"; session: SessionInfo };
+
+export interface IntercomExtensionChannel {
+  readonly namespace: string;
+  snapshot(): {
+    connected: boolean;
+    supported: boolean;
+    owner?: IntercomExtensionOwner;
+    state?: IntercomExtensionState;
+  };
+  publish(payload: unknown, options?: { audience?: "owner" | "capable"; ownerOnly?: boolean }): void;
+  commitState(payload: unknown, expectedRevision?: number): void;
+  listSessions(): Promise<SessionInfo[]>;
+}
+
+export interface IntercomExtensionRegistration {
+  namespace: string;
+  ownerEligible: boolean;
+  onEvent(event: IntercomExtensionEvent): void;
+  onReady(channel: IntercomExtensionChannel): void;
+}

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,16 @@ import { SessionListOverlay } from "./ui/session-list.ts";
 import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
 import { InlineMessageComponent } from "./ui/inline-message.ts";
 import { getAskTimeoutMs, loadConfig, type IntercomConfig } from "./config.ts";
-import type { SessionInfo, Message, Attachment } from "./types.ts";
+import { EXTENSION_BUS_FEATURE } from "./types.ts";
+import type { Attachment, BrokerMessage, Message, SessionInfo, SessionRegistration } from "./types.ts";
+import {
+  INTERCOM_EXTENSION_REGISTER_EVENT,
+  type IntercomExtensionChannel,
+  type IntercomExtensionEvent,
+  type IntercomExtensionOwner,
+  type IntercomExtensionRegistration,
+  type IntercomExtensionState,
+} from "./extension-api.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
 
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
@@ -431,6 +440,12 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   let client: IntercomClient | null = null;
   const config: IntercomConfig = loadConfig();
   const askTimeoutMs = getAskTimeoutMs();
+  const localExtensions = new Map<string, {
+    registration: IntercomExtensionRegistration;
+    channel: IntercomExtensionChannel;
+    owner?: IntercomExtensionOwner;
+    state?: IntercomExtensionState;
+  }>();
   let runtimeContext: ExtensionContext | null = null;
   let currentSessionId: string | null = null;
   let currentModel = "unknown";
@@ -564,7 +579,75 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     const lifecycleStatus = activeToolName ? `tool:${activeToolName}` : agentRunning ? "thinking" : "idle";
     return config.status ? `${lifecycleStatus} · ${config.status}` : lifecycleStatus;
   }
-  function buildRegistration(): Omit<SessionInfo, "id"> {
+  function emitLocalExtensionEvent(namespace: string, event: IntercomExtensionEvent): void {
+    try {
+      localExtensions.get(namespace)?.registration.onEvent(event);
+    } catch {
+      // One local extension must not break intercom or other extension channels.
+    }
+  }
+  function createExtensionChannel(namespace: string): IntercomExtensionChannel {
+    return {
+      namespace,
+      snapshot() {
+        const extension = localExtensions.get(namespace);
+        return {
+          connected: Boolean(client?.isConnected()),
+          supported: Boolean(client?.supportsFeature(EXTENSION_BUS_FEATURE)),
+          ...(extension?.owner ? { owner: extension.owner } : {}),
+          ...(extension?.state ? { state: extension.state } : {}),
+        };
+      },
+      publish(payload, options = {}) {
+        const activeClient = client;
+        if (!activeClient?.isConnected()) throw new Error("Intercom is not connected");
+        const extension = localExtensions.get(namespace);
+        const ownerOnly = options.ownerOnly ?? false;
+        const ownerEpoch = ownerOnly ? extension?.owner?.epoch : undefined;
+        if (ownerOnly && !ownerEpoch) throw new Error(`No owner is available for ${namespace}`);
+        activeClient.sendExtensionMessage({
+          type: "extension_publish",
+          namespace,
+          audience: options.audience ?? "owner",
+          ...(ownerOnly ? { ownerOnly: true, ownerEpoch } : {}),
+          payload,
+        });
+      },
+      commitState(payload, expectedRevision) {
+        const activeClient = client;
+        if (!activeClient?.isConnected()) throw new Error("Intercom is not connected");
+        const extension = localExtensions.get(namespace);
+        const ownerEpoch = extension?.owner?.epoch;
+        if (!ownerEpoch || extension.owner?.sessionId !== activeClient.sessionId) {
+          throw new Error(`Current session is not the owner of ${namespace}`);
+        }
+        activeClient.sendExtensionMessage({
+          type: "extension_state_commit",
+          namespace,
+          ownerEpoch,
+          expectedRevision: expectedRevision ?? extension.state?.revision ?? 0,
+          payload,
+        });
+      },
+      async listSessions() {
+        const activeClient = client;
+        if (!activeClient?.isConnected()) throw new Error("Intercom is not connected");
+        return activeClient.listSessions();
+      },
+    };
+  }
+  function registerLocalExtension(registration: IntercomExtensionRegistration): void {
+    if (!/^[a-z0-9][a-z0-9._/-]{0,63}$/.test(registration.namespace)) {
+      throw new Error(`Invalid intercom extension namespace: ${registration.namespace}`);
+    }
+    if (localExtensions.has(registration.namespace)) {
+      throw new Error(`Intercom extension namespace already registered: ${registration.namespace}`);
+    }
+    const channel = createExtensionChannel(registration.namespace);
+    localExtensions.set(registration.namespace, { registration, channel });
+    registration.onReady(channel);
+  }
+  function buildRegistration(): SessionRegistration {
     const liveContext = getLiveContext();
     if (!liveContext || !currentSessionId || sessionStartedAt === null) {
       throw new Error("Intercom runtime not initialized");
@@ -579,6 +662,14 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       startedAt: sessionStartedAt,
       lastActivity: Date.now(),
       status: currentStatus(),
+      ...(localExtensions.size > 0
+        ? {
+            extensions: [...localExtensions.values()].map(({ registration }) => ({
+              namespace: registration.namespace,
+              ownerEligible: registration.ownerEligible,
+            })),
+          }
+        : {}),
     };
   }
   function syncPresenceIdentity(sessionId: string): void {
@@ -763,6 +854,68 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     })();
   }
   function attachClientHandlers(nextClient: IntercomClient): void {
+    nextClient.onBrokerMessage((message: BrokerMessage) => {
+      if (client !== nextClient) return;
+      switch (message.type) {
+        case "registered": {
+          const supported = message.features?.includes(EXTENSION_BUS_FEATURE) ?? false;
+          for (const namespace of localExtensions.keys()) {
+            emitLocalExtensionEvent(namespace, { type: "connection", connected: true, supported });
+          }
+          break;
+        }
+        case "extension_owner": {
+          const extension = localExtensions.get(message.namespace);
+          if (!extension) break;
+          extension.owner = message.ownerId && message.ownerEpoch
+            ? { sessionId: message.ownerId, epoch: message.ownerEpoch }
+            : undefined;
+          emitLocalExtensionEvent(message.namespace, { type: "owner", ...(extension.owner ? { owner: extension.owner } : {}) });
+          break;
+        }
+        case "extension_message": {
+          const extension = localExtensions.get(message.namespace);
+          if (!extension) break;
+          emitLocalExtensionEvent(message.namespace, {
+            type: "message",
+            fromSessionId: message.fromSessionId,
+            owner: { sessionId: message.ownerId, epoch: message.ownerEpoch },
+            payload: message.payload,
+          });
+          break;
+        }
+        case "extension_state": {
+          const extension = localExtensions.get(message.namespace);
+          if (!extension) break;
+          extension.state = { revision: message.revision, payload: message.payload };
+          emitLocalExtensionEvent(message.namespace, { type: "state", state: extension.state });
+          break;
+        }
+        case "extension_state_result":
+          emitLocalExtensionEvent(message.namespace, {
+            type: "state_result",
+            committed: message.committed,
+            revision: message.revision,
+            ...(message.reason ? { reason: message.reason } : {}),
+          });
+          break;
+        case "session_joined":
+          for (const namespace of localExtensions.keys()) {
+            emitLocalExtensionEvent(namespace, { type: "session_joined", session: message.session });
+          }
+          break;
+        case "session_left":
+          for (const namespace of localExtensions.keys()) {
+            emitLocalExtensionEvent(namespace, { type: "session_left", sessionId: message.sessionId });
+          }
+          break;
+        case "presence_update":
+          for (const namespace of localExtensions.keys()) {
+            emitLocalExtensionEvent(namespace, { type: "presence_update", session: message.session });
+          }
+          break;
+      }
+    });
     nextClient.on("message", (from, message) => {
       const liveContext = getLiveContext();
       if (client !== nextClient || !liveContext) {
@@ -775,6 +928,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         return;
       }
       rejectReplyWaiter(new Error(`Disconnected while waiting for reply: ${error.message}`, { cause: error }));
+      for (const [namespace, extension] of localExtensions) {
+        extension.owner = undefined;
+        emitLocalExtensionEvent(namespace, { type: "connection", connected: false, supported: false });
+        emitLocalExtensionEvent(namespace, { type: "owner" });
+      }
       client = null;
       if (!shuttingDown && !disposed) {
         clearReconnectTimer();
@@ -1025,6 +1183,19 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       }
     })();
   }
+  const unsubscribeExtensionRegister = pi.events.on(INTERCOM_EXTENSION_REGISTER_EVENT, (payload) => {
+    if (!payload || typeof payload !== "object") return;
+    const registration = payload as Partial<IntercomExtensionRegistration>;
+    if (
+      typeof registration.namespace !== "string"
+      || typeof registration.ownerEligible !== "boolean"
+      || typeof registration.onEvent !== "function"
+      || typeof registration.onReady !== "function"
+    ) {
+      return;
+    }
+    registerLocalExtension(registration as IntercomExtensionRegistration);
+  });
   const unsubscribeSubagentControlIntercom = pi.events.on(SUBAGENT_CONTROL_INTERCOM_EVENT, (payload) => {
     relaySubagentIntercomPayload(payload, {
       sender: "subagent-control",
@@ -1048,6 +1219,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   });
   
   pi.on("session_shutdown", async () => {
+    unsubscribeExtensionRegister();
     unsubscribeSubagentControlIntercom();
     unsubscribeSubagentResultIntercom();
     shuttingDown = true;

--- a/index.ts
+++ b/index.ts
@@ -1233,7 +1233,6 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     });
   });
   pi.on("session_start", (_event, ctx) => {
-    pi.events.emit(INTERCOM_EXTENSION_REGISTRY_READY_EVENT, { version: 1 });
     if (!config.enabled) {
       return;
     }

--- a/index.ts
+++ b/index.ts
@@ -888,7 +888,9 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
           emitLocalExtensionEvent(message.namespace, {
             type: "message",
             fromSessionId: message.fromSessionId,
-            owner: { sessionId: message.ownerId, epoch: message.ownerEpoch },
+            ...(message.ownerId && message.ownerEpoch
+              ? { owner: { sessionId: message.ownerId, epoch: message.ownerEpoch } }
+              : {}),
             payload: message.payload,
           });
           break;

--- a/index.ts
+++ b/index.ts
@@ -637,6 +637,12 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       },
     };
   }
+  function currentExtensionCapabilities() {
+    return [...localExtensions.values()].map(({ registration }) => ({
+      namespace: registration.namespace,
+      ownerEligible: registration.ownerEligible,
+    }));
+  }
   function registerLocalExtension(registration: IntercomExtensionRegistration): void {
     if (!/^[a-z0-9][a-z0-9._/-]{0,63}$/.test(registration.namespace)) {
       throw new Error(`Invalid intercom extension namespace: ${registration.namespace}`);
@@ -646,14 +652,17 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     const channel = createExtensionChannel(registration.namespace);
     localExtensions.set(registration.namespace, { registration, channel });
+    const activeClient = client;
+    const connected = Boolean(activeClient?.isConnected());
+    const supported = Boolean(activeClient?.supportsFeature(EXTENSION_BUS_FEATURE));
+    // Write the capability update before exposing a connected channel. Socket
+    // framing preserves this order if onReady publishes synchronously.
+    if (activeClient && connected && supported) {
+      activeClient.updateExtensionCapabilities(currentExtensionCapabilities());
+    }
     registration.onReady(channel);
-    if (client?.isConnected() && client.supportsFeature(EXTENSION_BUS_FEATURE)) {
-      client.updateExtensionCapabilities(
-        [...localExtensions.values()].map(({ registration: registered }) => ({
-          namespace: registered.namespace,
-          ownerEligible: registered.ownerEligible,
-        })),
-      );
+    if (connected) {
+      emitLocalExtensionEvent(registration.namespace, { type: "connection", connected: true, supported });
     }
   }
   function buildRegistration(): SessionRegistration {
@@ -673,10 +682,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       status: currentStatus(),
       ...(localExtensions.size > 0
         ? {
-            extensions: [...localExtensions.values()].map(({ registration }) => ({
-              namespace: registration.namespace,
-              ownerEligible: registration.ownerEligible,
-            })),
+            extensions: currentExtensionCapabilities(),
           }
         : {}),
     };
@@ -868,6 +874,9 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       switch (message.type) {
         case "registered": {
           const supported = message.features?.includes(EXTENSION_BUS_FEATURE) ?? false;
+          if (supported && localExtensions.size > 0) {
+            nextClient.updateExtensionCapabilities(currentExtensionCapabilities());
+          }
           for (const namespace of localExtensions.keys()) {
             emitLocalExtensionEvent(namespace, { type: "connection", connected: true, supported });
           }
@@ -1224,6 +1233,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     });
   });
   pi.on("session_start", (_event, ctx) => {
+    pi.events.emit(INTERCOM_EXTENSION_REGISTRY_READY_EVENT, { version: 1 });
     if (!config.enabled) {
       return;
     }

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import { EXTENSION_BUS_FEATURE } from "./types.ts";
 import type { Attachment, BrokerMessage, Message, SessionInfo, SessionRegistration } from "./types.ts";
 import {
   INTERCOM_EXTENSION_REGISTER_EVENT,
+  INTERCOM_EXTENSION_REGISTRY_READY_EVENT,
   type IntercomExtensionChannel,
   type IntercomExtensionEvent,
   type IntercomExtensionOwner,
@@ -646,6 +647,14 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     const channel = createExtensionChannel(registration.namespace);
     localExtensions.set(registration.namespace, { registration, channel });
     registration.onReady(channel);
+    if (client?.isConnected() && client.supportsFeature(EXTENSION_BUS_FEATURE)) {
+      client.updateExtensionCapabilities(
+        [...localExtensions.values()].map(({ registration: registered }) => ({
+          namespace: registered.namespace,
+          ownerEligible: registered.ownerEligible,
+        })),
+      );
+    }
   }
   function buildRegistration(): SessionRegistration {
     const liveContext = getLiveContext();
@@ -1196,6 +1205,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     registerLocalExtension(registration as IntercomExtensionRegistration);
   });
+  pi.events.emit(INTERCOM_EXTENSION_REGISTRY_READY_EVENT, { version: 1 });
   const unsubscribeSubagentControlIntercom = pi.events.on(SUBAGENT_CONTROL_INTERCOM_EVENT, (payload) => {
     relaySubagentIntercomPayload(payload, {
       sender: "subagent-control",

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,17 @@ import { SessionListOverlay } from "./ui/session-list.ts";
 import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
 import { InlineMessageComponent } from "./ui/inline-message.ts";
 import { getAskTimeoutMs, loadConfig, type IntercomConfig } from "./config.ts";
-import type { SessionInfo, Message, Attachment } from "./types.ts";
+import { EXTENSION_BUS_FEATURE } from "./types.ts";
+import type { Attachment, BrokerMessage, Message, SessionInfo, SessionRegistration } from "./types.ts";
+import {
+  INTERCOM_EXTENSION_REGISTER_EVENT,
+  INTERCOM_EXTENSION_REGISTRY_READY_EVENT,
+  type IntercomExtensionChannel,
+  type IntercomExtensionEvent,
+  type IntercomExtensionOwner,
+  type IntercomExtensionRegistration,
+  type IntercomExtensionState,
+} from "./extension-api.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
 import { resolve as resolvePath } from "node:path";
 import { sameCwd } from "./cwd.ts";
@@ -442,6 +452,12 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   let client: IntercomClient | null = null;
   const config: IntercomConfig = loadConfig();
   const askTimeoutMs = getAskTimeoutMs();
+  const localExtensions = new Map<string, {
+    registration: IntercomExtensionRegistration;
+    channel: IntercomExtensionChannel;
+    owner?: IntercomExtensionOwner;
+    state?: IntercomExtensionState;
+  }>();
   let runtimeContext: ExtensionContext | null = null;
   let currentSessionId: string | null = null;
   let currentIntercomSessionId: string | null = null;
@@ -581,7 +597,92 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     const lifecycleStatus = activeToolName ? `tool:${activeToolName}` : agentRunning ? "thinking" : "idle";
     return config.status ? `${lifecycleStatus} · ${config.status}` : lifecycleStatus;
   }
-  function buildRegistration(): Omit<SessionInfo, "id"> {
+  function emitLocalExtensionEvent(namespace: string, event: IntercomExtensionEvent): void {
+    try {
+      localExtensions.get(namespace)?.registration.onEvent(event);
+    } catch {
+      // One local extension must not break intercom or other extension channels.
+    }
+  }
+  function createExtensionChannel(namespace: string): IntercomExtensionChannel {
+    return {
+      namespace,
+      snapshot() {
+        const extension = localExtensions.get(namespace);
+        return {
+          connected: Boolean(client?.isConnected()),
+          supported: Boolean(client?.supportsFeature(EXTENSION_BUS_FEATURE)),
+          ...(extension?.owner ? { owner: extension.owner } : {}),
+          ...(extension?.state ? { state: extension.state } : {}),
+        };
+      },
+      publish(payload, options = {}) {
+        const activeClient = client;
+        if (!activeClient?.isConnected()) throw new Error("Intercom is not connected");
+        const extension = localExtensions.get(namespace);
+        const ownerOnly = options.ownerOnly ?? false;
+        const ownerEpoch = ownerOnly ? extension?.owner?.epoch : undefined;
+        if (ownerOnly && !ownerEpoch) throw new Error(`No owner is available for ${namespace}`);
+        activeClient.sendExtensionMessage({
+          type: "extension_publish",
+          namespace,
+          audience: options.audience ?? "owner",
+          ...(ownerOnly ? { ownerOnly: true, ownerEpoch } : {}),
+          payload,
+        });
+      },
+      commitState(payload, expectedRevision) {
+        const activeClient = client;
+        if (!activeClient?.isConnected()) throw new Error("Intercom is not connected");
+        const extension = localExtensions.get(namespace);
+        const ownerEpoch = extension?.owner?.epoch;
+        if (!ownerEpoch || extension.owner?.sessionId !== activeClient.sessionId) {
+          throw new Error(`Current session is not the owner of ${namespace}`);
+        }
+        activeClient.sendExtensionMessage({
+          type: "extension_state_commit",
+          namespace,
+          ownerEpoch,
+          expectedRevision: expectedRevision ?? extension.state?.revision ?? 0,
+          payload,
+        });
+      },
+      async listSessions() {
+        const activeClient = client;
+        if (!activeClient?.isConnected()) throw new Error("Intercom is not connected");
+        return activeClient.listSessions();
+      },
+    };
+  }
+  function currentExtensionCapabilities() {
+    return [...localExtensions.values()].map(({ registration }) => ({
+      namespace: registration.namespace,
+      ownerEligible: registration.ownerEligible,
+    }));
+  }
+  function registerLocalExtension(registration: IntercomExtensionRegistration): void {
+    if (!/^[a-z0-9][a-z0-9._/-]{0,63}$/.test(registration.namespace)) {
+      throw new Error(`Invalid intercom extension namespace: ${registration.namespace}`);
+    }
+    if (localExtensions.has(registration.namespace)) {
+      throw new Error(`Intercom extension namespace already registered: ${registration.namespace}`);
+    }
+    const channel = createExtensionChannel(registration.namespace);
+    localExtensions.set(registration.namespace, { registration, channel });
+    const activeClient = client;
+    const connected = Boolean(activeClient?.isConnected());
+    const supported = Boolean(activeClient?.supportsFeature(EXTENSION_BUS_FEATURE));
+    // Write the capability update before exposing a connected channel. Socket
+    // framing preserves this order if onReady publishes synchronously.
+    if (activeClient && connected && supported) {
+      activeClient.updateExtensionCapabilities(currentExtensionCapabilities());
+    }
+    registration.onReady(channel);
+    if (connected) {
+      emitLocalExtensionEvent(registration.namespace, { type: "connection", connected: true, supported });
+    }
+  }
+  function buildRegistration(): SessionRegistration {
     const liveContext = getLiveContext();
     if (!liveContext || !currentSessionId || sessionStartedAt === null) {
       throw new Error("Intercom runtime not initialized");
@@ -596,6 +697,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       startedAt: sessionStartedAt,
       lastActivity: Date.now(),
       status: currentStatus(),
+      ...(localExtensions.size > 0
+        ? {
+            extensions: currentExtensionCapabilities(),
+          }
+        : {}),
     };
   }
   // Snapshot the live session's context-window usage for presence. getContextUsage()
@@ -802,6 +908,73 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     })();
   }
   function attachClientHandlers(nextClient: IntercomClient): void {
+    nextClient.onBrokerMessage((message: BrokerMessage) => {
+      if (client !== nextClient) return;
+      switch (message.type) {
+        case "registered": {
+          const supported = message.features?.includes(EXTENSION_BUS_FEATURE) ?? false;
+          if (supported && localExtensions.size > 0) {
+            nextClient.updateExtensionCapabilities(currentExtensionCapabilities());
+          }
+          for (const namespace of localExtensions.keys()) {
+            emitLocalExtensionEvent(namespace, { type: "connection", connected: true, supported });
+          }
+          break;
+        }
+        case "extension_owner": {
+          const extension = localExtensions.get(message.namespace);
+          if (!extension) break;
+          extension.owner = message.ownerId && message.ownerEpoch
+            ? { sessionId: message.ownerId, epoch: message.ownerEpoch }
+            : undefined;
+          emitLocalExtensionEvent(message.namespace, { type: "owner", ...(extension.owner ? { owner: extension.owner } : {}) });
+          break;
+        }
+        case "extension_message": {
+          const extension = localExtensions.get(message.namespace);
+          if (!extension) break;
+          emitLocalExtensionEvent(message.namespace, {
+            type: "message",
+            fromSessionId: message.fromSessionId,
+            ...(message.ownerId && message.ownerEpoch
+              ? { owner: { sessionId: message.ownerId, epoch: message.ownerEpoch } }
+              : {}),
+            payload: message.payload,
+          });
+          break;
+        }
+        case "extension_state": {
+          const extension = localExtensions.get(message.namespace);
+          if (!extension) break;
+          extension.state = { revision: message.revision, payload: message.payload };
+          emitLocalExtensionEvent(message.namespace, { type: "state", state: extension.state });
+          break;
+        }
+        case "extension_state_result":
+          emitLocalExtensionEvent(message.namespace, {
+            type: "state_result",
+            committed: message.committed,
+            revision: message.revision,
+            ...(message.reason ? { reason: message.reason } : {}),
+          });
+          break;
+        case "session_joined":
+          for (const namespace of localExtensions.keys()) {
+            emitLocalExtensionEvent(namespace, { type: "session_joined", session: message.session });
+          }
+          break;
+        case "session_left":
+          for (const namespace of localExtensions.keys()) {
+            emitLocalExtensionEvent(namespace, { type: "session_left", sessionId: message.sessionId });
+          }
+          break;
+        case "presence_update":
+          for (const namespace of localExtensions.keys()) {
+            emitLocalExtensionEvent(namespace, { type: "presence_update", session: message.session });
+          }
+          break;
+      }
+    });
     nextClient.on("message", (from, message) => {
       const liveContext = getLiveContext();
       if (client !== nextClient || !liveContext) {
@@ -814,6 +987,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         return;
       }
       rejectReplyWaiter(new Error(`Disconnected while waiting for reply: ${error.message}`, { cause: error }));
+      for (const [namespace, extension] of localExtensions) {
+        extension.owner = undefined;
+        emitLocalExtensionEvent(namespace, { type: "connection", connected: false, supported: false });
+        emitLocalExtensionEvent(namespace, { type: "owner" });
+      }
       client = null;
       if (!shuttingDown && !disposed) {
         clearReconnectTimer();
@@ -1066,6 +1244,20 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       }
     })();
   }
+  const unsubscribeExtensionRegister = pi.events.on(INTERCOM_EXTENSION_REGISTER_EVENT, (payload) => {
+    if (!payload || typeof payload !== "object") return;
+    const registration = payload as Partial<IntercomExtensionRegistration>;
+    if (
+      typeof registration.namespace !== "string"
+      || typeof registration.ownerEligible !== "boolean"
+      || typeof registration.onEvent !== "function"
+      || typeof registration.onReady !== "function"
+    ) {
+      return;
+    }
+    registerLocalExtension(registration as IntercomExtensionRegistration);
+  });
+  pi.events.emit(INTERCOM_EXTENSION_REGISTRY_READY_EVENT, { version: 1 });
   const unsubscribeSubagentControlIntercom = pi.events.on(SUBAGENT_CONTROL_INTERCOM_EVENT, (payload) => {
     relaySubagentIntercomPayload(payload, {
       sender: "subagent-control",
@@ -1089,6 +1281,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   });
   
   pi.on("session_shutdown", async () => {
+    unsubscribeExtensionRegister();
     unsubscribeSubagentControlIntercom();
     unsubscribeSubagentResultIntercom();
     shuttingDown = true;

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -7,6 +7,7 @@ import { EventEmitter, once } from "node:events";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { ReplyTracker } from "./reply-tracker.ts";
 import type { Message, SessionInfo } from "./types.ts";
+import { INTERCOM_EXTENSION_REGISTER_EVENT, type IntercomExtensionChannel } from "./extension-api.ts";
 
 const repoDir = process.cwd();
 const childEnvKeys = [
@@ -343,7 +344,11 @@ test("opt-in TCP broker requires endpoint state for health and registration", { 
         lastActivity: Date.now(),
       },
     }, true);
-    assert.deepEqual(registerMessages, [{ type: "registered", sessionId: "authorized-tcp-client" }]);
+    assert.deepEqual(registerMessages, [{
+      type: "registered",
+      sessionId: "authorized-tcp-client",
+      features: ["extension-bus-v1"],
+    }]);
   } finally {
     if (broker.exitCode === null && broker.signalCode === null) {
       broker.kill("SIGTERM");
@@ -816,6 +821,30 @@ test("intercom tool prefers exact names over ID prefixes", { concurrency: false 
     await evilPrefix.disconnect().catch(() => undefined);
     await cleanup();
   }
+});
+
+test("extension channels register locally without creating conversation messages", async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const harness = createExtensionHarness();
+  let channel: IntercomExtensionChannel | undefined;
+  const extensionEvents: unknown[] = [];
+
+  piIntercomExtension(harness.pi as never);
+  harness.pi.events.emit(INTERCOM_EXTENSION_REGISTER_EVENT, {
+    namespace: "test-extension/v1",
+    ownerEligible: true,
+    onReady: (value: IntercomExtensionChannel) => { channel = value; },
+    onEvent: (event: unknown) => extensionEvents.push(event),
+  });
+
+  assert.equal(channel?.namespace, "test-extension/v1");
+  assert.deepEqual(channel?.snapshot(), {
+    connected: false,
+    supported: false,
+  });
+  assert.deepEqual(extensionEvents, []);
+  assert.deepEqual(harness.sentMessages, []);
+  assert.deepEqual(harness.entries, []);
 });
 
 test("intercom tool renders compact call and result rows", async () => {

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -847,6 +847,68 @@ test("extension channels register locally without creating conversation messages
   assert.deepEqual(harness.entries, []);
 });
 
+test("late extension registration advertises before an onReady publish", { concurrency: false }, async () => {
+  const { cleanup } = await setupClients();
+  const observer = new IntercomClient();
+  const observerMessages: BrokerMessage[] = [];
+  const harness = createExtensionHarness("late-extension-worker");
+  const extensionEvents: unknown[] = [];
+
+  try {
+    observer.onBrokerMessage((message) => observerMessages.push(message));
+    observer.on("error", () => {});
+    await observer.connect({
+      name: "extension-observer",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+      extensions: [{ namespace: "late-extension/v1", ownerEligible: false }],
+    });
+
+    const { default: piIntercomExtension } = await import("./index.ts");
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    await waitForSessionByName(observer, "late-extension-worker");
+
+    harness.pi.events.emit(INTERCOM_EXTENSION_REGISTER_EVENT, {
+      namespace: "late-extension/v1",
+      ownerEligible: true,
+      onReady: (channel: IntercomExtensionChannel) => {
+        channel.publish({ probe: "onReady" }, { audience: "capable" });
+      },
+      onEvent: (event: unknown) => extensionEvents.push(event),
+    });
+
+    const deadline = Date.now() + 3000;
+    while (
+      Date.now() < deadline
+      && !observerMessages.some((message) => message.type === "extension_message"
+        && (message.payload as { probe?: string }).probe === "onReady")
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(
+      observerMessages.some((message) => message.type === "extension_message"
+        && (message.payload as { probe?: string }).probe === "onReady"),
+      true,
+    );
+    assert.equal(
+      extensionEvents.some((event) => typeof event === "object" && event !== null
+        && (event as { type?: string }).type === "connection"
+        && (event as { connected?: boolean }).connected === true),
+      true,
+    );
+    assert.deepEqual(harness.sentMessages, []);
+    assert.deepEqual(harness.entries, []);
+    await harness.emitLifecycle("session_shutdown");
+  } finally {
+    await observer.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
 test("intercom tool renders compact call and result rows", async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const harness = createExtensionHarness();

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -6,7 +6,8 @@ import { tmpdir } from "node:os";
 import { EventEmitter, once } from "node:events";
 import { spawn, type ChildProcess } from "node:child_process";
 import { ReplyTracker } from "./reply-tracker.ts";
-import type { Message, SessionInfo } from "./types.ts";
+import type { BrokerMessage, Message, SessionInfo } from "./types.ts";
+import { INTERCOM_EXTENSION_REGISTER_EVENT, type IntercomExtensionChannel } from "./extension-api.ts";
 
 const repoDir = process.cwd();
 const childEnvKeys = [
@@ -349,7 +350,11 @@ test("opt-in TCP broker requires endpoint state for health and registration", { 
         lastActivity: Date.now(),
       },
     }, true);
-    assert.deepEqual(registerMessages, [{ type: "registered", sessionId: "authorized-tcp-client" }]);
+    assert.deepEqual(registerMessages, [{
+      type: "registered",
+      sessionId: "authorized-tcp-client",
+      features: ["extension-bus-v1"],
+    }]);
   } finally {
     if (broker.exitCode === null && broker.signalCode === null) {
       broker.kill("SIGTERM");
@@ -899,6 +904,92 @@ test("intercom tool points at the short id when names collide", { concurrency: f
   } finally {
     await twinA.disconnect().catch(() => undefined);
     await twinB.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("extension channels register locally without creating conversation messages", async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const harness = createExtensionHarness();
+  let channel: IntercomExtensionChannel | undefined;
+  const extensionEvents: unknown[] = [];
+
+  piIntercomExtension(harness.pi as never);
+  harness.pi.events.emit(INTERCOM_EXTENSION_REGISTER_EVENT, {
+    namespace: "test-extension/v1",
+    ownerEligible: true,
+    onReady: (value: IntercomExtensionChannel) => { channel = value; },
+    onEvent: (event: unknown) => extensionEvents.push(event),
+  });
+
+  assert.equal(channel?.namespace, "test-extension/v1");
+  assert.deepEqual(channel?.snapshot(), {
+    connected: false,
+    supported: false,
+  });
+  assert.deepEqual(extensionEvents, []);
+  assert.deepEqual(harness.sentMessages, []);
+  assert.deepEqual(harness.entries, []);
+});
+
+test("late extension registration advertises before an onReady publish", { concurrency: false }, async () => {
+  const { cleanup } = await setupClients();
+  const observer = new IntercomClient();
+  const observerMessages: BrokerMessage[] = [];
+  const harness = createExtensionHarness("late-extension-worker");
+  const extensionEvents: unknown[] = [];
+
+  try {
+    observer.onBrokerMessage((message) => observerMessages.push(message));
+    observer.on("error", () => {});
+    await observer.connect({
+      name: "extension-observer",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+      extensions: [{ namespace: "late-extension/v1", ownerEligible: false }],
+    });
+
+    const { default: piIntercomExtension } = await import("./index.ts");
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    await waitForSessionByName(observer, "late-extension-worker");
+
+    harness.pi.events.emit(INTERCOM_EXTENSION_REGISTER_EVENT, {
+      namespace: "late-extension/v1",
+      ownerEligible: true,
+      onReady: (channel: IntercomExtensionChannel) => {
+        channel.publish({ probe: "onReady" }, { audience: "capable" });
+      },
+      onEvent: (event: unknown) => extensionEvents.push(event),
+    });
+
+    const deadline = Date.now() + 3000;
+    while (
+      Date.now() < deadline
+      && !observerMessages.some((message) => message.type === "extension_message"
+        && (message.payload as { probe?: string }).probe === "onReady")
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(
+      observerMessages.some((message) => message.type === "extension_message"
+        && (message.payload as { probe?: string }).probe === "onReady"),
+      true,
+    );
+    assert.equal(
+      extensionEvents.some((event) => typeof event === "object" && event !== null
+        && (event as { type?: string }).type === "connection"
+        && (event as { connected?: boolean }).connected === true),
+      true,
+    );
+    assert.deepEqual(harness.sentMessages, []);
+    assert.deepEqual(harness.entries, []);
+    await harness.emitLifecycle("session_shutdown");
+  } finally {
+    await observer.disconnect().catch(() => undefined);
     await cleanup();
   }
 });

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "index.ts",
     "types.ts",
     "config.ts",
+    "extension-api.ts",
     "reply-tracker.ts",
     "broker/**/*.ts",
     "ui/**/*.ts",
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "types.ts",
     "config.ts",
     "cwd.ts",
+    "extension-api.ts",
     "format-context.ts",
     "reply-tracker.ts",
     "broker/**/*.ts",
@@ -16,7 +17,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/runtime-claim.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/runtime-claim.test.ts broker/spawn.test.ts config.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/types.ts
+++ b/types.ts
@@ -43,6 +43,7 @@ export type SessionRegistration = Omit<SessionInfo, "id" | "peerUid" | "trustedL
 export type ClientMessage =
   | { type: "register"; session: SessionRegistration; sessionId?: string; stateId?: string }
   | { type: "unregister" }
+  | { type: "extension_capabilities_update"; extensions: ExtensionCapability[] }
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }
   | { type: "cancel_ask"; messageId: string }

--- a/types.ts
+++ b/types.ts
@@ -79,8 +79,8 @@ export type BrokerMessage =
       type: "extension_message";
       namespace: string;
       fromSessionId: string;
-      ownerId: string;
-      ownerEpoch: string;
+      ownerId?: string;
+      ownerEpoch?: string;
       payload: unknown;
     }
   | {

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,5 @@
+export const EXTENSION_BUS_FEATURE = "extension-bus-v1";
+
 export interface SessionInfo {
   id: string;
   name?: string;
@@ -29,7 +31,14 @@ export interface Attachment {
   language?: string;
 }
 
-export type SessionRegistration = Omit<SessionInfo, "id" | "peerUid" | "trustedLocal">;
+export interface ExtensionCapability {
+  namespace: string;
+  ownerEligible: boolean;
+}
+
+export type SessionRegistration = Omit<SessionInfo, "id" | "peerUid" | "trustedLocal"> & {
+  extensions?: ExtensionCapability[];
+};
 
 export type ClientMessage =
   | { type: "register"; session: SessionRegistration; sessionId?: string; stateId?: string }
@@ -37,10 +46,25 @@ export type ClientMessage =
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }
   | { type: "cancel_ask"; messageId: string }
-  | { type: "presence"; name?: string; status?: string; model?: string };
+  | { type: "presence"; name?: string; status?: string; model?: string }
+  | {
+      type: "extension_publish";
+      namespace: string;
+      audience: "owner" | "capable";
+      ownerEpoch?: string;
+      ownerOnly?: boolean;
+      payload: unknown;
+    }
+  | {
+      type: "extension_state_commit";
+      namespace: string;
+      ownerEpoch: string;
+      expectedRevision: number;
+      payload: unknown;
+    };
 
 export type BrokerMessage =
-  | { type: "registered"; sessionId: string }
+  | { type: "registered"; sessionId: string; features?: string[] }
   | { type: "sessions"; requestId: string; sessions: SessionInfo[] }
   | { type: "message"; from: SessionInfo; message: Message }
   | { type: "presence_update"; session: SessionInfo }
@@ -48,4 +72,26 @@ export type BrokerMessage =
   | { type: "session_left"; sessionId: string }
   | { type: "error"; error: string }
   | { type: "delivered"; messageId: string }
-  | { type: "delivery_failed"; messageId: string; reason: string };
+  | { type: "delivery_failed"; messageId: string; reason: string }
+  | { type: "extension_owner"; namespace: string; ownerId?: string; ownerEpoch?: string }
+  | {
+      type: "extension_message";
+      namespace: string;
+      fromSessionId: string;
+      ownerId: string;
+      ownerEpoch: string;
+      payload: unknown;
+    }
+  | {
+      type: "extension_state";
+      namespace: string;
+      revision: number;
+      payload: unknown;
+    }
+  | {
+      type: "extension_state_result";
+      namespace: string;
+      committed: boolean;
+      revision: number;
+      reason?: string;
+    };

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,5 @@
+export const EXTENSION_BUS_FEATURE = "extension-bus-v1";
+
 export interface SessionInfo {
   id: string;
   name?: string;
@@ -37,23 +39,41 @@ export interface Attachment {
   language?: string;
 }
 
-export type SessionRegistration = Omit<SessionInfo, "id" | "peerUid" | "trustedLocal">;
+export interface ExtensionCapability {
+  namespace: string;
+  ownerEligible: boolean;
+}
+
+export type SessionRegistration = Omit<SessionInfo, "id" | "peerUid" | "trustedLocal"> & {
+  extensions?: ExtensionCapability[];
+};
 
 export type ClientMessage =
   | { type: "register"; session: SessionRegistration; sessionId?: string; stateId?: string }
   | { type: "unregister" }
+  | { type: "extension_capabilities_update"; extensions: ExtensionCapability[] }
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }
   | { type: "cancel_ask"; messageId: string }
-  // presence carries optional context-usage fields so peers see each session's
-  // live context% without a separate query. contextPct/contextTokens/contextWindow
-  // accept null as an explicit CLEAR signal (post-compaction the value is unknown
-  // until the next assistant response); the broker deletes the field rather than
-  // carrying the stale value forward.
-  | { type: "presence"; name?: string; status?: string; model?: string; contextPct?: number | null; contextTokens?: number | null; contextWindow?: number | null };
+  | { type: "presence"; name?: string; status?: string; model?: string; contextPct?: number | null; contextTokens?: number | null; contextWindow?: number | null }
+  | {
+      type: "extension_publish";
+      namespace: string;
+      audience: "owner" | "capable";
+      ownerEpoch?: string;
+      ownerOnly?: boolean;
+      payload: unknown;
+    }
+  | {
+      type: "extension_state_commit";
+      namespace: string;
+      ownerEpoch: string;
+      expectedRevision: number;
+      payload: unknown;
+    };
 
 export type BrokerMessage =
-  | { type: "registered"; sessionId: string }
+  | { type: "registered"; sessionId: string; features?: string[] }
   | { type: "sessions"; requestId: string; sessions: SessionInfo[] }
   | { type: "message"; from: SessionInfo; message: Message }
   | { type: "presence_update"; session: SessionInfo }
@@ -61,4 +81,26 @@ export type BrokerMessage =
   | { type: "session_left"; sessionId: string }
   | { type: "error"; error: string }
   | { type: "delivered"; messageId: string }
-  | { type: "delivery_failed"; messageId: string; reason: string };
+  | { type: "delivery_failed"; messageId: string; reason: string }
+  | { type: "extension_owner"; namespace: string; ownerId?: string; ownerEpoch?: string }
+  | {
+      type: "extension_message";
+      namespace: string;
+      fromSessionId: string;
+      ownerId?: string;
+      ownerEpoch?: string;
+      payload: unknown;
+    }
+  | {
+      type: "extension_state";
+      namespace: string;
+      revision: number;
+      payload: unknown;
+    }
+  | {
+      type: "extension_state_result";
+      namespace: string;
+      committed: boolean;
+      revision: number;
+      reason?: string;
+    };


### PR DESCRIPTION
## Summary

Maintainer rebase for the accepted-in-principle #69 extension bus feature:

- adds capability-negotiated, namespaced channels for silent extension coordination
- elects socket-bound namespace owners and rejects stale owner-only writes
- persists bounded opaque state with compare-and-swap revisions and backup recovery
- supports late capability sync and keeps extension traffic out of Pi messages/transcripts
- reconciles the branch with stable IDs, `list-cwd`, and context-presence changes already on main

Credit: thanks to Kieran Bond for PR #69.

## Validation

- `npm test` — 121/121 passed
- `git diff --check`
- `npm pack --dry-run` — includes `extension-api.ts` and extension bus runtime files