### PR TITLE
fix: add intercom delivery diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+- Added protocol-visible delivery metadata, receiver lifecycle receipts, receiver-side inbound message dedupe, and clearer ask-timeout receipts for ordered delivery diagnostics. Thanks to Donnie Thomas for issue #65.
+
 ## [0.8.0] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ This matters because the agent receiving the message doesn't need to reconstruct
 
 `reply` is receiver-side sugar for replying to an inbound ask. In the turn triggered by an incoming intercom ask, `intercom({ action: "reply", message: "..." })` targets that exact sender and message automatically. If you reply later, it falls back to the single unresolved inbound ask. If multiple asks are pending, use `intercom({ action: "pending" })` to inspect them and then call `reply` with `to` to disambiguate.
 
+Incoming messages now carry diagnostic metadata end to end: stable message ID, sender sequence, sender timestamp, broker receive/delivery timestamps, receiver receive timestamp, and injection timestamp. Receivers emit lifecycle receipts for `receiver_received`, `acknowledged`, `queued`, `injected`, and `expired`; duplicate message IDs are acknowledged but injected at most once per receiving session. If an `ask` times out, the timeout names the message ID and last known delivery state. Timeout is not cancellation: the recipient may still have the message queued or actionable unless an explicit cancellation path says otherwise.
+
 The planner typically uses `send`. If you prefer manual approval for outgoing non-reply messages, turn on `confirmSend: true`. The worker uses `ask` for everything (no confirmation needed, gets answers inline), so it can operate autonomously either way.
 
 ## Workflow: Subagent-to-Supervisor Escalation

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -16,7 +16,7 @@ import {
 } from "./paths.ts";
 import { getAskTimeoutMs } from "../config.ts";
 import { EXTENSION_BUS_FEATURE } from "../types.ts";
-import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration, ExtensionCapability } from "../types.ts";
+import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration, ExtensionCapability, MessageReceipt, MessageReceiptStatus } from "../types.ts";
 import { ExtensionStateManager } from "./extension-state.ts";
 import { assertNoLiveBroker } from "./runtime-claim.ts";
 
@@ -34,6 +34,7 @@ const PRESENCE_HEARTBEAT_MS = 1000;
 const MAX_EXTENSIONS_PER_SESSION = 32;
 const MAX_EXTENSION_MESSAGE_BYTES = 16 * 1024;
 const MAX_EXTENSION_STATE_BYTES = 64 * 1024;
+const MESSAGE_RECEIPT_ROUTE_RETENTION_MS = 60 * 60 * 1000;
 
 function serializedPayloadSize(payload: unknown): number | null {
   try {
@@ -70,6 +71,32 @@ interface AskEdge {
   createdAt: number;
 }
 
+interface MessageReceiptRoute {
+  from: string;
+  to: string;
+  createdAt: number;
+}
+
+function isMessageReceiptStatus(value: unknown): value is MessageReceiptStatus {
+  return value === "receiver_received"
+    || value === "queued"
+    || value === "injected"
+    || value === "acknowledged"
+    || value === "expired"
+    || value === "cancelled";
+}
+
+function isMessageReceipt(value: unknown): value is MessageReceipt {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const receipt = value as Record<string, unknown>;
+  if (typeof receipt.messageId !== "string" || !isMessageReceiptStatus(receipt.status) || typeof receipt.timestamp !== "number") {
+    return false;
+  }
+  return receipt.detail === undefined || typeof receipt.detail === "string";
+}
+
 function isAttachment(value: unknown): value is Attachment {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -101,6 +128,12 @@ function isMessage(value: unknown): value is Message {
 
   if (typeof message.id !== "string" || typeof message.timestamp !== "number") {
     return false;
+  }
+
+  for (const key of ["senderSequence", "brokerReceivedAt", "brokerDeliveredAt", "receiverReceivedAt", "injectedAt"] as const) {
+    if (message[key] !== undefined && typeof message[key] !== "number") {
+      return false;
+    }
   }
 
   if (message.replyTo !== undefined && typeof message.replyTo !== "string") {
@@ -155,6 +188,7 @@ function isSessionRegistration(value: unknown): value is SessionRegistration {
 class IntercomBroker {
   private sessions = new Map<string, ConnectedSession>();
   private askEdges = new Map<string, AskEdge>();
+  private messageReceiptRoutes = new Map<string, MessageReceiptRoute>();
   private connections = new Set<net.Socket>();
   private unregisteredConnections = new Set<net.Socket>();
   private server: net.Server;
@@ -270,6 +304,7 @@ class IntercomBroker {
         if (existing?.socket === socket) {
           this.sessions.delete(sessionId);
           this.clearAskEdgesForSession(sessionId);
+          this.clearMessageReceiptRoutesForSession(sessionId);
           this.broadcast({ type: "session_left", sessionId }, sessionId);
           this.recomputeNamespaceOwners();
           this.scheduleShutdownCheck();
@@ -400,6 +435,7 @@ class IntercomBroker {
         }
         if (previous) {
           this.clearAskEdgesForSession(id);
+          this.clearMessageReceiptRoutesForSession(id);
           previous.socket.end();
         }
         setId(id);
@@ -470,6 +506,7 @@ class IntercomBroker {
         if (existing?.socket === socket) {
           this.sessions.delete(currentId);
           this.clearAskEdgesForSession(currentId);
+          this.clearMessageReceiptRoutesForSession(currentId);
           this.broadcast({ type: "session_left", sessionId: currentId }, currentId);
           this.recomputeNamespaceOwners();
           this.scheduleShutdownCheck();
@@ -543,6 +580,7 @@ class IntercomBroker {
           break;
         }
 
+        const brokerReceivedAt = Date.now();
         this.pruneAskEdges();
         const replyEdge = message.replyTo ? this.askEdges.get(message.replyTo) : undefined;
 
@@ -586,14 +624,20 @@ class IntercomBroker {
             }
             this.askEdges.set(message.id, { from: currentId, to: target.info.id, createdAt: Date.now() });
           }
+          const deliveredMessage: Message = {
+            ...message,
+            brokerReceivedAt,
+            brokerDeliveredAt: Date.now(),
+          };
           writeMessage(target.socket, {
             type: "message",
             from: fromSession.info,
-            message,
+            message: deliveredMessage,
           });
           if (message.replyTo) {
             this.askEdges.delete(message.replyTo);
           }
+          this.messageReceiptRoutes.set(message.id, { from: currentId, to: target.info.id, createdAt: brokerReceivedAt });
           writeMessage(socket, { type: "delivered", messageId: message.id });
           break;
         }
@@ -612,6 +656,27 @@ class IntercomBroker {
           messageId: message.id,
           reason: "Session not found",
         });
+        break;
+      }
+
+      case "message_receipt": {
+        if (!currentId) {
+          throw new Error("Received message_receipt before register");
+        }
+        if (!isMessageReceipt(clientMessage.receipt)) {
+          throw new Error("Invalid message_receipt message");
+        }
+        this.pruneMessageReceiptRoutes();
+        const route = this.messageReceiptRoutes.get(clientMessage.receipt.messageId);
+        const receiver = this.sessions.get(currentId);
+        const sender = route ? this.sessions.get(route.from) : undefined;
+        if (route?.to === currentId && receiver?.socket === socket && sender) {
+          writeMessage(sender.socket, {
+            type: "message_receipt",
+            from: receiver.info,
+            receipt: clientMessage.receipt,
+          });
+        }
         break;
       }
 
@@ -734,6 +799,22 @@ class IntercomBroker {
     for (const [messageId, edge] of this.askEdges) {
       if (edge.from === sessionId || edge.to === sessionId) {
         this.askEdges.delete(messageId);
+      }
+    }
+  }
+
+  private pruneMessageReceiptRoutes(now = Date.now()): void {
+    for (const [messageId, route] of this.messageReceiptRoutes) {
+      if (now - route.createdAt > MESSAGE_RECEIPT_ROUTE_RETENTION_MS) {
+        this.messageReceiptRoutes.delete(messageId);
+      }
+    }
+  }
+
+  private clearMessageReceiptRoutesForSession(sessionId: string): void {
+    for (const [messageId, route] of this.messageReceiptRoutes) {
+      if (route.from === sessionId || route.to === sessionId) {
+        this.messageReceiptRoutes.delete(messageId);
       }
     }
   }

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -9,6 +9,8 @@ import type {
   BrokerMessage,
   ClientMessage,
   Message,
+  MessageReceipt,
+  MessageReceiptStatus,
   SessionInfo,
   SessionRegistration,
 } from "../types.ts";
@@ -35,6 +37,26 @@ function connectToBrokerTarget(target: BrokerConnectTarget): net.Socket {
   return typeof target === "string"
     ? net.connect(target)
     : net.connect({ host: target.host, port: target.port });
+}
+
+function isMessageReceiptStatus(value: unknown): value is MessageReceiptStatus {
+  return value === "receiver_received"
+    || value === "queued"
+    || value === "injected"
+    || value === "acknowledged"
+    || value === "expired"
+    || value === "cancelled";
+}
+
+function isMessageReceipt(value: unknown): value is MessageReceipt {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const receipt = value as Record<string, unknown>;
+  if (typeof receipt.messageId !== "string" || !isMessageReceiptStatus(receipt.status) || typeof receipt.timestamp !== "number") {
+    return false;
+  }
+  return receipt.detail === undefined || typeof receipt.detail === "string";
 }
 
 function isAttachment(value: unknown): value is Attachment {
@@ -68,6 +90,12 @@ function isMessage(value: unknown): value is Message {
 
   if (typeof message.id !== "string" || typeof message.timestamp !== "number") {
     return false;
+  }
+
+  for (const key of ["senderSequence", "brokerReceivedAt", "brokerDeliveredAt", "receiverReceivedAt", "injectedAt"] as const) {
+    if (message[key] !== undefined && typeof message[key] !== "number") {
+      return false;
+    }
   }
 
   if (message.replyTo !== undefined && typeof message.replyTo !== "string") {
@@ -136,6 +164,7 @@ export class IntercomClient extends EventEmitter {
   private _features = new Set<string>();
   private pendingSends = new Map<string, { resolve: (r: SendResult) => void; reject: (e: Error) => void }>();
   private pendingLists = new Map<string, { resolve: (sessions: SessionInfo[]) => void; reject: (e: Error) => void }>();
+  private nextSenderSequence = 1;
   private disconnecting = false;
   private disconnectError: Error | null = null;
 
@@ -413,6 +442,15 @@ export class IntercomClient extends EventEmitter {
         break;
       }
 
+      case "message_receipt": {
+        if (!isSessionInfo(brokerMessage.from) || !isMessageReceipt(brokerMessage.receipt)) {
+          throw new Error("Invalid message_receipt event");
+        }
+        this.emit("broker_message", brokerMessage as BrokerMessage);
+        this.emit("message_receipt", brokerMessage.from, brokerMessage.receipt);
+        break;
+      }
+
       case "session_joined": {
         if (!isSessionInfo(brokerMessage.session)) {
           throw new Error("Invalid session_joined message");
@@ -620,6 +658,7 @@ export class IntercomClient extends EventEmitter {
     const message: Message = {
       id: messageId,
       timestamp: Date.now(),
+      senderSequence: this.nextSenderSequence++,
       replyTo: options.replyTo,
       expectsReply: options.expectsReply,
       content: {
@@ -653,6 +692,19 @@ export class IntercomClient extends EventEmitter {
         reject(toError(error));
       }
     });
+  }
+
+  sendMessageReceipt(receipt: MessageReceipt): void {
+    if (this.disconnecting) {
+      return;
+    }
+
+    const socket = this.socket;
+    if (!socket || !this._sessionId || socket.destroyed || socket.writableEnded || !socket.writable) {
+      return;
+    }
+
+    writeMessage(socket, { type: "message_receipt", receipt });
   }
 
   cancelAsk(messageId: string): void {
@@ -696,5 +748,10 @@ export class IntercomClient extends EventEmitter {
   onBrokerMessage(handler: (message: BrokerMessage) => void): () => void {
     this.on("broker_message", handler);
     return () => this.off("broker_message", handler);
+  }
+
+  onMessageReceipt(handler: (from: SessionInfo, receipt: MessageReceipt) => void): () => void {
+    this.on("message_receipt", handler);
+    return () => this.off("message_receipt", handler);
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
 import { InlineMessageComponent } from "./ui/inline-message.ts";
 import { getAskTimeoutMs, loadConfig, type IntercomConfig } from "./config.ts";
 import { EXTENSION_BUS_FEATURE } from "./types.ts";
-import type { Attachment, BrokerMessage, Message, SessionInfo, SessionRegistration } from "./types.ts";
+import type { Attachment, BrokerMessage, Message, MessageReceiptStatus, SessionInfo, SessionRegistration } from "./types.ts";
 import {
   INTERCOM_EXTENSION_REGISTER_EVENT,
   INTERCOM_EXTENSION_REGISTRY_READY_EVENT,
@@ -30,6 +30,8 @@ const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
 const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delivery";
 const INBOUND_FLUSH_DELAY_MS = 200;
 const INBOUND_IDLE_RETRY_MS = 500;
+const INBOUND_MESSAGE_DEDUPE_MAX = 1000;
+const INBOUND_MESSAGE_DEDUPE_RETENTION_MS = 60 * 60 * 1000;
 const DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX = "subagent-chat";
 const SUBAGENT_ORCHESTRATOR_TARGET_ENV = "PI_SUBAGENT_ORCHESTRATOR_TARGET";
 const SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV = "PI_SUBAGENT_ORCHESTRATOR_SESSION_ID";
@@ -438,6 +440,22 @@ function previewText(value: unknown, maxLength = 72): string | undefined {
 function firstTextContent(result: { content?: Array<{ type: string; text?: string }> }): string {
   return result.content?.find((item) => item.type === "text" && typeof item.text === "string")?.text?.replace(/\*\*/g, "") ?? "";
 }
+function formatMessageTimestamp(timestamp: number | undefined): string | undefined {
+  return typeof timestamp === "number" && Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : undefined;
+}
+function formatInboundDeliveryMetadata(message: Message): string {
+  const parts = [`id ${message.id}`];
+  if (typeof message.senderSequence === "number") parts.push(`seq ${message.senderSequence}`);
+  const sentAt = formatMessageTimestamp(message.timestamp);
+  if (sentAt) parts.push(`sent ${sentAt}`);
+  const brokerDeliveredAt = formatMessageTimestamp(message.brokerDeliveredAt);
+  if (brokerDeliveredAt) parts.push(`broker delivered ${brokerDeliveredAt}`);
+  const receiverReceivedAt = formatMessageTimestamp(message.receiverReceivedAt);
+  if (receiverReceivedAt) parts.push(`receiver received ${receiverReceivedAt}`);
+  const injectedAt = formatMessageTimestamp(message.injectedAt);
+  if (injectedAt) parts.push(`injected ${injectedAt}`);
+  return parts.join(" · ");
+}
 function getNamePollMs(): number {
   const configured = process.env[NAME_POLL_MS_ENV];
   if (configured !== undefined) {
@@ -479,10 +497,55 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   const activeTools = new Map<string, string>();
   const replyTracker = new ReplyTracker();
   const pendingIdleMessages: InboundMessageEntry[] = [];
+  const seenInboundMessages = new Map<string, number>();
+  const latestOutboundReceipts = new Map<string, { status: MessageReceiptStatus; timestamp: number; detail?: string }>();
   function dismissIncomingAsk(messageId: string): void {
     replyTracker.dismissPendingAsk(messageId);
     const queuedIndex = pendingIdleMessages.findIndex((entry) => entry.message.id === messageId);
     if (queuedIndex >= 0) pendingIdleMessages.splice(queuedIndex, 1);
+  }
+  function expirePendingIdleMessages(detail: string): void {
+    for (const entry of pendingIdleMessages) {
+      emitMessageReceipt(entry.message.id, "expired", detail);
+    }
+    pendingIdleMessages.length = 0;
+  }
+  function hasSeenInboundMessage(from: SessionInfo, message: Message, now = Date.now()): boolean {
+    for (const [key, seenAt] of seenInboundMessages) {
+      if (now - seenAt > INBOUND_MESSAGE_DEDUPE_RETENTION_MS) {
+        seenInboundMessages.delete(key);
+      }
+    }
+    const key = `${from.id}\0${message.id}`;
+    if (seenInboundMessages.has(key)) {
+      return true;
+    }
+    seenInboundMessages.set(key, now);
+    while (seenInboundMessages.size > INBOUND_MESSAGE_DEDUPE_MAX) {
+      const oldestKey = seenInboundMessages.keys().next().value;
+      if (typeof oldestKey !== "string") break;
+      seenInboundMessages.delete(oldestKey);
+    }
+    return false;
+  }
+  function emitMessageReceipt(messageId: string, status: MessageReceiptStatus, detail?: string): void {
+    try {
+      client?.sendMessageReceipt({
+        messageId,
+        status,
+        timestamp: Date.now(),
+        ...(detail ? { detail } : {}),
+      });
+    } catch {
+      // Receipts are diagnostics; message handling should not fail when the sender disconnects.
+    }
+  }
+  function latestDeliveryState(messageId: string | null, fallback: string): string {
+    if (!messageId) {
+      return fallback;
+    }
+    const receipt = latestOutboundReceipts.get(messageId);
+    return receipt ? receipt.status : fallback;
   }
   let inboundFlushTimer: NodeJS.Timeout | null = null;
   let replyWaiter: {
@@ -491,7 +554,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     resolve: (message: Message) => void;
     reject: (error: Error) => void;
   } | null = null;
-  function waitForReply(from: string, replyTo: string, signal?: AbortSignal, onCancel?: () => void): Promise<Message> {
+  function waitForReply(from: string, replyTo: string, signal?: AbortSignal, cancelOnAbort?: () => void, getDeliveryState: () => string = () => "unknown"): Promise<Message> {
     if (replyWaiter) {
       return Promise.reject(new Error("Already waiting for a reply"));
     }
@@ -500,9 +563,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
-        onCancel?.();
         const timeoutDescription = askTimeoutMs % 60000 === 0 ? `${askTimeoutMs / 60000} minutes` : `${askTimeoutMs}ms`;
-        rejectReplyWaiter(new Error(`No reply from "${from}" within ${timeoutDescription}`));
+        rejectReplyWaiter(new Error(`No reply from "${from}" for message ${replyTo} within ${timeoutDescription}. Last known delivery state: ${getDeliveryState()}. This waiter timeout is not cancellation; the delivered message may still be queued or actionable in the recipient session.`));
       }, askTimeoutMs);
       const cleanup = () => {
         clearTimeout(timeout);
@@ -512,7 +574,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         }
       };
       const onAbort = () => {
-        onCancel?.();
+        cancelOnAbort?.();
         cleanup();
         reject(new Error("Cancelled"));
       };
@@ -793,17 +855,21 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     if (runtimeStarted && !getLiveContext(runtimeContext, generation)) {
       return;
     }
+    const injectedMessage = { ...entry.message, injectedAt: Date.now() };
+    emitMessageReceipt(injectedMessage.id, "injected");
+    const deliveredEntry = { ...entry, message: injectedMessage };
     if (delivery !== "followUp") {
-      replyTracker.queueTurnContext({ from: entry.from, message: entry.message, receivedAt: Date.now() });
+      replyTracker.queueTurnContext({ from: entry.from, message: injectedMessage, receivedAt: Date.now() });
     }
     const senderDisplay = entry.from.name || entry.from.id.slice(0, 8);
     const replyInstruction = entry.replyCommand ? `\n\nTo reply, use the intercom tool: ${entry.replyCommand}` : "";
+    const deliveryMetadata = formatInboundDeliveryMetadata(injectedMessage);
     pi.sendMessage(
       {
         customType: "intercom_message",
-        content: `**📨 From ${senderDisplay}** (${entry.from.cwd})${replyInstruction}\n\n${entry.bodyText}`,
+        content: `**📨 From ${senderDisplay}** (${entry.from.cwd})${replyInstruction}\n\n_${deliveryMetadata}_\n\n${entry.bodyText}`,
         display: true,
-        details: entry,
+        details: deliveredEntry,
       },
       delivery === "trigger" && shouldTriggerInboundMessage(entry, forceTrigger)
         ? { triggerTurn: true }
@@ -849,6 +915,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   }
   function queueIdleMessage(entry: InboundMessageEntry): void {
     pendingIdleMessages.push(entry);
+    emitMessageReceipt(entry.message.id, "queued");
     scheduleInboundFlush();
   }
   function handleIncomingMessage(ctx: ExtensionContext, from: SessionInfo, message: Message): void {
@@ -857,25 +924,34 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     if (!liveContext) {
       return;
     }
+    const receiverReceivedAt = Date.now();
+    if (hasSeenInboundMessage(from, message, receiverReceivedAt)) {
+      emitMessageReceipt(message.id, "acknowledged", "duplicate message id suppressed");
+      return;
+    }
+    const receivedMessage = { ...message, receiverReceivedAt };
+    emitMessageReceipt(receivedMessage.id, "receiver_received");
     if (replyWaiter) {
       const senderTarget = from.name || from.id;
       const fromMatches = senderTarget.toLowerCase() === replyWaiter.from.toLowerCase()
         || from.id === replyWaiter.from;
-      const replyMatches = message.replyTo === replyWaiter.replyTo;
+      const replyMatches = receivedMessage.replyTo === replyWaiter.replyTo;
       if (fromMatches && replyMatches) {
-        replyWaiter.resolve(message);
+        emitMessageReceipt(receivedMessage.id, "acknowledged", "matched reply waiter");
+        replyWaiter.resolve(receivedMessage);
         return;
       }
     }
-    const attachmentText = message.content.attachments?.length
-      ? formatAttachments(message.content.attachments)
+    const attachmentText = receivedMessage.content.attachments?.length
+      ? formatAttachments(receivedMessage.content.attachments)
       : "";
-    const bodyText = `${message.content.text}${attachmentText}`;
-    const replyCommand = config.replyHint && message.expectsReply
+    const bodyText = `${receivedMessage.content.text}${attachmentText}`;
+    const replyCommand = config.replyHint && receivedMessage.expectsReply
       ? `intercom({ action: "reply", message: "..." })`
       : undefined;
-    replyTracker.recordIncomingMessage(from, message);
-    const entry = { from, message, replyCommand, bodyText };
+    replyTracker.recordIncomingMessage(from, receivedMessage, receiverReceivedAt);
+    emitMessageReceipt(receivedMessage.id, "acknowledged", "accepted by receiver");
+    const entry = { from, message: receivedMessage, replyCommand, bodyText };
     void (async () => {
       const activeContext = getLiveContext(liveContext, messageGeneration);
       if (!activeContext) {
@@ -956,6 +1032,13 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
             committed: message.committed,
             revision: message.revision,
             ...(message.reason ? { reason: message.reason } : {}),
+          });
+          break;
+        case "message_receipt":
+          latestOutboundReceipts.set(message.receipt.messageId, {
+            status: message.receipt.status,
+            timestamp: message.receipt.timestamp,
+            ...(message.receipt.detail ? { detail: message.receipt.detail } : {}),
           });
           break;
         case "session_joined":
@@ -1136,10 +1219,6 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   }
   function startSessionRuntime(ctx: ExtensionContext): void {
     const previousClient = client;
-    if (previousClient) {
-      client = null;
-      void previousClient.disconnect().catch(() => undefined);
-    }
     shuttingDown = false;
     disposed = false;
     runtimeStarted = true;
@@ -1151,7 +1230,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     clearInboundFlushTimer();
     rejectReplyWaiter(new Error("Session replaced"));
     replyTracker.reset();
-    pendingIdleMessages.length = 0;
+    expirePendingIdleMessages("receiver session replaced before injection");
+    if (previousClient) {
+      client = null;
+      void previousClient.disconnect().catch(() => undefined);
+    }
     runtimeContext = ctx;
     currentSessionId = ctx.sessionManager.getSessionId();
     currentIntercomSessionId = resolveConfiguredIntercomSessionId(currentSessionId, config);
@@ -1293,7 +1376,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     restoreIntercomSessionId();
     rejectReplyWaiter(new Error("Session shutting down"));
     replyTracker.reset();
-    pendingIdleMessages.length = 0;
+    expirePendingIdleMessages("receiver session shut down before injection");
     clearInboundFlushTimer();
     agentRunning = false;
     activeTools.clear();
@@ -1536,9 +1619,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         }
 
         let replyPromise: Promise<Message> | null = null;
+        let deliveryState = "created";
+        let questionId: string | null = null;
         try {
-          const questionId = randomUUID();
-          replyPromise = waitForReply(sendTo, questionId, signal, () => connectedClient.cancelAsk(questionId));
+          questionId = randomUUID();
+          replyPromise = waitForReply(sendTo, questionId, signal, () => connectedClient.cancelAsk(questionId!), () => latestDeliveryState(questionId, deliveryState));
           replyPromise.catch(() => undefined);
           if (signal?.aborted) {
             rejectReplyWaiter(new Error("Cancelled"));
@@ -1560,6 +1645,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
             text: requestText,
             expectsReply: true,
           });
+          deliveryState = sendResult.delivered ? "socket_delivered" : "delivery_failed";
           if (!sendResult.delivered) {
             const errorText = sendResult.reason ?? "Session may not exist or has disconnected.";
             rejectReplyWaiter(new Error(`Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}`));
@@ -1618,7 +1704,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
           }
           return {
             content: [{ type: "text", text: `Failed: ${getErrorMessage(error)}` }],
-            details: { error: true },
+            details: { error: true, ...(questionId ? { messageId: questionId, deliveryState: latestDeliveryState(questionId, deliveryState) } : {}) },
           };
         }
       },
@@ -1887,6 +1973,8 @@ Usage:
             };
           }
           let replyPromise: Promise<Message> | null = null;
+          let deliveryState = "created";
+          let questionId: string | null = null;
 
           try {
             const sendTo = await resolveSessionTarget(connectedClient, to) ?? to;
@@ -1908,8 +1996,8 @@ Usage:
                 details: { error: true },
               };
             }
-            const questionId = randomUUID();
-            replyPromise = waitForReply(sendTo, questionId, _signal, () => connectedClient.cancelAsk(questionId));
+            questionId = randomUUID();
+            replyPromise = waitForReply(sendTo, questionId, _signal, () => connectedClient.cancelAsk(questionId!), () => latestDeliveryState(questionId, deliveryState));
             replyPromise.catch(() => undefined);
             const sendResult = await connectedClient.send(sendTo, {
               messageId: questionId,
@@ -1919,6 +2007,7 @@ Usage:
               expectsReply: true,
             });
 
+            deliveryState = sendResult.delivered ? "socket_delivered" : "delivery_failed";
             if (!sendResult.delivered) {
               const errorText = sendResult.reason ?? "Session may not exist or has disconnected.";
               rejectReplyWaiter(new Error(`Message to "${to}" was not delivered: ${errorText}`));
@@ -1966,7 +2055,7 @@ Usage:
             }
             return {
               content: [{ type: "text", text: `Failed: ${getErrorMessage(error)}` }],
-              details: { error: true },
+              details: { error: true, ...(questionId ? { messageId: questionId, deliveryState: latestDeliveryState(questionId, deliveryState) } : {}) },
             };
           }
         }

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -1210,6 +1210,99 @@ test("busy interactive sessions idle-gate top-level asks without aborting", { co
   }
 });
 
+test("duplicate inbound message IDs inject once with visible delivery metadata", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { planner, cleanup } = await setupClients();
+  const harness = createExtensionHarness("dedupe-worker", { hasUI: true });
+
+  try {
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    const worker = await waitForSessionByName(planner, "dedupe-worker");
+    const receipts: string[] = [];
+    const unsubscribeReceipts = planner.onMessageReceipt((_from, receipt) => {
+      if (receipt.messageId === "duplicate-inbound") receipts.push(receipt.detail ? `${receipt.status}:${receipt.detail}` : receipt.status);
+    });
+
+    try {
+      assert.equal((await planner.send(worker.id, { messageId: "duplicate-inbound", text: "First copy" })).delivered, true);
+      assert.equal((await planner.send(worker.id, { messageId: "duplicate-inbound", text: "Second copy" })).delivered, true);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    } finally {
+      unsubscribeReceipts();
+    }
+
+    assert.equal(harness.sentMessages.length, 1);
+    assert.ok(receipts.includes("receiver_received"));
+    assert.ok(receipts.includes("acknowledged:accepted by receiver"));
+    assert.ok(receipts.includes("injected"));
+    assert.ok(receipts.includes("acknowledged:duplicate message id suppressed"));
+    const sent = harness.sentMessages[0]!;
+    assert.match(sent.message.content ?? "", /id duplicate-inbound/);
+    assert.match(sent.message.content ?? "", /seq 1/);
+    assert.match(sent.message.content ?? "", /broker delivered/);
+    assert.match(sent.message.content ?? "", /receiver received/);
+    assert.match(sent.message.content ?? "", /injected/);
+    const details = sent.message.details as { message?: Message };
+    assert.equal(details.message?.id, "duplicate-inbound");
+    assert.equal(details.message?.senderSequence, 1);
+    assert.equal(typeof details.message?.brokerReceivedAt, "number");
+    assert.equal(typeof details.message?.brokerDeliveredAt, "number");
+    assert.equal(typeof details.message?.receiverReceivedAt, "number");
+    assert.equal(typeof details.message?.injectedAt, "number");
+  } finally {
+    await harness.emitLifecycle("session_shutdown");
+    await cleanup();
+  }
+});
+
+test("busy interactive sessions keep same-sender queued messages in sequence order", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { planner, cleanup } = await setupClients();
+  let idle = false;
+  const harness = createExtensionHarness("sequence-worker", {
+    hasUI: true,
+    isIdle: () => idle,
+  });
+
+  try {
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    const worker = await waitForSessionByName(planner, "sequence-worker");
+    const receipts = new Map<string, string[]>();
+    const unsubscribeReceipts = planner.onMessageReceipt((_from, receipt) => {
+      const statuses = receipts.get(receipt.messageId) ?? [];
+      statuses.push(receipt.status);
+      receipts.set(receipt.messageId, statuses);
+    });
+
+    assert.equal((await planner.send(worker.id, { messageId: "sequence-1", text: "First queued message" })).delivered, true);
+    assert.equal((await planner.send(worker.id, { messageId: "sequence-2", text: "Second queued message" })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(harness.sentMessages.length, 0);
+
+    idle = true;
+    await harness.emitLifecycle("agent_end");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    assert.equal(harness.sentMessages.length, 2);
+    assert.match(harness.sentMessages[0]?.message.content ?? "", /First queued message/);
+    assert.match(harness.sentMessages[1]?.message.content ?? "", /Second queued message/);
+    assert.equal(harness.sentMessages[0]?.options?.triggerTurn, true);
+    assert.equal(harness.sentMessages[1]?.options?.deliverAs, "followUp");
+    const firstDetails = harness.sentMessages[0]?.message.details as { message?: Message } | undefined;
+    const secondDetails = harness.sentMessages[1]?.message.details as { message?: Message } | undefined;
+    assert.equal(firstDetails?.message?.senderSequence, 1);
+    assert.equal(secondDetails?.message?.senderSequence, 2);
+    assert.deepEqual(receipts.get("sequence-1"), ["receiver_received", "acknowledged", "queued", "injected"]);
+    assert.deepEqual(receipts.get("sequence-2"), ["receiver_received", "acknowledged", "queued", "injected"]);
+    unsubscribeReceipts();
+  } finally {
+    await harness.emitLifecycle("session_shutdown");
+    await cleanup();
+  }
+});
+
 test("replied idle-gated asks are discarded before delivery", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
@@ -1328,6 +1421,10 @@ test("queued inbound messages are discarded after shutdown", { concurrency: fals
     piIntercomExtension(harness.pi as never);
     await harness.emitLifecycle("session_start");
     const target = await waitForSessionByName(planner, "disposed-worker");
+    const receipts: string[] = [];
+    const unsubscribeReceipts = planner.onMessageReceipt((_from, receipt) => {
+      if (receipt.messageId === "disposed-ask") receipts.push(receipt.status);
+    });
 
     const delivered = await planner.send(target.id, {
       messageId: "disposed-ask",
@@ -1344,6 +1441,8 @@ test("queued inbound messages are discarded after shutdown", { concurrency: fals
     await new Promise((resolve) => setTimeout(resolve, 250));
 
     assert.equal(harness.sentMessages.length, 0);
+    assert.deepEqual(receipts, ["receiver_received", "acknowledged", "queued", "expired"]);
+    unsubscribeReceipts();
   } finally {
     await cleanup();
   }
@@ -1799,6 +1898,42 @@ test("failed replies do not clear broker mutual-ask edges", { concurrency: false
     });
     assert.equal(nextAsk.delivered, true);
   } finally {
+    await cleanup();
+  }
+});
+
+test("regular intercom ask timeout reports message id and delivery state", { concurrency: false }, async () => {
+  const previousTimeout = process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+  process.env.PI_INTERCOM_ASK_TIMEOUT_MS = "50";
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const { planner, cleanup } = await setupClients();
+  const senderHarness = createExtensionHarness("timeout-worker", { sessionId: "session-timeout-worker" });
+  const receiverHarness = createExtensionHarness("timeout-target", { sessionId: "session-timeout-target", hasUI: true });
+
+  try {
+    piIntercomExtension(senderHarness.pi as never);
+    piIntercomExtension(receiverHarness.pi as never);
+    await senderHarness.emitLifecycle("session_start");
+    await receiverHarness.emitLifecycle("session_start");
+    await waitForSessionByName(planner, "timeout-target");
+    const intercomTool = senderHarness.tools.find((tool) => tool.name === "intercom")!;
+
+    const result = await intercomTool.execute("ask-timeout", { action: "ask", to: "timeout-target", message: "Will this time out?" }, new AbortController().signal, undefined, senderHarness.ctx);
+
+    assert.equal(result.details?.error, true);
+    assert.equal(result.details?.deliveryState, "injected");
+    assert.match(result.content[0]?.text ?? "", new RegExp(String(result.details?.messageId)));
+    assert.match(result.content[0]?.text ?? "", /Last known delivery state: injected/);
+    assert.match(result.content[0]?.text ?? "", /not cancellation/);
+    assert.equal(receiverHarness.sentMessages.length, 1);
+  } finally {
+    if (previousTimeout === undefined) {
+      delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+    } else {
+      process.env.PI_INTERCOM_ASK_TIMEOUT_MS = previousTimeout;
+    }
+    await senderHarness.emitLifecycle("session_shutdown");
+    await receiverHarness.emitLifecycle("session_shutdown");
     await cleanup();
   }
 });

--- a/types.ts
+++ b/types.ts
@@ -24,6 +24,11 @@ export interface SessionInfo {
 export interface Message {
   id: string;
   timestamp: number;
+  senderSequence?: number;
+  brokerReceivedAt?: number;
+  brokerDeliveredAt?: number;
+  receiverReceivedAt?: number;
+  injectedAt?: number;
   replyTo?: string;
   expectsReply?: boolean;
   content: {
@@ -37,6 +42,15 @@ export interface Attachment {
   name: string;
   content: string;
   language?: string;
+}
+
+export type MessageReceiptStatus = "receiver_received" | "queued" | "injected" | "acknowledged" | "expired" | "cancelled";
+
+export interface MessageReceipt {
+  messageId: string;
+  status: MessageReceiptStatus;
+  timestamp: number;
+  detail?: string;
 }
 
 export interface ExtensionCapability {
@@ -54,6 +68,7 @@ export type ClientMessage =
   | { type: "extension_capabilities_update"; extensions: ExtensionCapability[] }
   | { type: "list"; requestId: string }
   | { type: "send"; to: string; message: Message }
+  | { type: "message_receipt"; receipt: MessageReceipt }
   | { type: "cancel_ask"; messageId: string }
   | { type: "presence"; name?: string; status?: string; model?: string; contextPct?: number | null; contextTokens?: number | null; contextWindow?: number | null }
   | {
@@ -82,6 +97,7 @@ export type BrokerMessage =
   | { type: "error"; error: string }
   | { type: "delivered"; messageId: string }
   | { type: "delivery_failed"; messageId: string; reason: string }
+  | { type: "message_receipt"; from: SessionInfo; receipt: MessageReceipt }
   | { type: "extension_owner"; namespace: string; ownerId?: string; ownerEpoch?: string }
   | {
       type: "extension_message";


### PR DESCRIPTION
## Summary

This carries #65 past metadata-only diagnostics into receiver lifecycle receipts.

- add protocol-visible message metadata for sender sequence, broker receive/delivery, receiver receive, and injection timestamps
- route receiver lifecycle receipts back to the original sender through the broker
- expose client APIs for emitting and observing message receipts
- emit receiver receipts for `receiver_received`, `acknowledged`, `queued`, `injected`, and `expired`
- suppress duplicate inbound message IDs before reply tracking, idle queueing, or Pi injection while acknowledging the duplicate to the sender
- make ask timeouts report the message ID and latest known delivery state without implying cancellation
- document the delivery diagnostics contract in the README

Refs #65. This covers the concrete ordered/deduped delivery diagnostics in the issue. The only parts I would still leave as future protocol work are explicit user-authored retry/supersede semantics and receiver-side cancellation propagation, because those need product/API choices rather than hidden behavior.

## Validation

- `npm test` — 124/124 passed
- `npm pack --dry-run`
- `git diff --check`