### PR TITLE
fix: queue replies for ephemeral senders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ## [Unreleased]
 
 ### Fixed
+- Added a bounded in-memory broker mailbox so replies to recently disconnected named CLI senders are queued and delivered when a process reconnects with the same name. Thanks to Luke for issue #63.
 - Added protocol-visible delivery metadata, receiver lifecycle receipts, receiver-side inbound message dedupe, explicit cancel/supersede controls, and clearer ask-timeout receipts for ordered delivery diagnostics. Thanks to Donnie Thomas for issue #65.
 
 ## [0.8.0] - 2026-07-29

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ This matters because the agent receiving the message doesn't need to reconstruct
 
 `reply` is receiver-side sugar for replying to an inbound ask. In the turn triggered by an incoming intercom ask, `intercom({ action: "reply", message: "..." })` targets that exact sender and message automatically. If you reply later, it falls back to the single unresolved inbound ask. If multiple asks are pending, use `intercom({ action: "pending" })` to inspect them and then call `reply` with `to` to disambiguate.
 
+The broker keeps a bounded in-memory mailbox for recently disconnected named sessions. If a lightweight CLI sender asks a long-running session something and exits before the answer, the later `reply` is accepted into that mailbox instead of failing with `Session not found`; a process that reconnects with the same name receives the queued reply. This is per-broker runtime state, not durable storage across broker restarts.
+
 Incoming messages now carry diagnostic metadata end to end: stable message ID, sender sequence, sender timestamp, broker receive/delivery timestamps, receiver receive timestamp, and injection timestamp. Receivers emit lifecycle receipts for `receiver_received`, `acknowledged`, `queued`, `injected`, `expired`, `cancelled`, `superseded`, and `cancellation_requested`; duplicate message IDs are acknowledged but injected at most once per receiving session. If an `ask` times out, the timeout names the message ID and last known delivery state. Timeout is not cancellation: the recipient may still have the message queued or actionable unless an explicit cancellation path says otherwise.
 
 Cancellation is explicit: call `intercom({ action: "cancel", messageId })` to request cancellation of a message you originally sent. If the receiver has not injected it yet, it is removed from the queue and reported as `cancelled`; if it is already injected or processed, the receiver reports `cancellation_requested` instead of hiding it. Supersede is also explicit: pass `supersedes: "old-message-id"` on a new `send` or `ask`. The broker only allows same sender → same receiver supersedes, marks the old message `superseded`, and sends the replacement with a new message ID. Retries are never automatic; a retry should be a new authored message, optionally linked with `retryOf`.
@@ -319,11 +321,14 @@ The supervisor can reply with plain JSON or a fenced `json` block. If the reply 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `action` | string | `"list"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, or `"status"` |
+| `action` | string | `"list"`, `"list-cwd"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, `"status"`, or `"cancel"` |
 | `to` | string | Target session name or ID (for send/ask, or to disambiguate reply) |
 | `message` | string | Message text (for send/ask/reply) |
 | `attachments` | array | Optional `file`, `snippet`, or `context` attachments |
 | `replyTo` | string | Optional message ID for threading or replying to an `ask` |
+| `messageId` | string | Optional explicit message ID for send/ask, or required message ID for `cancel` |
+| `supersedes` | string | Optional previous message ID that this send/ask explicitly replaces |
+| `retryOf` | string | Optional previous message ID that this send/ask explicitly retries |
 
 ### contact_supervisor
 
@@ -352,6 +357,8 @@ Only registered in sessions where `pi-subagents` supplied the required child bri
 **`reply`** — Replies to the current intercom-triggered message if there is one. Otherwise it falls back to the single unresolved inbound ask. If multiple asks are pending, pass `to` or inspect them with `pending` first. Under the hood this is still a normal `send` with the exact `replyTo` value.
 
 **`pending`** — Lists unresolved inbound asks with sender, message ID, elapsed time, and a short preview. Useful when replying after the original triggered turn.
+
+**`cancel`** — Requests cancellation of a message previously sent by the current session. Queued messages are removed before injection; already-injected messages receive a visible cancellation request.
 
 **`status`** — Shows connection status, session ID, and total count of active sessions (including the current session).
 

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -35,6 +35,9 @@ const MAX_EXTENSIONS_PER_SESSION = 32;
 const MAX_EXTENSION_MESSAGE_BYTES = 16 * 1024;
 const MAX_EXTENSION_STATE_BYTES = 64 * 1024;
 const MESSAGE_RECEIPT_ROUTE_RETENTION_MS = 60 * 60 * 1000;
+const DISCONNECTED_SESSION_RETENTION_MS = 24 * 60 * 60 * 1000;
+const MAILBOX_MESSAGE_RETENTION_MS = 24 * 60 * 60 * 1000;
+const MAX_MAILBOX_MESSAGES = 256;
 
 function serializedPayloadSize(payload: unknown): number | null {
   try {
@@ -75,6 +78,18 @@ interface MessageReceiptRoute {
   from: string;
   to: string;
   createdAt: number;
+}
+
+interface DisconnectedSession {
+  info: SessionInfo;
+  disconnectedAt: number;
+}
+
+interface MailboxMessage {
+  from: SessionInfo;
+  target: SessionInfo;
+  message: Message;
+  queuedAt: number;
 }
 
 function isMessageReceiptStatus(value: unknown): value is MessageReceiptStatus {
@@ -199,6 +214,8 @@ class IntercomBroker {
   private sessions = new Map<string, ConnectedSession>();
   private askEdges = new Map<string, AskEdge>();
   private messageReceiptRoutes = new Map<string, MessageReceiptRoute>();
+  private disconnectedSessions = new Map<string, DisconnectedSession>();
+  private mailboxMessages: MailboxMessage[] = [];
   private connections = new Set<net.Socket>();
   private unregisteredConnections = new Set<net.Socket>();
   private server: net.Server;
@@ -312,8 +329,8 @@ class IntercomBroker {
       if (sessionId) {
         const existing = this.sessions.get(sessionId);
         if (existing?.socket === socket) {
+          this.rememberDisconnectedSession(existing.info);
           this.sessions.delete(sessionId);
-          this.clearAskEdgesForSession(sessionId);
           this.clearMessageReceiptRoutesForSession(sessionId);
           this.broadcast({ type: "session_left", sessionId }, sessionId);
           this.recomputeNamespaceOwners();
@@ -437,6 +454,8 @@ class IntercomBroker {
           }
         }
 
+        this.pruneDisconnectedSessions();
+        this.pruneMailboxMessages();
         const previous = this.sessions.get(id);
         if (!previous && this.sessions.size >= MAX_SESSIONS) {
           writeMessage(socket, { type: "error", error: "Too many registered intercom sessions" });
@@ -461,13 +480,15 @@ class IntercomBroker {
           trustedLocal: typeof LISTEN_TARGET === "string" && process.platform !== "win32",
         };
 
-        this.sessions.set(id, {
+        const connectedSession: ConnectedSession = {
           socket,
           info,
           lastPresenceBroadcastAt: Date.now(),
           ownerOrder: previous?.ownerOrder ?? this.nextOwnerOrder++,
           extensions,
-        });
+        };
+        this.sessions.set(id, connectedSession);
+        this.disconnectedSessions.delete(id);
         
         if (this.shutdownTimer) {
           clearTimeout(this.shutdownTimer);
@@ -485,6 +506,7 @@ class IntercomBroker {
         this.broadcast({ type: "session_joined", session: info }, id);
 
         this.recomputeNamespaceOwners();
+        this.flushMailboxForSession(connectedSession);
 
         if (extensions) {
           for (const ext of extensions) {
@@ -514,8 +536,8 @@ class IntercomBroker {
         }
         const existing = this.sessions.get(currentId);
         if (existing?.socket === socket) {
+          this.rememberDisconnectedSession(existing.info);
           this.sessions.delete(currentId);
-          this.clearAskEdgesForSession(currentId);
           this.clearMessageReceiptRoutesForSession(currentId);
           this.broadcast({ type: "session_left", sessionId: currentId }, currentId);
           this.recomputeNamespaceOwners();
@@ -686,6 +708,87 @@ class IntercomBroker {
           break;
         }
 
+        const disconnectedTargets = this.findDisconnectedSessions(clientMessage.to);
+        if (disconnectedTargets.length === 1) {
+          if (message.replyTo && !replyEdge) {
+            writeMessage(socket, {
+              type: "delivery_failed",
+              messageId: message.id,
+              reason: "Reply target does not match a pending ask",
+            });
+            break;
+          }
+          const fromSession = this.sessions.get(currentId);
+          if (!fromSession || fromSession.socket !== socket) {
+            writeMessage(socket, {
+              type: "delivery_failed",
+              messageId: message.id,
+              reason: "Sender session not found",
+            });
+            break;
+          }
+          const target = disconnectedTargets[0]!.info;
+          if (message.supersedes) {
+            writeMessage(socket, {
+              type: "delivery_failed",
+              messageId: message.id,
+              reason: "Supersede target is not connected",
+            });
+            break;
+          }
+          if (replyEdge && (replyEdge.to !== currentId || replyEdge.from !== target.id)) {
+            writeMessage(socket, {
+              type: "delivery_failed",
+              messageId: message.id,
+              reason: "Reply target does not match the pending ask",
+            });
+            break;
+          }
+          const liveMailboxTarget = this.findUniqueLiveSessionForDisconnectedSession(target);
+          const effectiveTargetId = liveMailboxTarget?.info.id ?? target.id;
+          if (message.expectsReply) {
+            const reverseEdge = Array.from(this.askEdges.entries()).find(([edgeMessageId, edge]) => edgeMessageId !== message.replyTo && edge.from === effectiveTargetId && edge.to === currentId);
+            if (reverseEdge) {
+              writeMessage(socket, {
+                type: "delivery_failed",
+                messageId: message.id,
+                reason: "Mutual ask refused: target session is already waiting for a reply from this session.",
+              });
+              break;
+            }
+            this.askEdges.set(message.id, { from: currentId, to: effectiveTargetId, createdAt: Date.now() });
+          }
+          if (liveMailboxTarget) {
+            const deliveredMessage: Message = {
+              ...message,
+              brokerReceivedAt,
+              brokerDeliveredAt: Date.now(),
+            };
+            writeMessage(liveMailboxTarget.socket, {
+              type: "message",
+              from: fromSession.info,
+              message: deliveredMessage,
+            });
+            this.messageReceiptRoutes.set(message.id, { from: currentId, to: liveMailboxTarget.info.id, createdAt: brokerReceivedAt });
+          } else {
+            this.queueMailboxMessage(fromSession.info, target, message, brokerReceivedAt);
+          }
+          if (message.replyTo) {
+            this.askEdges.delete(message.replyTo);
+          }
+          writeMessage(socket, { type: "delivered", messageId: message.id });
+          break;
+        }
+
+        if (disconnectedTargets.length > 1) {
+          writeMessage(socket, {
+            type: "delivery_failed",
+            messageId: message.id,
+            reason: `Multiple disconnected sessions named \"${clientMessage.to}\" can receive queued mail. Use the session ID instead.`,
+          });
+          break;
+        }
+
         writeMessage(socket, {
           type: "delivery_failed",
           messageId: message.id,
@@ -723,8 +826,19 @@ class IntercomBroker {
           throw new Error("Invalid cancel_message message");
         }
         this.pruneMessageReceiptRoutes();
-        const route = this.messageReceiptRoutes.get(clientMessage.messageId);
+        this.pruneMailboxMessages();
         const sender = this.sessions.get(currentId);
+        const queuedIndex = this.mailboxMessages.findIndex(entry => entry.message.id === clientMessage.messageId && entry.from.id === currentId);
+        if (queuedIndex >= 0 && sender?.socket === socket) {
+          this.mailboxMessages.splice(queuedIndex, 1);
+          const edge = this.askEdges.get(clientMessage.messageId);
+          if (edge?.from === currentId) {
+            this.askEdges.delete(clientMessage.messageId);
+          }
+          writeMessage(socket, { type: "delivered", messageId: clientMessage.messageId });
+          break;
+        }
+        const route = this.messageReceiptRoutes.get(clientMessage.messageId);
         const receiver = route ? this.sessions.get(route.to) : undefined;
         if (route?.from !== currentId || sender?.socket !== socket || !receiver) {
           writeMessage(socket, {
@@ -858,6 +972,88 @@ class IntercomBroker {
     }
   }
 
+  private rememberDisconnectedSession(info: SessionInfo, now = Date.now()): void {
+    this.disconnectedSessions.set(info.id, { info: { ...info }, disconnectedAt: now });
+    this.pruneDisconnectedSessions(now);
+  }
+
+  private pruneDisconnectedSessions(now = Date.now()): void {
+    for (const [sessionId, session] of this.disconnectedSessions) {
+      if (now - session.disconnectedAt > DISCONNECTED_SESSION_RETENTION_MS) {
+        this.disconnectedSessions.delete(sessionId);
+      }
+    }
+  }
+
+  private pruneMailboxMessages(now = Date.now()): void {
+    for (let index = this.mailboxMessages.length - 1; index >= 0; index -= 1) {
+      const entry = this.mailboxMessages[index]!;
+      if (now - entry.queuedAt > MAILBOX_MESSAGE_RETENTION_MS) {
+        if (entry.message.expectsReply) {
+          this.askEdges.delete(entry.message.id);
+        }
+        this.messageReceiptRoutes.delete(entry.message.id);
+        this.mailboxMessages.splice(index, 1);
+      }
+    }
+  }
+
+  private queueMailboxMessage(from: SessionInfo, target: SessionInfo, message: Message, brokerReceivedAt: number): void {
+    this.pruneMailboxMessages(brokerReceivedAt);
+    while (this.mailboxMessages.length >= MAX_MAILBOX_MESSAGES) {
+      const evicted = this.mailboxMessages.shift();
+      if (!evicted) break;
+      if (evicted.message.expectsReply) {
+        this.askEdges.delete(evicted.message.id);
+      }
+      this.messageReceiptRoutes.delete(evicted.message.id);
+    }
+    this.mailboxMessages.push({
+      from: { ...from },
+      target: { ...target },
+      message: { ...message, brokerReceivedAt },
+      queuedAt: brokerReceivedAt,
+    });
+  }
+
+  private flushMailboxForSession(session: ConnectedSession, now = Date.now()): void {
+    this.pruneMailboxMessages(now);
+    const sessionName = session.info.name?.toLowerCase();
+    const uniqueLiveName = sessionName
+      ? Array.from(this.sessions.values()).filter(candidate => candidate.info.name?.toLowerCase() === sessionName).length === 1
+      : false;
+
+    for (let index = 0; index < this.mailboxMessages.length;) {
+      const entry = this.mailboxMessages[index]!;
+      const matchesId = entry.target.id === session.info.id;
+      const matchesUniqueName = Boolean(uniqueLiveName && sessionName && entry.target.name?.toLowerCase() === sessionName);
+      if (!matchesId && !matchesUniqueName) {
+        index += 1;
+        continue;
+      }
+
+      this.mailboxMessages.splice(index, 1);
+      const edge = this.askEdges.get(entry.message.id);
+      if (edge?.to === entry.target.id) {
+        edge.to = session.info.id;
+      }
+      const deliveredMessage: Message = {
+        ...entry.message,
+        brokerDeliveredAt: Date.now(),
+      };
+      writeMessage(session.socket, {
+        type: "message",
+        from: entry.from,
+        message: deliveredMessage,
+      });
+      this.messageReceiptRoutes.set(entry.message.id, {
+        from: entry.from.id,
+        to: session.info.id,
+        createdAt: entry.message.brokerReceivedAt ?? entry.queuedAt,
+      });
+    }
+  }
+
   private pruneAskEdges(now = Date.now()): void {
     for (const [messageId, edge] of this.askEdges) {
       if (now - edge.createdAt > this.askTimeoutMs) {
@@ -905,6 +1101,33 @@ class IntercomBroker {
     return Array.from(this.sessions.entries())
       .filter(([id]) => id.startsWith(nameOrId))
       .map(([, session]) => session);
+  }
+
+  private findDisconnectedSessions(nameOrId: string): DisconnectedSession[] {
+    this.pruneDisconnectedSessions();
+    const byId = this.disconnectedSessions.get(nameOrId);
+    if (byId) {
+      return [byId];
+    }
+
+    const lowerName = nameOrId.toLowerCase();
+    const byName = Array.from(this.disconnectedSessions.values()).filter(session => session.info.name?.toLowerCase() === lowerName);
+    if (byName.length > 0) {
+      return byName;
+    }
+
+    return Array.from(this.disconnectedSessions.entries())
+      .filter(([id]) => id.startsWith(nameOrId))
+      .map(([, session]) => session);
+  }
+
+  private findUniqueLiveSessionForDisconnectedSession(info: SessionInfo): ConnectedSession | null {
+    const lowerName = info.name?.toLowerCase();
+    if (!lowerName) {
+      return null;
+    }
+    const matches = Array.from(this.sessions.values()).filter(session => session.info.name?.toLowerCase() === lowerName);
+    return matches.length === 1 ? matches[0]! : null;
   }
 
   private broadcast(msg: BrokerMessage, exclude?: string): void {
@@ -1272,6 +1495,9 @@ class IntercomBroker {
     }
     this.sessions.clear();
     this.askEdges.clear();
+    this.messageReceiptRoutes.clear();
+    this.disconnectedSessions.clear();
+    this.mailboxMessages.length = 0;
     if (typeof LISTEN_TARGET === "string" && process.platform !== "win32") {
       try {
         unlinkSync(LISTEN_TARGET);

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -2242,10 +2242,87 @@ test("intercom reply targets exact replyTo when multiple asks are pending", { co
   }
 });
 
-test("intercom reply dismisses stale pending ask only when sender session is gone", { concurrency: false }, async () => {
+test("broker queues replies to recently disconnected named senders", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const replacement = new IntercomClient();
+
+  try {
+    const originalPlannerId = planner.sessionId!;
+    const receivedAsk = once(orchestrator, "message") as Promise<[SessionInfo, Message]>;
+    assert.equal((await planner.send(orchestrator.sessionId!, { messageId: "ephemeral-cli-ask", text: "Can you answer later?", expectsReply: true })).delivered, true);
+    await receivedAsk;
+    await planner.disconnect();
+
+    const queuedReply = once(replacement, "message") as Promise<[SessionInfo, Message]>;
+    const reply = await orchestrator.send(originalPlannerId, {
+      messageId: "queued-reply-to-ephemeral",
+      text: "Queued answer.",
+      replyTo: "ephemeral-cli-ask",
+    });
+    assert.equal(reply.delivered, true);
+
+    await replacement.connect({
+      name: "planner",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    });
+    const [from, message] = await queuedReply;
+    assert.equal(from.id, orchestrator.sessionId);
+    assert.equal(message.id, "queued-reply-to-ephemeral");
+    assert.equal(message.replyTo, "ephemeral-cli-ask");
+    assert.equal(message.content.text, "Queued answer.");
+    assert.equal(typeof message.brokerReceivedAt, "number");
+    assert.equal(typeof message.brokerDeliveredAt, "number");
+  } finally {
+    await replacement.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("broker delivers old-id replies to an already reconnected same-name sender", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const replacement = new IntercomClient();
+
+  try {
+    const originalPlannerId = planner.sessionId!;
+    const receivedAsk = once(orchestrator, "message") as Promise<[SessionInfo, Message]>;
+    assert.equal((await planner.send(orchestrator.sessionId!, { messageId: "reconnected-cli-ask", text: "Can you answer after reconnect?", expectsReply: true })).delivered, true);
+    await receivedAsk;
+    await planner.disconnect();
+
+    await replacement.connect({
+      name: "planner",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    });
+    const deliveredReply = once(replacement, "message") as Promise<[SessionInfo, Message]>;
+    const reply = await orchestrator.send(originalPlannerId, {
+      messageId: "reply-after-cli-reconnect",
+      text: "Immediate answer after reconnect.",
+      replyTo: "reconnected-cli-ask",
+    });
+    assert.equal(reply.delivered, true);
+    const [, message] = await deliveredReply;
+    assert.equal(message.id, "reply-after-cli-reconnect");
+    assert.equal(message.replyTo, "reconnected-cli-ask");
+    assert.equal(message.content.text, "Immediate answer after reconnect.");
+  } finally {
+    await replacement.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("intercom reply queues mail for a disconnected named sender", { concurrency: false }, async () => {
   const { planner, cleanup } = await setupClients();
   const { default: piIntercomExtension } = await import("./index.ts");
   const harness = createExtensionHarness("stale-reply-worker");
+  const replacement = new IntercomClient();
 
   try {
     piIntercomExtension(harness.pi as never);
@@ -2261,12 +2338,25 @@ test("intercom reply dismisses stale pending ask only when sender session is gon
       message: "No sender remains.",
       replyTo: "stale-reply-ask",
     }, new AbortController().signal, undefined, harness.ctx);
-    assert.equal(result.details?.delivered, false);
-    assert.equal(result.details?.reason, "Session not found");
+    assert.equal(result.details?.delivered, true);
 
     const pending = await intercomTool.execute("pending-after-stale", { action: "pending" }, new AbortController().signal, undefined, harness.ctx);
     assert.match(pending.content[0]?.text ?? "", /No unresolved inbound asks/);
+
+    const queuedReply = once(replacement, "message") as Promise<[SessionInfo, Message]>;
+    await replacement.connect({
+      name: "planner",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    });
+    const [, message] = await queuedReply;
+    assert.equal(message.replyTo, "stale-reply-ask");
+    assert.equal(message.content.text, "No sender remains.");
   } finally {
+    await replacement.disconnect().catch(() => undefined);
     await harness.emitLifecycle("session_shutdown");
     await cleanup();
   }

--- a/skills/pi-intercom/SKILL.md
+++ b/skills/pi-intercom/SKILL.md
@@ -402,6 +402,7 @@ if (!result.delivered) {
   await intercom({ action: "list" });
 }
 ```
+Replies to recently disconnected named senders can be queued by the broker and delivered if that sender reconnects with the same name. New sends still need a known live or recently disconnected target.
 
 **Ask timeout**
 ```typescript


### PR DESCRIPTION
## Summary

This addresses #63 by adding a bounded in-memory broker mailbox for recently disconnected named sessions.

- remember recently disconnected sessions for a bounded TTL
- accept replies addressed to the old ephemeral sender ID instead of failing with `Session not found`
- deliver queued replies when a process reconnects with the same unique name
- deliver immediately when the same-name replacement has already reconnected before the reply is sent
- keep mailbox messages bounded and in-memory only; this is not durable storage across broker restarts
- allow queued mailbox messages to be cancelled before delivery
- document the behavior and credit Luke for the report

Closes #63.

## Review

- Fresh read-only review found one reconnect-before-reply release risk
- Fixed that path by resolving old disconnected IDs to a unique live same-name replacement
- Targeted follow-up review found the prior risk fixed and no concrete release risk in the touched path

## Validation

- `npm test` — 130/130 passed
- `npm pack --dry-run`
- `git diff --check`