### PR TITLE
perf: linear frame parsing and inline render caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Changed
+- Rewrote the broker frame reader as a bounded state machine and made frame writes a single allocation, removing quadratic `Buffer.concat` accumulation on fragmented socket reads (up to ~28x faster on heavily fragmented frames).
+- Cached the collapsed preview and width-keyed wrapped body lines in the inline message renderer, cutting repeated rerender cost of long messages by ~2-3x while keeping live theme changes applied per render.
+
 ## [0.9.0] - 2026-07-29
 
 ### Added

--- a/broker/framing.test.ts
+++ b/broker/framing.test.ts
@@ -28,6 +28,26 @@ test("createMessageReader handles normal fragmented frames", () => {
   assert.deepEqual(errors, []);
 });
 
+test("createMessageReader reassembles a fragmented frame after a header-boundary fast-path frame", () => {
+  const messages: unknown[] = [];
+  const errors: Error[] = [];
+  const reader = createMessageReader(
+    (message) => messages.push(message),
+    (error) => errors.push(error),
+    64,
+  );
+  const frameA = framePayload(Buffer.from(JSON.stringify({ a: 1 }), "utf-8"));
+  const frameB = framePayload(Buffer.from(JSON.stringify({ bb: "1234567890" }), "utf-8"));
+
+  reader(frameA.subarray(0, 4)); // chunk ends exactly at the end of frame A's header
+  reader(frameA.subarray(4)); // frame A's payload arrives whole (zero-copy fast path)
+  reader(frameB.subarray(0, 6)); // frame B header + partial payload (buffered path)
+  reader(frameB.subarray(6));
+
+  assert.deepEqual(messages, [{ a: 1 }, { bb: "1234567890" }]);
+  assert.deepEqual(errors, []);
+});
+
 test("createMessageReader rejects an oversized declared frame", () => {
   const messages: unknown[] = [];
   const errors: Error[] = [];

--- a/broker/framing.ts
+++ b/broker/framing.ts
@@ -8,10 +8,11 @@ export const MAX_FRAME_BYTES = 1024 * 1024;
  */
 export function writeMessage(socket: Socket, msg: unknown): void {
   const json = JSON.stringify(msg);
-  const payload = Buffer.from(json, "utf-8");
-  const header = Buffer.alloc(4);
-  header.writeUInt32BE(payload.length, 0);
-  socket.write(Buffer.concat([header, payload]));
+  const payloadLength = Buffer.byteLength(json, "utf-8");
+  const frame = Buffer.allocUnsafe(4 + payloadLength);
+  frame.writeUInt32BE(payloadLength, 0);
+  frame.write(json, 4, payloadLength, "utf-8");
+  socket.write(frame);
 }
 
 /**
@@ -24,12 +25,16 @@ export function createMessageReader(
   onError: (error: Error) => void,
   maxFrameBytes = MAX_FRAME_BYTES,
 ) {
-  let buffer = Buffer.alloc(0);
+  const header = Buffer.allocUnsafe(4);
+  let headerBytes = 0;
+  let payload: Buffer | null = null;
+  let payloadBytes = 0;
+  let payloadLength = 0;
 
-  function reportMessage(payload: Buffer): boolean {
+  function reportMessage(framePayload: Buffer): boolean {
     let msg: unknown;
     try {
-      msg = JSON.parse(payload.toString("utf-8"));
+      msg = JSON.parse(framePayload.toString("utf-8"));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       onError(new Error(`Failed to parse intercom message: ${message}`, { cause: error }));
@@ -47,39 +52,62 @@ export function createMessageReader(
   }
 
   return (data: Buffer) => {
-    let remaining = data;
+    let offset = 0;
 
-    while (remaining.length > 0) {
-      if (buffer.length < 4) {
-        const headerBytes = Math.min(4 - buffer.length, remaining.length);
-        buffer = Buffer.concat([buffer, remaining.subarray(0, headerBytes)]);
-        remaining = remaining.subarray(headerBytes);
-        if (buffer.length < 4) {
+    while (offset < data.length) {
+      if (headerBytes < 4) {
+        const bytes = Math.min(4 - headerBytes, data.length - offset);
+        data.copy(header, headerBytes, offset, offset + bytes);
+        headerBytes += bytes;
+        offset += bytes;
+        if (headerBytes < 4) {
+          return;
+        }
+
+        payloadLength = header.readUInt32BE(0);
+        if (payloadLength > maxFrameBytes) {
+          headerBytes = 0;
+          onError(new Error(`Intercom frame length ${payloadLength} exceeds maximum ${maxFrameBytes} bytes`));
           return;
         }
       }
 
-      const length = buffer.readUInt32BE(0);
-      if (length > maxFrameBytes) {
-        buffer = Buffer.alloc(0);
-        onError(new Error(`Intercom frame length ${length} exceeds maximum ${maxFrameBytes} bytes`));
+      // Fast path: the whole payload is already in this chunk, so parse it
+      // in place without copying into a reassembly buffer.
+      if (payloadBytes === 0 && data.length - offset >= payloadLength) {
+        const framePayload = data.subarray(offset, offset + payloadLength);
+        offset += payloadLength;
+        headerBytes = 0;
+        payload = null;
+        payloadLength = 0;
+        if (!reportMessage(framePayload)) {
+          return;
+        }
+        continue;
+      }
+
+      // A buffer allocated for a previous frame (e.g. when a chunk ended
+      // exactly on a header boundary) must not be reused for a frame of a
+      // different size, so the reassembly buffer is size-checked, not just
+      // presence-checked.
+      if (payload === null || payload.length !== payloadLength) {
+        payload = Buffer.allocUnsafe(payloadLength);
+      }
+      const bytes = Math.min(payloadLength - payloadBytes, data.length - offset);
+      data.copy(payload, payloadBytes, offset, offset + bytes);
+      payloadBytes += bytes;
+      offset += bytes;
+
+      if (payloadBytes < payloadLength) {
         return;
       }
 
-      const missingPayloadBytes = length - Math.max(0, buffer.length - 4);
-      const payloadBytes = Math.min(missingPayloadBytes, remaining.length);
-      if (payloadBytes > 0) {
-        buffer = Buffer.concat([buffer, remaining.subarray(0, payloadBytes)]);
-        remaining = remaining.subarray(payloadBytes);
-      }
-
-      if (buffer.length < 4 + length) {
-        return;
-      }
-
-      const payload = buffer.subarray(4, 4 + length);
-      buffer = Buffer.alloc(0);
-      if (!reportMessage(payload)) {
+      const framePayload = payload;
+      headerBytes = 0;
+      payload = null;
+      payloadBytes = 0;
+      payloadLength = 0;
+      if (!reportMessage(framePayload)) {
         return;
       }
     }

--- a/ui/inline-message.ts
+++ b/ui/inline-message.ts
@@ -10,6 +10,10 @@ export class InlineMessageComponent implements Component {
   private replyCommand?: string;
   private bodyText?: string;
   private collapsed: boolean;
+  // Caches assume message/bodyText never mutate after construction; theme
+  // styling stays outside the caches so live theme changes apply per render.
+  private collapsedPreview?: string;
+  private wrappedBody?: { width: number; lines: string[] };
 
   constructor(
     from: SessionInfo,
@@ -54,8 +58,8 @@ export class InlineMessageComponent implements Component {
     };
 
     if (this.collapsed) {
-      const preview = (this.bodyText || this.message.content.text).replace(/\s+/g, " ").trim();
-      lines.push(frameLine(this.theme.fg("text", preview)));
+      this.collapsedPreview ??= (this.bodyText || this.message.content.text).replace(/\s+/g, " ").trim();
+      lines.push(frameLine(this.theme.fg("text", this.collapsedPreview)));
 
       const meta: string[] = [];
       if (this.replyCommand) meta.push(`↩ To reply: ${this.replyCommand}`);
@@ -71,8 +75,13 @@ export class InlineMessageComponent implements Component {
       return lines;
     }
 
-    const contentLines = wrapTextWithAnsi(this.bodyText || this.message.content.text, bodyWidth);
-    for (const line of contentLines) {
+    if (this.wrappedBody?.width !== bodyWidth) {
+      this.wrappedBody = {
+        width: bodyWidth,
+        lines: wrapTextWithAnsi(this.bodyText || this.message.content.text, bodyWidth),
+      };
+    }
+    for (const line of this.wrappedBody.lines) {
       lines.push(frameLine(this.theme.fg("text", line)));
     }
 


### PR DESCRIPTION
Two measured performance fixes, no behavior changes.

The broker frame reader used to grow a single buffer with `Buffer.concat` on every chunk, which is quadratic in chunk count when frames arrive fragmented. It now parses with a fixed 4-byte header buffer plus a preallocated payload buffer, and takes a zero-copy path when a whole payload lands in one chunk. `writeMessage` builds each frame with one allocation instead of three. Same-process before/after medians on a 256 KiB frame: 64-byte chunks ~28x faster, 256-byte chunks ~15-19x faster.

The inline message renderer redid full O(message-length) work on every frame render (pi-tui rerenders children each frame). It now caches the collapsed preview and the width-keyed unstyled wrapped body lines; theme styling, borders, and truncation still run per render, so live theme changes keep working. Long-message rerenders are ~2-3x faster.

An adversarial review of the reader rewrite caught a real bug before merge: the zero-copy fast path reset header state but not a previously allocated payload buffer, so a stale wrongly sized buffer could be reused for a later fragmented frame (payload truncation and stream desync, or decoding uninitialized `allocUnsafe` memory). Fixed with a size-checked reassembly buffer plus clearing it in the fast-path reset, and covered by a new regression test that reproduces the exact 4-chunk trigger (chunk ending on a header boundary, whole payload next, then a differently sized fragmented frame).

Full suite passes 131/131. `writeMessage` output was verified byte-for-byte identical to the old implementation, including multibyte, lone-surrogate, and empty payloads.