### PR TITLE
fix(broker): avoid treating standalone Pi as Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+- Avoid relaunching standalone Pi executables as the Node runtime when starting the default broker process. Thanks to ZacharyQin for PR #82 and to jeffutter and awaae001 for confirming the impact.
+
 ## [0.9.1] - 2026-07-30
 
 ### Fixed

--- a/broker/spawn.test.ts
+++ b/broker/spawn.test.ts
@@ -71,6 +71,26 @@ test("getBrokerLaunchSpec uses wscript launcher on Windows without writing files
   }
 });
 
+test("getBrokerLaunchSpec falls back to PATH node for a standalone Pi executable on Windows", () => {
+  const intercomDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-"));
+
+  try {
+    const spec = getBrokerLaunchSpec(
+      "C:/repo/broker.ts",
+      "npx",
+      ["--no-install", "tsx"],
+      "C:/repo",
+      "win32",
+      intercomDir,
+      "C:/Program Files/Pi/pi.exe",
+    );
+    assert.equal(spec.kind, "windows-launcher");
+    assert.equal(spec.launcherCommandLine, `"node" "${getTsxCliPath("C:/repo")}" "C:/repo/broker.ts"`);
+  } finally {
+    rmSync(intercomDir, { recursive: true, force: true });
+  }
+});
+
 test("getBrokerLaunchSpec uses custom broker command on Windows", () => {
   const intercomDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-"));
 
@@ -90,6 +110,24 @@ test("getBrokerLaunchSpec uses node + resolved tsx for the default non-Windows l
   assert.deepEqual(spec.args, [
     getTsxCliPath("C:/repo"),
     "C:/repo/broker.ts",
+  ]);
+  assert.equal(spec.kind, "direct");
+});
+
+test("getBrokerLaunchSpec falls back to PATH node for a standalone Pi executable on non-Windows", () => {
+  const spec = getBrokerLaunchSpec(
+    "/repo/broker.ts",
+    "npx",
+    ["--no-install", "tsx"],
+    "/repo",
+    "darwin",
+    "/tmp/intercom",
+    "/Applications/Pi.app/Contents/MacOS/pi",
+  );
+  assert.equal(spec.command, "node");
+  assert.deepEqual(spec.args, [
+    getTsxCliPath("/repo"),
+    "/repo/broker.ts",
   ]);
   assert.equal(spec.kind, "direct");
 });

--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -71,6 +71,13 @@ function usesDefaultBrokerCommand(brokerCommand: string, brokerArgs: string[]): 
     && brokerArgs[1] === "tsx";
 }
 
+function getNodeCommand(nodePath: string): string {
+  const executableName = nodePath.split(/[\\/]/).pop();
+  return executableName && /^node(?:js)?(?:\.exe)?$/i.test(executableName)
+    ? nodePath
+    : "node";
+}
+
 export function getWindowsBrokerCommandLine(
   brokerPath: string,
   extensionDir: string = EXTENSION_DIR,
@@ -79,7 +86,7 @@ export function getWindowsBrokerCommandLine(
   brokerArgs: string[] = ["--no-install", "tsx"],
 ): string {
   if (usesDefaultBrokerCommand(brokerCommand, brokerArgs)) {
-    return [quoteWindowsArg(nodePath), quoteWindowsArg(getTsxCliPath(extensionDir)), quoteWindowsArg(brokerPath)].join(" ");
+    return [quoteWindowsArg(getNodeCommand(nodePath)), quoteWindowsArg(getTsxCliPath(extensionDir)), quoteWindowsArg(brokerPath)].join(" ");
   }
 
   return [quoteWindowsArg(brokerCommand), ...brokerArgs.map(quoteWindowsArg), quoteWindowsArg(brokerPath)].join(" ");
@@ -141,7 +148,7 @@ export function getBrokerLaunchSpec(
   if (usesDefaultBrokerCommand(brokerCommand, brokerArgs)) {
     return {
       kind: "direct",
-      command: nodePath,
+      command: getNodeCommand(nodePath),
       args: [getTsxCliPath(extensionDir), brokerPath],
     };
   }


### PR DESCRIPTION
## Problem summary

On a local standalone Pi installation, a default `pi-intercom` broker startup attempt launched another Pi process instead of Node. The nested process received the resolved `tsx` CLI and broker script paths as input, loaded `pi-intercom`, and could repeat the same startup path. The process arguments and corresponding Pi session records were observed locally; no credential compromise is asserted here.

## Mechanism

The default broker launch is intended to execute the resolved `tsx` CLI and broker script with Node:

```text
node <resolved-tsx-cli> <pi-intercom>/broker/broker.ts
```

On the standalone installation, the effective command instead used the Pi executable as the runtime:

```text
pi <resolved-tsx-cli> <pi-intercom>/broker/broker.ts
```

The default launch optimization replaces `npx --no-install tsx` with `process.execPath` plus the resolved `tsx` CLI. That is valid when Pi itself is running under Node, but standalone builds use the Pi executable as `process.execPath`. The resulting child is another Pi process, which treats the script paths as input and loads the extension again.

The affected non-Windows default launch path was introduced in [`77fa49a` (`feat: harden intercom trust controls`)](https://github.com/nicobailon/pi-intercom/commit/77fa49aa84f2a0e5e05cc5831b6a1a9850ca7f71), which changed the default from `npx --no-install tsx` to `process.execPath` with the resolved `tsx` CLI.

The Windows hidden-launcher path builds its VBS command line from the same `process.execPath` assumption, although that assumption predates `77fa49a` and the local observation above was on a non-Windows standalone installation.

## Solution and validation

The default launch now reuses `process.execPath` only when its executable basename is `node`, `nodejs`, or the corresponding `.exe` form. Other executables fall back to `node` from `PATH`, while continuing to invoke the already resolved `tsx` CLI directly. Custom `brokerCommand` and `brokerArgs` values are unchanged. If Node is unavailable, startup fails with the normal executable-not-found error instead of invoking the standalone Pi executable as a JavaScript runtime.

Two regression tests cover standalone Pi executable paths on non-Windows and Windows launchers. Both tests fail against the parent commit because the generated launch command contains the Pi executable, and pass with this change. Existing Node-path and custom-command coverage remains unchanged.

Validation:

- `node_modules/.bin/tsx --test broker/spawn.test.ts` — 14/14 passed
- `npm test` — 136/136 passed
- TypeScript language-server diagnostics — no findings in the changed files
- `git diff --check` — passed
