### PR TITLE
fix: resolve pending replies by short session ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+- Allow replies to target pending asks by a unique sender session-ID prefix. Thanks to Benjamin Jesuiter (`bjesuiter`) for PR #85.
+
 ## [0.9.2] - 2026-08-03
 
 ### Fixed

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -2242,6 +2242,39 @@ test("intercom reply targets exact replyTo when multiple asks are pending", { co
   }
 });
 
+test("intercom reply targets one of multiple pending asks by short session ID", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const harness = createExtensionHarness("reply-short-id-worker");
+
+  try {
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    const worker = await waitForSessionByName(planner, "reply-short-id-worker");
+
+    assert.equal((await planner.send(worker.id, { messageId: "reply-short-id-1", text: "First?", expectsReply: true })).delivered, true);
+    assert.equal((await orchestrator.send(worker.id, { messageId: "reply-short-id-2", text: "Second?", expectsReply: true })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
+    const replyReceived = waitForReply(planner, "reply-short-id-1");
+    const result = await intercomTool.execute("reply-short-id", {
+      action: "reply",
+      to: planner.sessionId!.slice(0, 8),
+      message: "First answer.",
+    }, new AbortController().signal, undefined, harness.ctx);
+    assert.equal(result.details?.delivered, true);
+    assert.equal((await replyReceived).message.content.text, "First answer.");
+
+    const pending = await intercomTool.execute("pending-after-short-id", { action: "pending" }, new AbortController().signal, undefined, harness.ctx);
+    assert.doesNotMatch(pending.content[0]?.text ?? "", /reply-short-id-1/);
+    assert.match(pending.content[0]?.text ?? "", /reply-short-id-2/);
+  } finally {
+    await harness.emitLifecycle("session_shutdown");
+    await cleanup();
+  }
+});
+
 test("broker queues replies to recently disconnected named senders", { concurrency: false }, async () => {
   const { planner, orchestrator, cleanup } = await setupClients();
   const replacement = new IntercomClient();

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -2275,6 +2275,55 @@ test("intercom reply targets one of multiple pending asks by short session ID", 
   }
 });
 
+test("a short-ID reply unblocks the original ask when another ask is pending", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const askerHarness = createExtensionHarness("short-id-asker", { sessionId: "asker123-session" });
+  const replierHarness = createExtensionHarness("short-id-replier", { sessionId: "replier-session" });
+
+  try {
+    piIntercomExtension(askerHarness.pi as never);
+    piIntercomExtension(replierHarness.pi as never);
+    await askerHarness.emitLifecycle("session_start");
+    await replierHarness.emitLifecycle("session_start");
+    const asker = await waitForSessionByName(planner, "short-id-asker");
+    const replier = await waitForSessionByName(planner, "short-id-replier");
+    const askerTool = askerHarness.tools.find((tool) => tool.name === "intercom")!;
+    const replierTool = replierHarness.tools.find((tool) => tool.name === "intercom")!;
+
+    const originalAsk = askerTool.execute("ask-for-work", {
+      action: "ask",
+      to: replier.id,
+      message: "Is any work pending?",
+    }, new AbortController().signal, undefined, askerHarness.ctx);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal((await orchestrator.send(replier.id, {
+      messageId: "another-pending-ask",
+      text: "A separate pending question",
+      expectsReply: true,
+    })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const reply = await replierTool.execute("reply-to-work-ask", {
+      action: "reply",
+      to: asker.id.slice(0, 8),
+      message: "No work is pending.",
+    }, new AbortController().signal, undefined, replierHarness.ctx);
+    assert.equal(reply.details?.delivered, true, reply.content.map((part) => part.text).join("\n"));
+
+    const result = await originalAsk;
+    assert.doesNotMatch(result.content[0]?.text ?? "", /No reply from/);
+    assert.match(result.content[0]?.text ?? "", /No work is pending/);
+
+    const pending = await replierTool.execute("remaining-pending", { action: "pending" }, new AbortController().signal, undefined, replierHarness.ctx);
+    assert.match(pending.content[0]?.text ?? "", /another-pending-ask/);
+  } finally {
+    await askerHarness.emitLifecycle("session_shutdown");
+    await replierHarness.emitLifecycle("session_shutdown");
+    await cleanup();
+  }
+});
+
 test("broker queues replies to recently disconnected named senders", { concurrency: false }, async () => {
   const { planner, orchestrator, cleanup } = await setupClients();
   const replacement = new IntercomClient();

--- a/reply-tracker.test.ts
+++ b/reply-tracker.test.ts
@@ -50,8 +50,36 @@ test("reply with to resolves matching pending ask", () => {
   tracker.recordIncomingMessage(createSession("planner-id", "planner"), createMessage("ask-1", "First"), 1000);
   tracker.recordIncomingMessage(createSession("reviewer-id", "reviewer"), createMessage("ask-2", "Second"), 1001);
 
-  assert.equal(tracker.resolveReplyTarget({ to: "reviewer" }, 1002).message.id, "ask-2");
+  assert.equal(tracker.resolveReplyTarget({ to: "ReViEwEr" }, 1002).message.id, "ask-2");
   assert.equal(tracker.resolveReplyTarget({ to: "planner-id" }, 1002).message.id, "ask-1");
+});
+
+test("reply with to resolves a pending ask by a unique short session ID", () => {
+  const tracker = new ReplyTracker();
+  tracker.recordIncomingMessage(createSession("019fd3c4-1111-7222-8333-444444444444", "planner"), createMessage("ask-1", "First"), 1000);
+  tracker.recordIncomingMessage(createSession("019fd3d5-1111-7222-8333-444444444444", "reviewer"), createMessage("ask-2", "Second"), 1001);
+
+  assert.equal(tracker.resolveReplyTarget({ to: "019fd3c4" }, 1002).message.id, "ask-1");
+  assert.equal(tracker.resolveReplyTarget({ to: "019fd3c4", replyTo: "ask-1" }, 1002).message.id, "ask-1");
+});
+
+test("reply with to prefers an exact sender name over another sender ID prefix", () => {
+  const tracker = new ReplyTracker();
+  tracker.recordIncomingMessage(createSession("planner-session-id", "019fd3c4"), createMessage("ask-1", "Named sender"), 1000);
+  tracker.recordIncomingMessage(createSession("019fd3c4-1111-7222-8333-444444444444", "reviewer"), createMessage("ask-2", "Prefixed sender"), 1001);
+
+  assert.equal(tracker.resolveReplyTarget({ to: "019fd3c4" }, 1002).message.id, "ask-1");
+});
+
+test("reply with to clearly rejects an ambiguous session ID prefix", () => {
+  const tracker = new ReplyTracker();
+  tracker.recordIncomingMessage(createSession("019fd3c4-1111-7222-8333-444444444444", "planner"), createMessage("ask-1", "First"), 1000);
+  tracker.recordIncomingMessage(createSession("019fd3c4-5555-7666-8777-888888888888", "reviewer"), createMessage("ask-2", "Second"), 1001);
+
+  assert.throws(
+    () => tracker.resolveReplyTarget({ to: "019fd3c4" }, 1002),
+    /Multiple pending asks match ID prefix "019fd3c4" — use a longer session ID prefix or specify `replyTo`/,
+  );
 });
 
 test("explicit to overrides the current turn context", () => {

--- a/reply-tracker.ts
+++ b/reply-tracker.ts
@@ -8,11 +8,40 @@ export interface IntercomContext {
 }
 
 function matchesPendingSender(context: IntercomContext, to: string): boolean {
-  if (context.from.id === to) {
+  if (context.from.id === to || context.from.id.startsWith(to)) {
     return true;
   }
 
   return context.from.name?.toLowerCase() === to.toLowerCase();
+}
+
+function resolvePendingSender(pending: IntercomContext[], to: string): IntercomContext {
+  const exactIdMatches = pending.filter((context) => context.from.id === to);
+  if (exactIdMatches.length === 1) {
+    return exactIdMatches[0]!;
+  }
+  if (exactIdMatches.length > 1) {
+    throw new Error(`Multiple pending asks from session ID "${to}" — specify \`replyTo\``);
+  }
+
+  const lowerTo = to.toLowerCase();
+  const exactNameMatches = pending.filter((context) => context.from.name?.toLowerCase() === lowerTo);
+  if (exactNameMatches.length === 1) {
+    return exactNameMatches[0]!;
+  }
+  if (exactNameMatches.length > 1) {
+    throw new Error(`Multiple pending asks match sender name "${to}" — specify a full session ID or \`replyTo\``);
+  }
+
+  const idPrefixMatches = pending.filter((context) => context.from.id.startsWith(to));
+  if (idPrefixMatches.length === 1) {
+    return idPrefixMatches[0]!;
+  }
+  if (idPrefixMatches.length > 1) {
+    throw new Error(`Multiple pending asks match ID prefix "${to}" — use a longer session ID prefix or specify \`replyTo\``);
+  }
+
+  throw new Error(`No pending ask from "${to}"`);
 }
 
 export class ReplyTracker {
@@ -65,14 +94,7 @@ export class ReplyTracker {
 
     const pending = Array.from(this.pendingAsks.values());
     if (options.to) {
-      const matches = pending.filter((context) => matchesPendingSender(context, options.to!));
-      if (matches.length === 1) {
-        return matches[0]!;
-      }
-      if (matches.length > 1) {
-        throw new Error(`Multiple pending asks from "${options.to}" — use the sender session ID instead.`);
-      }
-      throw new Error(`No pending ask from "${options.to}"`);
+      return resolvePendingSender(pending, options.to);
     }
 
     if (this.currentTurnContext) {


### PR DESCRIPTION
## Summary

Fix pending-ask reply targeting when callers use the short session ID shown by `intercom({ action: "list" })`.

- resolve replies by unique leading session-ID prefixes
- preserve precedence: full ID, exact name, then ID prefix
- return a clear error for ambiguous prefixes
- retain exact `replyTo` validation when a short sender ID is also supplied

## Root cause

`ReplyTracker` accepted only a full sender ID or exact sender name, while the public tool schema documents that `to` may use the short ID displayed by `list`. Consequently, a pending ask could be visible but `reply({ to: "<short-id>" })` failed with `No pending ask`.

## Validation

```text
npm test
# tests 140
# pass 140
# fail 0
```
