### PR TITLE
fix: steer busy inbound messages promptly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Fixed
 - Allow replies to target pending asks by a unique sender session-ID prefix. Thanks to Benjamin Jesuiter (`bjesuiter`) for PR #85.
 - Detect half-open broker sockets and reconnect clients. Thanks to Nicolas Marchildon (`elecnix`) for issue #89 and PR #88.
-- Hand busy interactive inbound messages directly to Pi's safe steering queue instead of waiting for aggregate idle, preventing stale coordination from appearing hours after it was received. See #86.
+- Hand busy interactive inbound messages directly to Pi's safe steering queue instead of waiting for aggregate idle, preventing stale coordination from appearing hours after it was received. Thanks to Xiangzhe (`xz-dev`) for issue #86 and PR #87.
 
 ## [0.9.2] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Fixed
 - Allow replies to target pending asks by a unique sender session-ID prefix. Thanks to Benjamin Jesuiter (`bjesuiter`) for PR #85.
 - Detect half-open broker sockets and reconnect clients. Thanks to Nicolas Marchildon (`elecnix`) for issue #89 and PR #88.
+- Hand busy interactive inbound messages directly to Pi's safe steering queue instead of waiting for aggregate idle, preventing stale coordination from appearing hours after it was received. See #86.
 
 ## [0.9.2] - 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Found the issue — UserService.validate() doesn't check for null input.
 See auth.ts:142-156.
 ```
 
-The reply hint (enabled by default) points to `intercom({ action: "reply", ... })`, so recipients do not need raw sender or `replyTo` IDs. Idle recipients get a new turn immediately; busy interactive recipients receive the message once they go idle. Attachment content is included in the agent-visible body, and messages are rendered inline and stored in Pi session history.
+The reply hint (enabled by default) points to `intercom({ action: "reply", ... })`, so recipients do not need raw sender or `replyTo` IDs. Idle recipients get a new turn immediately; busy interactive recipients receive the message through Pi's steering queue at the next safe model boundary without aborting the active turn. Attachment content is included in the agent-visible body, and messages are rendered inline and stored in Pi session history.
 
 ## Workflow: Planner-Worker Coordination
 
@@ -205,7 +205,7 @@ To reply, use the intercom tool: intercom({ action: "reply", message: "..." })
 Only GET/PUT/DELETE — never POST. Max 3 retries with exponential backoff starting at 100ms.
 ```
 
-This matters because the agent receiving the message doesn't need to reconstruct raw `to` and `replyTo` IDs — the hint is right there. Combined with idle-gated `triggerTurn` delivery, it enables real back-and-forth conversation without interrupting work in progress. If the reply happens later instead of in the triggered turn, `intercom({ action: "reply" })` falls back to the single unresolved inbound ask, and `intercom({ action: "pending" })` shows who is still waiting.
+This matters because the agent receiving the message doesn't need to reconstruct raw `to` and `replyTo` IDs — the hint is right there. Combined with immediate idle triggering and safe busy-turn steering, it enables real back-and-forth conversation without aborting work in progress or delaying messages until they become stale. If the reply happens later instead of in the triggered turn, `intercom({ action: "reply" })` falls back to the single unresolved inbound ask, and `intercom({ action: "pending" })` shows who is still waiting.
 
 ### `send` vs `ask`
 
@@ -217,9 +217,9 @@ This matters because the agent receiving the message doesn't need to reconstruct
 
 The broker keeps a bounded in-memory mailbox for recently disconnected named sessions. If a lightweight CLI sender asks a long-running session something and exits before the answer, the later `reply` is accepted into that mailbox instead of failing with `Session not found`; a process that reconnects with the same name receives the queued reply. This is per-broker runtime state, not durable storage across broker restarts.
 
-Incoming messages now carry diagnostic metadata end to end: stable message ID, sender sequence, sender timestamp, broker receive/delivery timestamps, receiver receive timestamp, and injection timestamp. Receivers emit lifecycle receipts for `receiver_received`, `acknowledged`, `queued`, `injected`, `expired`, `cancelled`, `superseded`, and `cancellation_requested`; duplicate message IDs are acknowledged but injected at most once per receiving session. If an `ask` times out, the timeout names the message ID and last known delivery state. Timeout is not cancellation: the recipient may still have the message queued or actionable unless an explicit cancellation path says otherwise.
+Incoming messages carry diagnostic metadata end to end: stable message ID, sender sequence, sender timestamp, broker receive/delivery timestamps, receiver receive timestamp, and injection timestamp. Connected interactive receivers emit `receiver_received`, `acknowledged`, and `injected` as they hand messages to Pi; duplicate IDs are acknowledged but injected at most once per receiving session. Broker mailbox delivery for temporarily disconnected targets can still report queued delivery. If an `ask` times out, the timeout names the message ID and last known delivery state. Timeout is not cancellation: an injected or broker-queued message may remain actionable unless an explicit cancellation path says otherwise.
 
-Cancellation is explicit: call `intercom({ action: "cancel", messageId })` to request cancellation of a message you originally sent. If the receiver has not injected it yet, it is removed from the queue and reported as `cancelled`; if it is already injected or processed, the receiver reports `cancellation_requested` instead of hiding it. Supersede is also explicit: pass `supersedes: "old-message-id"` on a new `send` or `ask`. The broker only allows same sender → same receiver supersedes, marks the old message `superseded`, and sends the replacement with a new message ID. Retries are never automatic; a retry should be a new authored message, optionally linked with `retryOf`.
+Cancellation is explicit: call `intercom({ action: "cancel", messageId })` to request cancellation of a message you originally sent. Connected interactive messages are injected immediately, so the receiver normally reports `cancellation_requested` rather than pretending it removed work from a private queue. Supersede is also explicit: pass `supersedes: "old-message-id"` on a new `send` or `ask`. The broker only allows same sender → same receiver supersedes, marks the old message `superseded`, and sends the replacement with a new ID; an already-steered old message may still be processed. Retries are never automatic; a retry should be a new authored message, optionally linked with `retryOf`.
 
 The planner typically uses `send`. If you prefer manual approval for outgoing non-reply messages, turn on `confirmSend: true`. The worker uses `ask` for everything (no confirmation needed, gets answers inline), so it can operate autonomously either way.
 

--- a/index.ts
+++ b/index.ts
@@ -848,10 +848,13 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     const injectedMessage = { ...entry.message, injectedAt: Date.now() };
     emitMessageReceipt(injectedMessage.id, "injected");
-    const deliveredEntry = { ...entry, message: injectedMessage };
+    const replyCommand = delivery === "steer" && entry.replyCommand && entry.message.expectsReply
+      ? `intercom({ action: "reply", replyTo: ${JSON.stringify(entry.message.id)}, message: "..." })`
+      : entry.replyCommand;
+    const deliveredEntry = { ...entry, message: injectedMessage, replyCommand };
     replyTracker.queueTurnContext({ from: entry.from, message: injectedMessage, receivedAt: Date.now() });
     const senderDisplay = entry.from.name || entry.from.id.slice(0, 8);
-    const replyInstruction = entry.replyCommand ? `\n\nTo reply, use the intercom tool: ${entry.replyCommand}` : "";
+    const replyInstruction = replyCommand ? `\n\nTo reply, use the intercom tool: ${replyCommand}` : "";
     const deliveryMetadata = formatInboundDeliveryMetadata(injectedMessage);
     pi.sendMessage(
       {

--- a/index.ts
+++ b/index.ts
@@ -28,8 +28,6 @@ import { formatContextUsage } from "./format-context.ts";
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
 const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delivery";
-const INBOUND_FLUSH_DELAY_MS = 200;
-const INBOUND_IDLE_RETRY_MS = 500;
 const INBOUND_MESSAGE_DEDUPE_MAX = 1000;
 const INBOUND_MESSAGE_DEDUPE_RETENTION_MS = 60 * 60 * 1000;
 const DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX = "subagent-chat";
@@ -498,19 +496,10 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   let agentRunning = false;
   const activeTools = new Map<string, string>();
   const replyTracker = new ReplyTracker();
-  const pendingIdleMessages: InboundMessageEntry[] = [];
   const seenInboundMessages = new Map<string, number>();
   const latestOutboundReceipts = new Map<string, { status: MessageReceiptStatus; timestamp: number; detail?: string }>();
   function dismissIncomingAsk(messageId: string): void {
     replyTracker.dismissPendingAsk(messageId);
-    const queuedIndex = pendingIdleMessages.findIndex((entry) => entry.message.id === messageId);
-    if (queuedIndex >= 0) pendingIdleMessages.splice(queuedIndex, 1);
-  }
-  function expirePendingIdleMessages(detail: string): void {
-    for (const entry of pendingIdleMessages) {
-      emitMessageReceipt(entry.message.id, "expired", detail);
-    }
-    pendingIdleMessages.length = 0;
   }
   function hasSeenInboundMessage(from: SessionInfo, message: Message, now = Date.now()): boolean {
     for (const [key, seenAt] of seenInboundMessages) {
@@ -543,22 +532,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
   }
   function handleMessageControl(control: MessageControl): void {
-    const queuedIndex = pendingIdleMessages.findIndex((entry) => entry.message.id === control.messageId);
+    replyTracker.dismissPendingAsk(control.messageId);
     if (control.action === "cancel") {
-      if (queuedIndex >= 0) {
-        pendingIdleMessages.splice(queuedIndex, 1);
-        replyTracker.dismissPendingAsk(control.messageId);
-        emitMessageReceipt(control.messageId, "cancelled", "cancelled before injection");
-      } else {
-        emitMessageReceipt(control.messageId, "cancellation_requested", "message was not queued; it may already be injected or processed");
-      }
+      emitMessageReceipt(control.messageId, "cancellation_requested", "message may already be injected or processed");
       return;
     }
-
-    if (queuedIndex >= 0) {
-      pendingIdleMessages.splice(queuedIndex, 1);
-    }
-    replyTracker.dismissPendingAsk(control.messageId);
     emitMessageReceipt(control.messageId, "superseded", control.supersededBy ? `superseded by ${control.supersededBy}` : undefined);
   }
   function latestDeliveryState(messageId: string | null, fallback: string): string {
@@ -568,7 +546,6 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     const receipt = latestOutboundReceipts.get(messageId);
     return receipt ? receipt.status : fallback;
   }
-  let inboundFlushTimer: NodeJS.Timeout | null = null;
   let replyWaiter: {
     from: string;
     replyTo: string;
@@ -637,13 +614,6 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     clearInterval(namePollTimer);
     namePollTimer = null;
-  }
-  function clearInboundFlushTimer(): void {
-    if (!inboundFlushTimer) {
-      return;
-    }
-    clearTimeout(inboundFlushTimer);
-    inboundFlushTimer = null;
   }
   function getLiveContext(ctx: ExtensionContext | null = runtimeContext, generation = runtimeGeneration): ExtensionContext | null {
     if (disposed || shuttingDown || generation !== runtimeGeneration || !ctx) {
@@ -872,16 +842,14 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     return false;
   }
-  function sendIncomingMessage(entry: InboundMessageEntry, delivery: "trigger" | "followUp", generation = runtimeGeneration, forceTrigger = false): void {
+  function sendIncomingMessage(entry: InboundMessageEntry, delivery: "trigger" | "steer", generation = runtimeGeneration, forceTrigger = false): void {
     if (runtimeStarted && !getLiveContext(runtimeContext, generation)) {
       return;
     }
     const injectedMessage = { ...entry.message, injectedAt: Date.now() };
     emitMessageReceipt(injectedMessage.id, "injected");
     const deliveredEntry = { ...entry, message: injectedMessage };
-    if (delivery !== "followUp") {
-      replyTracker.queueTurnContext({ from: entry.from, message: injectedMessage, receivedAt: Date.now() });
-    }
+    replyTracker.queueTurnContext({ from: entry.from, message: injectedMessage, receivedAt: Date.now() });
     const senderDisplay = entry.from.name || entry.from.id.slice(0, 8);
     const replyInstruction = entry.replyCommand ? `\n\nTo reply, use the intercom tool: ${entry.replyCommand}` : "";
     const deliveryMetadata = formatInboundDeliveryMetadata(injectedMessage);
@@ -894,50 +862,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       },
       delivery === "trigger" && shouldTriggerInboundMessage(entry, forceTrigger)
         ? { triggerTurn: true }
-        : { deliverAs: "followUp" }
+        : { deliverAs: "steer" }
     );
-  }
-  function scheduleInboundFlush(delayMs = INBOUND_FLUSH_DELAY_MS): void {
-    if (!getLiveContext()) {
-      return;
-    }
-    const scheduledGeneration = runtimeGeneration;
-    clearInboundFlushTimer();
-    inboundFlushTimer = setTimeout(() => {
-      inboundFlushTimer = null;
-      flushIdleMessages(scheduledGeneration);
-    }, delayMs);
-  }
-  function flushIdleMessages(generation = runtimeGeneration): void {
-    if (pendingIdleMessages.length === 0) {
-      return;
-    }
-    const ctx = getLiveContext(runtimeContext, generation);
-    if (!ctx) {
-      return;
-    }
-
-    let isIdle: boolean;
-    try {
-      isIdle = ctx.isIdle();
-    } catch {
-      // Stale contexts are cleaned up by shutdown/reload; do not deliver queued messages through them.
-      return;
-    }
-    if (!isIdle) {
-      scheduleInboundFlush(INBOUND_IDLE_RETRY_MS);
-      return;
-    }
-
-    const entries = pendingIdleMessages.splice(0, pendingIdleMessages.length);
-    entries.forEach((entry, index) => {
-      sendIncomingMessage(entry, index === 0 ? "trigger" : "followUp");
-    });
-  }
-  function queueIdleMessage(entry: InboundMessageEntry): void {
-    pendingIdleMessages.push(entry);
-    emitMessageReceipt(entry.message.id, "queued");
-    scheduleInboundFlush();
   }
   function handleIncomingMessage(ctx: ExtensionContext, from: SessionInfo, message: Message): void {
     const messageGeneration = runtimeGeneration;
@@ -996,7 +922,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
           }
           return;
         }
-        queueIdleMessage(entry);
+        sendIncomingMessage(entry, "steer");
         return;
       }
       if (getLiveContext(liveContext, messageGeneration)) {
@@ -1251,10 +1177,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     clearReconnectTimer();
     clearStartupConnectTimer();
     clearNamePollTimer();
-    clearInboundFlushTimer();
     rejectReplyWaiter(new Error("Session replaced"));
     replyTracker.reset();
-    expirePendingIdleMessages("receiver session replaced before injection");
     if (previousClient) {
       client = null;
       void previousClient.disconnect().catch(() => undefined);
@@ -1400,8 +1324,6 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     restoreIntercomSessionId();
     rejectReplyWaiter(new Error("Session shutting down"));
     replyTracker.reset();
-    expirePendingIdleMessages("receiver session shut down before injection");
-    clearInboundFlushTimer();
     agentRunning = false;
     activeTools.clear();
     if (client) {
@@ -1418,7 +1340,6 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       return;
     }
     replyTracker.endTurn();
-    scheduleInboundFlush(0);
   });
   pi.on("agent_start", () => {
     if (!getLiveContext()) {
@@ -1449,7 +1370,6 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     agentRunning = false;
     activeTools.clear();
     syncPresenceStatus();
-    scheduleInboundFlush(0);
   });
   pi.on("turn_start", (_event, ctx) => {
     const sessionId = ctx.sessionManager.getSessionId();

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -1186,7 +1186,7 @@ test("busy interactive sessions steer top-level asks without aborting", { concur
     const target = await waitForSessionByName(planner, "interactive-worker");
 
     const delivered = await planner.send(target.id, {
-      messageId: "interactive-busy-ask",
+      messageId: 'interactive-busy-"ask',
       text: "Can you respond after your current turn?",
       expectsReply: true,
     });
@@ -1197,6 +1197,7 @@ test("busy interactive sessions steer top-level asks without aborting", { concur
     assert.equal(harness.sentMessages[0]?.message.customType, "intercom_message");
     assert.equal(harness.sentMessages[0]?.options?.deliverAs, "steer");
     assert.match(harness.sentMessages[0]?.message.content ?? "", /Can you respond after your current turn/);
+    assert.match(harness.sentMessages[0]?.message.content ?? "", /replyTo: "interactive-busy-\\"ask"/);
 
     await harness.emitLifecycle("turn_end");
     assert.equal(harness.sentMessages.length, 1, "turn end must not inject the steered message again");

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -1168,7 +1168,7 @@ test("turn_start re-registers when Pi replaces the session context", { concurren
   }
 });
 
-test("busy interactive sessions idle-gate top-level asks without aborting", { concurrency: false }, async () => {
+test("busy interactive sessions steer top-level asks without aborting", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
   let abortCount = 0;
@@ -1191,23 +1191,51 @@ test("busy interactive sessions idle-gate top-level asks without aborting", { co
       expectsReply: true,
     });
     assert.equal(delivered.delivered, true);
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 20));
     assert.equal(abortCount, 0);
-    assert.equal(harness.sentMessages.length, 0);
+    assert.equal(harness.sentMessages.length, 1);
+    assert.equal(harness.sentMessages[0]?.message.customType, "intercom_message");
+    assert.equal(harness.sentMessages[0]?.options?.deliverAs, "steer");
+    assert.match(harness.sentMessages[0]?.message.content ?? "", /Can you respond after your current turn/);
+
+    await harness.emitLifecycle("turn_end");
+    assert.equal(harness.sentMessages.length, 1, "turn end must not inject the steered message again");
 
     idle = true;
     await harness.emitLifecycle("agent_end");
     await new Promise((resolve) => setTimeout(resolve, 20));
 
     assert.equal(abortCount, 0);
-    assert.equal(harness.sentMessages.length, 1);
-    assert.equal(harness.sentMessages[0]?.message.customType, "intercom_message");
-    assert.equal(harness.sentMessages[0]?.options?.triggerTurn, true);
-    assert.match(harness.sentMessages[0]?.message.content ?? "", /Can you respond after your current turn/);
+    assert.equal(harness.sentMessages.length, 1, "agent end must not inject the steered message again");
   } finally {
     await harness.emitLifecycle("session_shutdown");
     await cleanup();
   }
+});
+
+test("idle interactive sessions trigger a new turn immediately", { concurrency: false }, async () => {
+	const { default: piIntercomExtension } = await import("./index.ts");
+	const { planner, cleanup } = await setupClients();
+	const harness = createExtensionHarness("idle-trigger-worker", {
+		hasUI: true,
+		isIdle: () => true,
+	});
+
+	try {
+		piIntercomExtension(harness.pi as never);
+		await harness.emitLifecycle("session_start");
+		const worker = await waitForSessionByName(planner, "idle-trigger-worker");
+
+		assert.equal((await planner.send(worker.id, { messageId: "idle-trigger", text: "Handle this now" })).delivered, true);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		assert.equal(harness.sentMessages.length, 1);
+		assert.equal(harness.sentMessages[0]?.options?.triggerTurn, true);
+		assert.equal(harness.sentMessages[0]?.options?.deliverAs, undefined);
+	} finally {
+		await harness.emitLifecycle("session_shutdown");
+		await cleanup();
+	}
 });
 
 test("duplicate inbound message IDs inject once with visible delivery metadata", { concurrency: false }, async () => {
@@ -1256,7 +1284,7 @@ test("duplicate inbound message IDs inject once with visible delivery metadata",
   }
 });
 
-test("busy interactive sessions keep same-sender queued messages in sequence order", { concurrency: false }, async () => {
+test("busy interactive sessions steer same-sender messages in sequence order", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
   let idle = false;
@@ -1276,26 +1304,25 @@ test("busy interactive sessions keep same-sender queued messages in sequence ord
       receipts.set(receipt.messageId, statuses);
     });
 
-    assert.equal((await planner.send(worker.id, { messageId: "sequence-1", text: "First queued message" })).delivered, true);
-    assert.equal((await planner.send(worker.id, { messageId: "sequence-2", text: "Second queued message" })).delivered, true);
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    assert.equal(harness.sentMessages.length, 0);
+    assert.equal((await planner.send(worker.id, { messageId: "sequence-1", text: "First steered message" })).delivered, true);
+    assert.equal((await planner.send(worker.id, { messageId: "sequence-2", text: "Second steered message" })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(harness.sentMessages.length, 2);
+    assert.match(harness.sentMessages[0]?.message.content ?? "", /First steered message/);
+    assert.match(harness.sentMessages[1]?.message.content ?? "", /Second steered message/);
+    assert.equal(harness.sentMessages[0]?.options?.deliverAs, "steer");
+    assert.equal(harness.sentMessages[1]?.options?.deliverAs, "steer");
 
     idle = true;
     await harness.emitLifecycle("agent_end");
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    assert.equal(harness.sentMessages.length, 2);
-    assert.match(harness.sentMessages[0]?.message.content ?? "", /First queued message/);
-    assert.match(harness.sentMessages[1]?.message.content ?? "", /Second queued message/);
-    assert.equal(harness.sentMessages[0]?.options?.triggerTurn, true);
-    assert.equal(harness.sentMessages[1]?.options?.deliverAs, "followUp");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(harness.sentMessages.length, 2, "steered messages must not be injected again at idle");
     const firstDetails = harness.sentMessages[0]?.message.details as { message?: Message } | undefined;
     const secondDetails = harness.sentMessages[1]?.message.details as { message?: Message } | undefined;
     assert.equal(firstDetails?.message?.senderSequence, 1);
     assert.equal(secondDetails?.message?.senderSequence, 2);
-    assert.deepEqual(receipts.get("sequence-1"), ["receiver_received", "acknowledged", "queued", "injected"]);
-    assert.deepEqual(receipts.get("sequence-2"), ["receiver_received", "acknowledged", "queued", "injected"]);
+    assert.deepEqual(receipts.get("sequence-1"), ["receiver_received", "acknowledged", "injected"]);
+    assert.deepEqual(receipts.get("sequence-2"), ["receiver_received", "acknowledged", "injected"]);
     unsubscribeReceipts();
   } finally {
     await harness.emitLifecycle("session_shutdown");
@@ -1303,7 +1330,7 @@ test("busy interactive sessions keep same-sender queued messages in sequence ord
   }
 });
 
-test("explicit cancel removes a queued inbound message before injection", { concurrency: false }, async () => {
+test("explicit cancel acknowledges that a steered inbound message may already be processed", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
   let idle = false;
@@ -1318,21 +1345,22 @@ test("explicit cancel removes a queued inbound message before injection", { conc
     const worker = await waitForSessionByName(planner, "cancel-worker");
     const receipts: string[] = [];
     const unsubscribeReceipts = planner.onMessageReceipt((_from, receipt) => {
-      if (receipt.messageId === "cancel-queued") receipts.push(receipt.status);
+      if (receipt.messageId === "cancel-steered") receipts.push(receipt.status);
     });
 
-    assert.equal((await planner.send(worker.id, { messageId: "cancel-queued", text: "Cancel this before delivery", expectsReply: true })).delivered, true);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    assert.equal(harness.sentMessages.length, 0);
-    assert.equal((await planner.cancelMessage("cancel-queued")).delivered, true);
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal((await planner.send(worker.id, { messageId: "cancel-steered", text: "Cancel after steering", expectsReply: true })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(harness.sentMessages.length, 1);
+    assert.equal(harness.sentMessages[0]?.options?.deliverAs, "steer");
+    assert.equal((await planner.cancelMessage("cancel-steered")).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
     idle = true;
     await harness.emitLifecycle("agent_end");
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
-    assert.equal(harness.sentMessages.length, 0);
-    assert.deepEqual(receipts, ["receiver_received", "acknowledged", "queued", "cancelled"]);
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(receipts, ["receiver_received", "acknowledged", "injected", "cancellation_requested"]);
     unsubscribeReceipts();
   } finally {
     await harness.emitLifecycle("session_shutdown");
@@ -1363,8 +1391,9 @@ test("intercom cancel action requests cancellation for a sent message", { concur
     const messageId = String(sendResult.details?.messageId);
     assert.equal(sendResult.details?.delivered, true);
     assert.notEqual(messageId, "undefined");
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    assert.equal(receiverHarness.sentMessages.length, 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(receiverHarness.sentMessages.length, 1);
+    assert.equal(receiverHarness.sentMessages[0]?.options?.deliverAs, "steer");
 
     const cancelResult = await intercomTool.execute("cancel-message", { action: "cancel", messageId }, new AbortController().signal, undefined, senderHarness.ctx);
     assert.equal(cancelResult.details?.delivered, true);
@@ -1372,8 +1401,8 @@ test("intercom cancel action requests cancellation for a sent message", { concur
 
     idle = true;
     await receiverHarness.emitLifecycle("agent_end");
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    assert.equal(receiverHarness.sentMessages.length, 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(receiverHarness.sentMessages.length, 1);
   } finally {
     await senderHarness.emitLifecycle("session_shutdown");
     await receiverHarness.emitLifecycle("session_shutdown");
@@ -1381,7 +1410,7 @@ test("intercom cancel action requests cancellation for a sent message", { concur
   }
 });
 
-test("same-sender supersede replaces a queued inbound message", { concurrency: false }, async () => {
+test("same-sender supersede reports an already-steered inbound message", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
   let idle = false;
@@ -1401,22 +1430,26 @@ test("same-sender supersede replaces a queued inbound message", { concurrency: f
       receipts.set(receipt.messageId, statuses);
     });
 
-    assert.equal((await planner.send(worker.id, { messageId: "superseded-message", text: "Old queued message", expectsReply: true })).delivered, true);
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal((await planner.send(worker.id, { messageId: "superseded-message", text: "Old steered message", expectsReply: true })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
     const replacement = await planner.send(worker.id, { messageId: "replacement-message", text: "Replacement message", supersedes: "superseded-message" });
     assert.equal(replacement.delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.equal(harness.sentMessages.length, 2);
+    assert.match(harness.sentMessages[0]?.message.content ?? "", /Old steered message/);
+    assert.match(harness.sentMessages[1]?.message.content ?? "", /Replacement message/);
+    assert.equal(harness.sentMessages[0]?.options?.deliverAs, "steer");
+    assert.equal(harness.sentMessages[1]?.options?.deliverAs, "steer");
+    const details = harness.sentMessages[1]?.message.details as { message?: Message } | undefined;
+    assert.equal(details?.message?.supersedes, "superseded-message");
 
     idle = true;
     await harness.emitLifecycle("agent_end");
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    assert.equal(harness.sentMessages.length, 1);
-    assert.doesNotMatch(harness.sentMessages[0]?.message.content ?? "", /Old queued message/);
-    assert.match(harness.sentMessages[0]?.message.content ?? "", /Replacement message/);
-    const details = harness.sentMessages[0]?.message.details as { message?: Message } | undefined;
-    assert.equal(details?.message?.supersedes, "superseded-message");
-    assert.deepEqual(receipts.get("superseded-message"), ["receiver_received", "acknowledged", "queued", "superseded"]);
-    assert.deepEqual(receipts.get("replacement-message"), ["receiver_received", "acknowledged", "queued", "injected"]);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(harness.sentMessages.length, 2);
+    assert.deepEqual(receipts.get("superseded-message"), ["receiver_received", "acknowledged", "injected", "superseded"]);
+    assert.deepEqual(receipts.get("replacement-message"), ["receiver_received", "acknowledged", "injected"]);
     unsubscribeReceipts();
   } finally {
     await harness.emitLifecycle("session_shutdown");
@@ -1461,7 +1494,7 @@ test("supersede is scoped to the same sender and receiver", { concurrency: false
   }
 });
 
-test("replied idle-gated asks are discarded before delivery", { concurrency: false }, async () => {
+test("replied steered asks are not injected again after the current turn", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
   let idle = false;
@@ -1482,8 +1515,9 @@ test("replied idle-gated asks are discarded before delivery", { concurrency: fal
       text: "Can you answer before this turn ends?",
       expectsReply: true,
     })).delivered, true);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    assert.equal(harness.sentMessages.length, 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(harness.sentMessages.length, 1);
+    assert.equal(harness.sentMessages[0]?.options?.deliverAs, "steer");
 
     const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
     const result = await intercomTool.execute("reply-while-busy", {
@@ -1496,8 +1530,8 @@ test("replied idle-gated asks are discarded before delivery", { concurrency: fal
 
     idle = true;
     await harness.emitLifecycle("agent_end");
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    assert.equal(harness.sentMessages.length, 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(harness.sentMessages.length, 1);
   } finally {
     await harness.emitLifecycle("session_shutdown");
     await cleanup();
@@ -1566,7 +1600,7 @@ test("stale overlay work stops after same-session restart", { concurrency: false
   }
 });
 
-test("queued inbound messages are discarded after shutdown", { concurrency: false }, async () => {
+test("steered inbound messages are not reinjected after shutdown", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
   let idle = false;
@@ -1586,20 +1620,21 @@ test("queued inbound messages are discarded after shutdown", { concurrency: fals
 
     const delivered = await planner.send(target.id, {
       messageId: "disposed-ask",
-      text: "This should not deliver after shutdown.",
+      text: "This should be steered before shutdown.",
       expectsReply: true,
     });
     assert.equal(delivered.delivered, true);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    assert.equal(harness.sentMessages.length, 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(harness.sentMessages.length, 1);
+    assert.equal(harness.sentMessages[0]?.options?.deliverAs, "steer");
 
     await harness.emitLifecycle("session_shutdown");
     idle = true;
     await harness.emitLifecycle("agent_end");
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
-    assert.equal(harness.sentMessages.length, 0);
-    assert.deepEqual(receipts, ["receiver_received", "acknowledged", "queued", "expired"]);
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(receipts, ["receiver_received", "acknowledged", "injected"]);
     unsubscribeReceipts();
   } finally {
     await cleanup();


### PR DESCRIPTION
## Summary

- hand inbound messages for busy interactive receivers directly to Pi with `deliverAs: "steer"`
- remove the receiver-side aggregate-idle queue and retry timers that could delay injection for hours
- preserve idle `triggerTurn` delivery and the existing busy non-interactive fail-closed response
- update ordering, lifecycle, cancellation/supersede tests and documentation for already-steered messages

Closes #86.

## Root cause

The broker and receiver were not slow. The receiver accepted and acknowledged messages immediately, then `pi-intercom` held them in `pendingIdleMessages` until `ctx.isIdle()` became true.

In one observed session:

- sent: `2026-08-05T16:16:47Z`
- broker delivered: immediate
- receiver received: immediate
- injected: `2026-08-05T22:34:38Z`

The message entered model context about 6h18m after receipt, after the task that needed it had already completed.

The idle gate originated as protection against aborting a busy turn. Current Pi exposes a narrower native contract: while streaming, `pi.sendMessage(..., { deliverAs: "steer" })` queues the custom message through the agent's steering queue for the next safe model boundary without calling `ctx.abort()`.

## Behavior

| Receiver state | Delivery |
|---|---|
| Interactive and idle | Existing `triggerTurn: true` |
| Interactive and busy | Immediate `deliverAs: "steer"` |
| Non-interactive and busy | Existing fail-closed auto-reply |

The change retains message IDs, sender sequence, metadata, dedupe, reply tracking, rendering and receipt order. Since connected busy messages are now handed to Pi immediately, cancellation and supersede no longer pretend they can remove a message from a private pre-injection queue; documentation and tests state that already-steered work may still be processed.

This is separate from the duplicate async completion issue reported in pi-intercom #62 / pi-subagents #662. That issue is already fixed in pi-subagents 0.37.1+ by suppressing the local completion only after grouped intercom delivery is acknowledged. This PR changes only ordinary broker inbound busy delivery and does not alter the grouped result relay/ack path.

## Testing

- Changed-path interaction tests: 10/10 passed in independent exact-head review
  - busy immediate steer and no abort
  - same-sender order
  - idle trigger
  - no turn/agent/shutdown reinjection
  - cancellation/supersede truth
  - busy non-interactive fallback
- `npm test`: 136/136 passed in a complete run
- `npm pack --dry-run`: passed, 27 files
- `git diff --check`: passed
- Intentional production mutation: focused busy test failed, then passed after restoration
- Independent exact-head review: APPROVED, C0/I0/M0

A separate unchanged broker rate-limit integration test is flaky under Node 26 because socket reset can surface as uncaught `ECONNRESET`; it reproduces on unchanged `main`. Later complete runs may therefore report 136/137 even though the changed-path tests remain green.

## Scope

Four files:

- `index.ts`
- `intercom.integration.test.ts`
- `README.md`
- `CHANGELOG.md`
