### PR TITLE
fix: show unique session ID prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 - Detect half-open broker sockets and reconnect clients. Thanks to Nicolas Marchildon (`elecnix`) for issue #89 and PR #88.
 - Hand busy interactive inbound messages directly to Pi's safe steering queue instead of waiting for aggregate idle, preventing stale coordination from appearing hours after it was received. Thanks to Xiangzhe (`xz-dev`) for issue #86 and PR #87.
 - Treat a public send to the sole pending asker as its reply. Thanks to Grant Hutchins (`nertzy`) for PR #90.
+- Display session-ID prefixes that distinguish listed sessions. Thanks to Chris Goddard (`chrisgoddard`) for issue #83.
 
 ## [0.9.2] - 2026-08-03
 

--- a/index.ts
+++ b/index.ts
@@ -377,8 +377,24 @@ function duplicateSessionNames(sessions: SessionInfo[]): Set<string> {
       .filter((name, index, names) => names.indexOf(name) !== index)
   );
 }
-function shortSessionId(sessionId: string): string {
-  return sessionId.slice(0, 8);
+function sessionIdPrefixes(sessions: SessionInfo[]): Map<string, string> {
+  const prefixes = new Map<string, string>();
+  for (const session of sessions) {
+    const longestSharedPrefix = Math.max(0, ...sessions
+      .filter((other) => other.id !== session.id)
+      .map((other) => {
+        let length = 0;
+        while (length < session.id.length && session.id[length] === other.id[length]) {
+          length += 1;
+        }
+        return length;
+      }));
+    const minimumLength = Math.max(8, longestSharedPrefix + 1);
+    const groupBoundary = session.id.indexOf("-", minimumLength);
+    const length = groupBoundary === -1 ? minimumLength : groupBoundary;
+    prefixes.set(session.id, session.id.slice(0, length));
+  }
+  return prefixes;
 }
 function parseSubagentIntercomPayload(payload: unknown): { to: string; message: string; requestId?: string } | null {
   if (typeof payload !== "object" || payload === null) {
@@ -415,15 +431,15 @@ function formatSessionLabel(session: SessionInfo, duplicates: Set<string>): stri
     return session.id;
   }
   return duplicates.has(session.name.toLowerCase())
-    ? `${session.name} (${shortSessionId(session.id)})`
+    ? `${session.name} (${session.id.slice(0, 8)})`
     : session.name;
 }
-function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: boolean): string {
+function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: boolean, idPrefix: string): string {
   const name = session.name || "Unnamed session";
   const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `• ${name} (${shortSessionId(session.id)}) — ${session.cwd} (${session.model}${formatContextUsage(session)})${suffix}`;
+  return `• ${name} (${idPrefix}) — ${session.cwd} (${session.model}${formatContextUsage(session)})${suffix}`;
 }
 function previewText(value: unknown, maxLength = 72): string | undefined {
   if (typeof value !== "string") {
@@ -1115,7 +1131,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     const lowerName = nameOrId.toLowerCase();
     const byName = sessions.filter(s => s.name?.toLowerCase() === lowerName);
     if (byName.length > 1) {
-      const ids = byName.map(s => shortSessionId(s.id)).join(", ");
+      const prefixes = sessionIdPrefixes(sessions);
+      const ids = byName.map((session) => prefixes.get(session.id)!).join(", ");
       throw new Error(`Multiple sessions named "${nameOrId}" are connected. Address one by the id shown in parentheses by "list" (${ids}).`);
     }
     if (byName.length === 1) {
@@ -1777,10 +1794,11 @@ Usage:
               };
             }
 
-            const currentSection = `**Current session:**\n${formatSessionListRow(currentSession, currentSession.cwd, true)}`;
+            const prefixes = sessionIdPrefixes(sessions);
+            const currentSection = `**Current session:**\n${formatSessionListRow(currentSession, currentSession.cwd, true, prefixes.get(currentSession.id)!)}`;
             const otherSection = otherSessions.length === 0
               ? "**Other sessions:**\nNo other sessions connected."
-              : `**Other sessions:**\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
+              : `**Other sessions:**\n${otherSessions.map((session) => formatSessionListRow(session, currentSession.cwd, false, prefixes.get(session.id)!)).join("\n")}`;
 
             return {
               content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],
@@ -1830,10 +1848,11 @@ Usage:
               }
             }
 
-            const currentSection = `**Current session:**\n${formatSessionListRow(currentSession, currentSession.cwd, true)}`;
+            const prefixes = sessionIdPrefixes(sessions);
+            const currentSection = `**Current session:**\n${formatSessionListRow(currentSession, currentSession.cwd, true, prefixes.get(currentSession.id)!)}`;
             const otherSection = otherSessions.length === 0
               ? `**Other sessions (cwd: ${filterCwd}):**\n${emptyNote}`
-              : `**Other sessions (cwd: ${filterCwd}):**\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
+              : `**Other sessions (cwd: ${filterCwd}):**\n${otherSessions.map((session) => formatSessionListRow(session, currentSession.cwd, false, prefixes.get(session.id)!)).join("\n")}`;
 
             return {
               content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -910,7 +910,7 @@ test("intercom-id inserts a stable handoff snippet into the editor", { concurren
   }
 });
 
-test("intercom tool points at the short id when names collide", { concurrency: false }, async () => {
+test("intercom tool shows unique ID prefixes when names collide", { concurrency: false }, async () => {
   const { cleanup } = await setupClients();
   const { default: piIntercomExtension } = await import("./index.ts");
   const twinA = new IntercomClient();
@@ -918,19 +918,29 @@ test("intercom tool points at the short id when names collide", { concurrency: f
   const harness = createExtensionHarness("collision-sender");
 
   try {
-    await twinA.connect({ name: "twin", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, "aaaa1111-session");
-    await twinB.connect({ name: "twin", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, "bbbb2222-session");
+    await twinA.connect({ name: "twin", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, "019fc92c-066f-755e-95d8-50ebb030d40d");
+    await twinB.connect({ name: "twin", cwd: `${repoDir}/other`, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, "019fc92c-b5f7-7536-b715-e41a4a6e9eb5");
     piIntercomExtension(harness.pi as never);
     await harness.emitLifecycle("session_start");
 
     const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
+    const listed = await intercomTool.execute("list-twin", { action: "list" }, new AbortController().signal, undefined, harness.ctx);
+    const listText = listed.content.map((part) => (part as { text?: string }).text ?? "").join("");
+    assert.match(listText, /019fc92c-066f/);
+    assert.match(listText, /019fc92c-b5f7/);
+
+    const listedCwd = await intercomTool.execute("list-cwd-twin", { action: "list-cwd" }, new AbortController().signal, undefined, harness.ctx);
+    const listCwdText = listedCwd.content.map((part) => (part as { text?: string }).text ?? "").join("");
+    assert.match(listCwdText, /019fc92c-066f/);
+    assert.doesNotMatch(listCwdText, /019fc92c-b5f7/);
+
     const result = await intercomTool.execute("send-twin", { action: "send", to: "twin", message: "which one?" }, new AbortController().signal, undefined, harness.ctx);
 
     assert.equal(result.details?.error, true);
     const text = result.content.map((part) => (part as { text?: string }).text ?? "").join("");
     assert.match(text, /parentheses/);
-    assert.match(text, /aaaa1111/);
-    assert.match(text, /bbbb2222/);
+    assert.match(text, /019fc92c-066f/);
+    assert.match(text, /019fc92c-b5f7/);
     await harness.emitLifecycle("session_shutdown");
   } finally {
     await twinA.disconnect().catch(() => undefined);


### PR DESCRIPTION
Fixes the remaining short-ID collision from #83.

`list` and `list-cwd` now show the shortest globally useful session-ID prefix for each listed session, extending to a UUID hyphen boundary when the first 8 characters collide. Ambiguous-name errors use the same displayed prefixes, so the hint no longer repeats an unusable value.

Closes #83.

Validation:
- `git diff --check origin/main..HEAD`
- `./node_modules/.bin/tsx --test --test-name-pattern 'intercom tool shows unique ID prefixes when names collide' intercom.integration.test.ts`
