### PR TITLE
refactor: simplify intercom send helpers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -380,15 +380,17 @@ function duplicateSessionNames(sessions: SessionInfo[]): Set<string> {
 function sessionIdPrefixes(sessions: SessionInfo[]): Map<string, string> {
   const prefixes = new Map<string, string>();
   for (const session of sessions) {
-    const longestSharedPrefix = Math.max(0, ...sessions
-      .filter((other) => other.id !== session.id)
-      .map((other) => {
-        let length = 0;
-        while (length < session.id.length && session.id[length] === other.id[length]) {
-          length += 1;
-        }
-        return length;
-      }));
+    let longestSharedPrefix = 0;
+    for (const other of sessions) {
+      if (other.id === session.id) {
+        continue;
+      }
+      let length = 0;
+      while (length < session.id.length && session.id[length] === other.id[length]) {
+        length += 1;
+      }
+      longestSharedPrefix = Math.max(longestSharedPrefix, length);
+    }
     const minimumLength = Math.max(8, longestSharedPrefix + 1);
     const groupBoundary = session.id.indexOf("-", minimumLength);
     const length = groupBoundary === -1 ? minimumLength : groupBoundary;
@@ -1947,15 +1949,9 @@ Usage:
             if (effectiveReplyTo) {
               dismissIncomingAsk(effectiveReplyTo);
             }
-            if (inferredAsk) {
-              return {
-                content: [{ type: "text", text: `Reply sent to ${to} (inferred from pending ask)` }],
-                details: { messageId: result.id, delivered: true, replyTo: effectiveReplyTo },
-              };
-            }
             return {
-              content: [{ type: "text", text: `Message sent to ${to}` }],
-              details: { messageId: result.id, delivered: true, replyTo: effectiveReplyTo },
+              content: [{ type: "text", text: inferredAsk ? `Reply sent to ${to} (inferred from pending ask)` : `Message sent to ${to}` }],
+              details: { messageId: result.id, delivered: true, ...(effectiveReplyTo ? { replyTo: effectiveReplyTo } : {}) },
             };
           } catch (error) {
             return {


### PR DESCRIPTION
Small TypeScript polish pass after the backlog fixes.

This keeps behavior the same and makes the touched `index.ts` paths simpler:
- replace the nested session-prefix `filter/map` chain with a plain loop
- collapse duplicated successful `send` result branches
- omit `details.replyTo` when a send is not threaded, instead of setting it to `undefined`

Validation:
- `git diff --check`
- `env -u PI_SUBAGENT_ORCHESTRATOR_TARGET -u PI_SUBAGENT_ORCHESTRATOR_SESSION_ID -u PI_SUBAGENT_RUN_ID -u PI_SUBAGENT_CHILD_AGENT -u PI_SUBAGENT_CHILD_INDEX -u PI_SUBAGENT_INTERCOM_SESSION_NAME -u PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR -u PI_INTERCOM_SESSION_ID -u PI_INTERCOM_STABLE_ID ./node_modules/.bin/tsx --test reply-tracker.test.ts intercom.integration.test.ts`
- `env -u PI_SUBAGENT_ORCHESTRATOR_TARGET -u PI_SUBAGENT_ORCHESTRATOR_SESSION_ID -u PI_SUBAGENT_RUN_ID -u PI_SUBAGENT_CHILD_AGENT -u PI_SUBAGENT_CHILD_INDEX -u PI_SUBAGENT_INTERCOM_SESSION_NAME -u PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR -u PI_INTERCOM_SESSION_ID -u PI_INTERCOM_STABLE_ID npm test`

Fresh review: no concrete findings on exact head `5819f6737707c64ca5a72d90694019e7382b068f`.
