### PR TITLE
feat: open project panes for cwd messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Added
+- Added cwd-scoped `send` and `ask` targeting plus `openProjectPaneIfMissing` for visible cross-codebase peer conversations through Herdr project panes.
+
 ### Fixed
 - Fail blocking `ask` and supervisor-decision requests immediately when the target is not connected instead of accepting a mailbox delivery that can wait until timeout.
 - Prevent disconnected mailbox routing from delivering a message back to its sender or transferring mail through runtime-only unnamed-session aliases. Thanks to ELA718 for PR #93.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ intercom({ action: "list-cwd" })
 intercom({ action: "send", to: "research", message: "Check if UserService.validate() handles null" })
 // → Message sent to research
 
+// Send to a visible peer session in another codebase, opening a Herdr project pane if needed
+intercom({
+  action: "send",
+  cwd: "/Users/me/projects/billing",
+  openProjectPaneIfMissing: true,
+  message: "Let's discuss the billing retry design in this repo."
+})
+// → Opened Herdr project pane pane-... for /Users/me/projects/billing and sent message to subagent-chat-...
+
 // Check connection status
 intercom({ action: "status" })
 // → Connected: Yes, Session ID: abc123, Active sessions: 3
@@ -248,6 +257,10 @@ If any are missing, the session falls back to the regular `intercom` tool.
 
 Do not use `contact_supervisor` for routine completion handoffs. Return the final subagent result normally through `pi-subagents`.
 
+A child subagent can still use the regular `intercom` tool to coordinate with an explicit peer session. Use `to` alone for any live peer on the machine, `cwd` alone for the sole live peer in another codebase, or `to` plus `cwd` when the directory is a safety guard. Use `contact_supervisor` instead when the answer changes the task contract, needs owner approval, or would require opening a new visible project pane.
+
+For bounded work in another codebase, prefer `pi-subagents` with an explicit `cwd`. Intercom project panes are for durable visible peer conversations, not ordinary delegated work.
+
 ### Example: Blocked Subagent Asks for Guidance
 
 ```typescript
@@ -322,13 +335,16 @@ The supervisor can reply with plain JSON or a fenced `json` block. If the reply 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `action` | string | `"list"`, `"list-cwd"`, `"send"`, `"ask"`, `"reply"`, `"pending"`, `"status"`, or `"cancel"` |
-| `to` | string | Target session name or ID (for send/ask, or to disambiguate reply) |
+| `to` | string | Target session name or ID. Without `cwd`, send/ask resolve it globally. With `cwd`, send/ask require the target to be in that directory. Also disambiguates reply. |
 | `message` | string | Message text (for send/ask/reply) |
 | `attachments` | array | Optional `file`, `snippet`, or `context` attachments |
 | `replyTo` | string | Optional message ID for threading or replying to an `ask` |
 | `messageId` | string | Optional explicit message ID for send/ask, or required message ID for `cancel` |
 | `supersedes` | string | Optional previous message ID that this send/ask explicitly replaces |
 | `retryOf` | string | Optional previous message ID that this send/ask explicitly retries |
+| `cwd` | string | Working directory filter for `list-cwd`. For send/ask, scopes target lookup to that directory; without `to`, selects the sole live peer there. |
+| `openProjectPaneIfMissing` | boolean | For `send`/`ask` with `cwd`, open a visible Herdr project pane and launch Pi when no matching live session exists |
+| `focus` | boolean | For `openProjectPaneIfMissing`, focus the new Herdr pane. Defaults to true |
 
 ### contact_supervisor
 
@@ -350,9 +366,9 @@ Only registered in sessions where `pi-subagents` supplied the required child bri
 
 **`list`** — Returns the current session plus other active intercom-connected sessions with name, short ID, working directory, model, and live status. Status is derived automatically from Pi lifecycle events: `idle`, `thinking`, or `tool:<name>`.
 
-**`send`** — Sends a message to the specified session and returns immediately after delivery. If the destination has exactly one pending inbound ask, `send` infers the message is its answer and returns `Reply sent to <target> (inferred from pending ask)`; zero or multiple matches remain unthreaded sends. Set `confirmSend: true` to confirm ordinary and inferred sends. A caller-supplied `replyTo` skips confirmation.
+**`send`** — Sends a message to the specified session and returns immediately after delivery. If the destination has exactly one pending inbound ask, `send` infers the message is its answer and returns `Reply sent to <target> (inferred from pending ask)`; zero or multiple matches remain unthreaded sends. Set `confirmSend: true` to confirm ordinary and inferred sends. A caller-supplied `replyTo` skips confirmation. `to` alone resolves globally across all live sessions. `cwd` alone targets the sole live peer in that directory. `to` plus `cwd` requires that peer to be in the directory. With `openProjectPaneIfMissing: true`, pi-intercom opens a visible Herdr project pane, starts Pi there, waits for that session to register, then delivers the message through normal intercom routing.
 
-**`ask`** — Requires a currently connected recipient, sends a message, and waits for the recipient to reply (10-minute timeout by default; configurable with `PI_INTERCOM_ASK_TIMEOUT_MS`). A disconnected target fails immediately rather than queueing a blocking request. The reply is returned as the tool result. No confirmation dialog. Only one pending `ask` is allowed per session at a time. Use this when the agent needs the answer to continue working.
+**`ask`** — Requires a currently connected recipient, sends a message, and waits for the recipient to reply (10-minute timeout by default; configurable with `PI_INTERCOM_ASK_TIMEOUT_MS`). A disconnected target fails immediately rather than queueing a blocking request. The reply is returned as the tool result. No confirmation dialog. Only one pending `ask` is allowed per session at a time. Use this when the agent needs the answer to continue working. The same `to`, `cwd`, and `openProjectPaneIfMissing` targeting rules apply.
 
 **`reply`** — Replies to the current intercom-triggered message if there is one. Otherwise it falls back to the single unresolved inbound ask. If multiple asks are pending, pass `to` or inspect them with `pending` first. Under the hood this is still a normal `send` with the exact `replyTo` value.
 
@@ -523,6 +539,7 @@ Use pi-messenger for multi-agent swarms working on a shared task. Use pi-interco
 ├── index.ts              # Extension entry point
 ├── types.ts              # SessionInfo, Message, protocol types
 ├── config.ts             # Config loading
+├── project-agent.ts      # Herdr project-pane launch and cwd target resolution
 ├── broker/
 │   ├── broker.ts         # Broker process
 │   ├── client.ts         # IntercomClient class

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@ import { ReplyTracker } from "./reply-tracker.ts";
 import { resolve as resolvePath } from "node:path";
 import { sameCwd } from "./cwd.ts";
 import { formatContextUsage } from "./format-context.ts";
+import { openProjectPane, resolveTargetInCwd, waitForProjectSession, type ProjectPaneLaunch } from "./project-agent.ts";
 
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
@@ -56,6 +57,12 @@ interface InboundMessageEntry {
   message: Message;
   replyCommand?: string;
   bodyText: string;
+}
+
+interface DeliveryTarget {
+  id: string;
+  label: string;
+  projectPane?: ProjectPaneLaunch;
 }
 
 type ContactSupervisorReason = "need_decision" | "progress_update" | "interview_request";
@@ -1165,6 +1172,50 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
     return resolveSessionTarget(activeClient, metadata.orchestratorTarget);
   }
+  async function resolveCwdDeliveryTarget(activeClient: IntercomClient, options: {
+    to?: string;
+    cwd: string;
+    openProjectPaneIfMissing?: boolean;
+    focus?: boolean;
+    signal?: AbortSignal;
+  }): Promise<DeliveryTarget> {
+    const sessions = await activeClient.listSessions();
+    const currentSessionId = activeClient.sessionId;
+    if (!currentSessionId) {
+      throw new Error("Current session is not registered with intercom.");
+    }
+    const currentSession = sessions.find((session) => session.id === currentSessionId);
+    if (!currentSession) {
+      throw new Error("Current session is missing from intercom session list.");
+    }
+
+    const targetCwd = options.cwd && options.cwd !== "."
+      ? resolvePath(currentSession.cwd, options.cwd)
+      : currentSession.cwd;
+    const existing = resolveTargetInCwd({
+      sessions,
+      currentSessionId,
+      targetCwd,
+      ...(options.to ? { to: options.to } : {}),
+    });
+    if (existing.kind === "found" && existing.session) {
+      return { id: existing.session.id, label: options.to || existing.session.name || existing.session.id };
+    }
+    if (!options.openProjectPaneIfMissing) {
+      throw new Error(`${existing.reason ?? `No intercom session is connected in ${targetCwd}.`} Pass openProjectPaneIfMissing: true to open a Herdr project pane and start Pi there.`);
+    }
+
+    const beforeSessionIds = new Set(sessions.map((session) => session.id));
+    const projectPane = await openProjectPane({ cwd: targetCwd, focus: options.focus, signal: options.signal });
+    const session = await waitForProjectSession(activeClient, {
+      projectRoot: projectPane.projectRoot,
+      currentSessionId,
+      beforeSessionIds,
+      ...(options.to ? { to: options.to } : {}),
+      signal: options.signal,
+    });
+    return { id: session.id, label: session.name || session.id, projectPane };
+  }
   function deliverLocalSubagentRelayMessage(sender: "subagent-control" | "subagent-result", status: string, messageText: string): void {
     const liveContext = getLiveContext();
     const now = Date.now();
@@ -1740,6 +1791,7 @@ Usage:
   intercom({ action: "list-cwd" })                → List sessions in the current working directory
   intercom({ action: "list-cwd", cwd: "/path" })  → List sessions in a specific directory
   intercom({ action: "send", to: "name-or-id", message: "..." })  → Send message
+  intercom({ action: "send", cwd: "/path", openProjectPaneIfMissing: true, message: "..." }) → Open a visible Herdr project pane when needed, then send
   intercom({ action: "ask", to: "name-or-id", message: "..." })   → Ask and wait for reply
   intercom({ action: "cancel", messageId: "..." })                 → Request cancellation of a sent message
   intercom({ action: "reply", message: "..." })                      → Reply to the active/single pending ask
@@ -1753,7 +1805,7 @@ Usage:
         description: "Action: 'list', 'list-cwd', 'send', 'ask', 'reply', 'pending', 'status', or 'cancel'",
       }),
       to: Type.Optional(Type.String({
-        description: "Target session: name, full session ID, or the short id shown in parentheses by 'list' (a leading ID prefix resolves). For 'send', 'ask', or disambiguating 'reply'.",
+        description: "Target session: name, full session ID, or the short id shown in parentheses by 'list' (a leading ID prefix resolves). For send/ask with cwd, omit to target the sole live session in that cwd or the newly opened project-pane session. For 'reply', disambiguates the pending ask.",
       })),
       message: Type.Optional(Type.String({
         description: "Message to send (for 'send', 'ask', or 'reply' action)",
@@ -1777,7 +1829,13 @@ Usage:
         description: "Previous message ID this send/ask is a user-authored retry of. Retries always send a new message ID.",
       })),
       cwd: Type.Optional(Type.String({
-        description: "Working directory filter for 'list-cwd' (absolute, or relative to the current session's cwd; '.' means the current cwd). Defaults to the current session's cwd.",
+        description: "Working directory filter for 'list-cwd'. For send/ask, scopes target lookup to that directory; omit 'to' to target the sole live peer there. Absolute, or relative to the current session's cwd; '.' means the current cwd.",
+      })),
+      openProjectPaneIfMissing: Type.Optional(Type.Boolean({
+        description: "For send/ask with cwd, open a visible Herdr project pane and launch Pi there when no matching live session is connected.",
+      })),
+      focus: Type.Optional(Type.Boolean({
+        description: "For openProjectPaneIfMissing, focus the new Herdr pane. Defaults to true.",
       })),
     }),
 
@@ -1794,7 +1852,7 @@ Usage:
 
       syncPresenceIdentity(ctx.sessionManager.getSessionId());
 
-      const { action, to, message, attachments, replyTo, messageId, supersedes, retryOf, cwd } = params;
+      const { action, to, message, attachments, replyTo, messageId, supersedes, retryOf, cwd, openProjectPaneIfMissing, focus } = params;
 
       switch (action) {
         case "list": {
@@ -1912,14 +1970,38 @@ Usage:
         }
 
         case "send": {
-          if (!to || !message) {
+          if ((!to && !cwd) || !message) {
             return {
-              content: [{ type: "text", text: "Missing 'to' or 'message' parameter" }],
+              content: [{ type: "text", text: "Missing 'to' or 'cwd', or missing 'message' parameter" }],
               details: { error: true },
             };
           }
           try {
-            const sendTo = await resolveSessionTarget(connectedClient, to) ?? to;
+            if (openProjectPaneIfMissing && !cwd) {
+              return {
+                content: [{ type: "text", text: "openProjectPaneIfMissing requires a target cwd." }],
+                details: { error: true },
+              };
+            }
+            const confirmSend = !replyTo && config.confirmSend && ctx.hasUI;
+            const attachmentText = attachments?.length ? formatAttachments(attachments) : "";
+            if (confirmSend && cwd && openProjectPaneIfMissing) {
+              const confirmed = await ctx.ui.confirm(
+                "Send Message",
+                `Send to "${to ?? cwd}":\n\n${message}${attachmentText}`,
+              );
+              if (!confirmed) {
+                return {
+                  content: [{ type: "text", text: "Message cancelled by user" }],
+                  details: {},
+                };
+              }
+            }
+            const target: DeliveryTarget = cwd
+              ? await resolveCwdDeliveryTarget(connectedClient, { to, cwd, openProjectPaneIfMissing, focus, signal: _signal })
+              : { id: await resolveSessionTarget(connectedClient, to) ?? to, label: to };
+            const sendTo = target.id;
+            const targetDisplay = target.projectPane ? target.label : to ?? target.label;
             if (sendTo === connectedClient.sessionId) {
               return {
                 content: [{ type: "text", text: "Cannot message the current session" }],
@@ -1928,11 +2010,10 @@ Usage:
             }
             const inferredAsk = replyTo ? null : replyTracker.findUniquePendingAskFrom(sendTo);
             const effectiveReplyTo = replyTo ?? inferredAsk?.message.id;
-            if (!replyTo && config.confirmSend && ctx.hasUI) {
-              const attachmentText = attachments?.length ? formatAttachments(attachments) : "";
+            if (confirmSend && !(cwd && openProjectPaneIfMissing)) {
               const confirmed = await ctx.ui.confirm(
                 "Send Message",
-                `Send to "${to}":\n\n${message}${attachmentText}`,
+                `Send to "${targetDisplay}":\n\n${message}${attachmentText}`,
               );
               if (!confirmed) {
                 return {
@@ -1951,12 +2032,12 @@ Usage:
             if (!result.delivered) {
               const errorText = result.reason ?? "Session may not exist or has disconnected.";
               return {
-                content: [{ type: "text", text: `Message to "${to}" was not delivered: ${errorText}` }],
+                content: [{ type: "text", text: `Message to "${targetDisplay}" was not delivered: ${errorText}` }],
                 details: { messageId: result.id, delivered: false, reason: result.reason },
               };
             }
             pi.appendEntry("intercom_sent", {
-              to,
+              to: targetDisplay,
               message: { text: message, attachments, replyTo: effectiveReplyTo, supersedes, retryOf },
               messageId: result.id,
               timestamp: Date.now(),
@@ -1965,8 +2046,18 @@ Usage:
               dismissIncomingAsk(effectiveReplyTo);
             }
             return {
-              content: [{ type: "text", text: inferredAsk ? `Reply sent to ${to} (inferred from pending ask)` : `Message sent to ${to}` }],
-              details: { messageId: result.id, delivered: true, ...(effectiveReplyTo ? { replyTo: effectiveReplyTo } : {}) },
+              content: [{
+                type: "text",
+                text: target.projectPane
+                  ? `Opened Herdr project pane ${target.projectPane.paneId} for ${target.projectPane.projectRoot} and sent message to ${targetDisplay}`
+                  : inferredAsk ? `Reply sent to ${targetDisplay} (inferred from pending ask)` : `Message sent to ${targetDisplay}`,
+              }],
+              details: {
+                messageId: result.id,
+                delivered: true,
+                ...(effectiveReplyTo ? { replyTo: effectiveReplyTo } : {}),
+                ...(target.projectPane ? { openedProjectPane: true, paneId: target.projectPane.paneId, projectRoot: target.projectPane.projectRoot } : {}),
+              },
             };
           } catch (error) {
             return {
@@ -1977,9 +2068,9 @@ Usage:
         }
 
         case "ask": {
-          if (!to || !message) {
+          if ((!to && !cwd) || !message) {
             return {
-              content: [{ type: "text", text: "Missing 'to' or 'message' parameter" }],
+              content: [{ type: "text", text: "Missing 'to' or 'cwd', or missing 'message' parameter" }],
               details: { error: true },
             };
           }
@@ -2002,13 +2093,27 @@ Usage:
           let questionId: string | null = null;
 
           try {
-            const sendTo = await resolveSessionTarget(connectedClient, to);
-            if (!sendTo) {
+            if (openProjectPaneIfMissing && !cwd) {
               return {
-                content: [{ type: "text", text: `Session "${to}" is not currently connected. Blocking asks are not queued; use send for a non-blocking mailbox delivery or retry after the session reconnects.` }],
+                content: [{ type: "text", text: "openProjectPaneIfMissing requires a target cwd." }],
                 details: { error: true },
               };
             }
+            let target: DeliveryTarget;
+            if (cwd) {
+              target = await resolveCwdDeliveryTarget(connectedClient, { to, cwd, openProjectPaneIfMissing, focus, signal: _signal });
+            } else {
+              const resolved = await resolveSessionTarget(connectedClient, to);
+              if (!resolved) {
+                return {
+                  content: [{ type: "text", text: `Session "${to}" is not currently connected. Blocking asks are not queued; use send for a non-blocking mailbox delivery or retry after the session reconnects.` }],
+                  details: { error: true },
+                };
+              }
+              target = { id: resolved, label: to };
+            }
+            const sendTo = target.id;
+            const targetDisplay = target.projectPane ? target.label : to ?? target.label;
             if (_signal?.aborted) {
               return {
                 content: [{ type: "text", text: "Cancelled" }],
@@ -2043,7 +2148,7 @@ Usage:
             deliveryState = sendResult.delivered ? "socket_delivered" : "delivery_failed";
             if (!sendResult.delivered) {
               const errorText = sendResult.reason ?? "Session may not exist or has disconnected.";
-              rejectReplyWaiter(new Error(`Message to "${to}" was not delivered: ${errorText}`));
+              rejectReplyWaiter(new Error(`Message to "${targetDisplay}" was not delivered: ${errorText}`));
               if (replyPromise) {
                 try {
                   await replyPromise;
@@ -2052,12 +2157,12 @@ Usage:
                 }
               }
               return {
-                content: [{ type: "text", text: `Message to "${to}" was not delivered: ${errorText}` }],
+                content: [{ type: "text", text: `Message to "${targetDisplay}" was not delivered: ${errorText}` }],
                 details: { error: true },
               };
             }
             pi.appendEntry("intercom_sent", {
-              to,
+              to: targetDisplay,
               message: { text: message, attachments, replyTo, supersedes, retryOf },
               messageId: sendResult.id,
               timestamp: Date.now(),
@@ -2068,14 +2173,14 @@ Usage:
               ? formatAttachments(replyMessage.content.attachments)
               : "";
             pi.appendEntry("intercom_received", {
-              from: to,
+              from: targetDisplay,
               message: { text: replyText, attachments: replyMessage.content.attachments },
               messageId: replyMessage.id,
               timestamp: replyMessage.timestamp,
             });
             return {
-              content: [{ type: "text", text: `**Reply from ${to}:**\n${replyText}${replyAttachments}` }],
-              details: {},
+              content: [{ type: "text", text: `**Reply from ${targetDisplay}:**\n${replyText}${replyAttachments}` }],
+              details: target.projectPane ? { openedProjectPane: true, paneId: target.projectPane.paneId, projectRoot: target.projectPane.projectRoot } : {},
             };
           } catch (error) {
             rejectReplyWaiter(toError(error));

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     "cwd.ts",
     "extension-api.ts",
     "format-context.ts",
+    "project-agent.ts",
     "reply-tracker.ts",
     "broker/**/*.ts",
     "ui/**/*.ts",
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/client-liveness.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/runtime-claim.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/client-liveness.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/runtime-claim.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts project-agent.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/project-agent.test.ts
+++ b/project-agent.test.ts
@@ -1,0 +1,145 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  openProjectPane,
+  resolveTargetInCwd,
+  waitForProjectSession,
+  type HerdrClient,
+} from "./project-agent.ts";
+import type { SessionInfo } from "./types.ts";
+
+function session(id: string, name: string | undefined, cwd: string): SessionInfo {
+  return {
+    id,
+    ...(name ? { name } : {}),
+    cwd,
+    model: "test-model",
+    pid: process.pid,
+    startedAt: 1,
+    lastActivity: 1,
+  };
+}
+
+test("resolveTargetInCwd selects the sole peer in the requested cwd", () => {
+  const resolved = resolveTargetInCwd({
+    sessions: [
+      session("self", "self", "/repo-a"),
+      session("worker-a", "worker", "/repo-b"),
+      session("worker-other", "worker", "/repo-c"),
+    ],
+    currentSessionId: "self",
+    targetCwd: "/repo-b",
+  });
+
+  assert.equal(resolved.kind, "found");
+  assert.equal(resolved.session?.id, "worker-a");
+});
+
+test("resolveTargetInCwd fails when a cwd has multiple possible peers and no target", () => {
+  assert.throws(
+    () => resolveTargetInCwd({
+      sessions: [
+        session("self", "self", "/repo-a"),
+        session("worker-a", "worker-a", "/repo-b"),
+        session("worker-b", "worker-b", "/repo-b"),
+      ],
+      currentSessionId: "self",
+      targetCwd: "/repo-b",
+    }),
+    /Multiple intercom sessions are connected in \/repo-b/,
+  );
+});
+
+test("resolveTargetInCwd scopes names to the requested cwd", () => {
+  const resolved = resolveTargetInCwd({
+    sessions: [
+      session("self", "self", "/repo-a"),
+      session("worker-a", "worker", "/repo-b"),
+      session("worker-other", "worker", "/repo-c"),
+    ],
+    currentSessionId: "self",
+    targetCwd: "/repo-b",
+    to: "worker",
+  });
+
+  assert.equal(resolved.kind, "found");
+  assert.equal(resolved.session?.id, "worker-a");
+});
+
+test("openProjectPane opens a Herdr pane and runs pi in the project", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-project-pane-"));
+  const project = join(root, "project");
+  mkdirSync(project);
+  const calls: string[][] = [];
+  const client: HerdrClient = {
+    async run(args) {
+      calls.push(args);
+      if (args[0] === "--version") return { ok: true, data: "herdr 0.7.5" };
+      if (args[0] === "pane" && args[1] === "split") return { ok: true, data: { pane: { id: "pane-1" } } };
+      if (args[0] === "pane" && args[1] === "run") return { ok: true, data: {} };
+      return { ok: false, error: { code: "VALIDATION_ERROR", message: `unexpected ${args.join(" ")}` } };
+    },
+  };
+
+  try {
+    const launched = await openProjectPane({ cwd: project, focus: false, client });
+
+    assert.equal(launched.paneId, "pane-1");
+    assert.equal(launched.herdrVersion, "herdr 0.7.5");
+    assert.deepEqual(calls[1], ["pane", "split", "--current", "--direction", "right", "--cwd", launched.projectRoot]);
+    assert.deepEqual(calls[2], ["pane", "run", "pane-1", "'pi'"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("waitForProjectSession returns the new project-pane session when no target is named", async () => {
+  const before = [session("self", "self", "/repo-a")];
+  const after = [...before, session("pane-peer", "subagent-chat-pane", "/repo-b")];
+  let calls = 0;
+  const client = {
+    async listSessions() {
+      calls += 1;
+      return calls === 1 ? before : after;
+    },
+  };
+
+  const resolved = await waitForProjectSession(client, {
+    projectRoot: "/repo-b",
+    currentSessionId: "self",
+    beforeSessionIds: new Set(before.map((item) => item.id)),
+    pollMs: 1,
+    timeoutMs: 100,
+  });
+
+  assert.equal(resolved.id, "pane-peer");
+});
+
+test("waitForProjectSession honors the target guard after opening a project pane", async () => {
+  const before = [session("self", "self", "/repo-a")];
+  const afterUnnamed = [...before, session("pane-peer", "subagent-chat-pane", "/repo-b")];
+  const afterNamed = [...afterUnnamed, session("worker-id", "worker", "/repo-b")];
+  let calls = 0;
+  const client = {
+    async listSessions() {
+      calls += 1;
+      if (calls === 1) return before;
+      if (calls === 2) return afterUnnamed;
+      return afterNamed;
+    },
+  };
+
+  const resolved = await waitForProjectSession(client, {
+    projectRoot: "/repo-b",
+    currentSessionId: "self",
+    beforeSessionIds: new Set(before.map((item) => item.id)),
+    to: "worker",
+    pollMs: 1,
+    timeoutMs: 100,
+  });
+
+  assert.equal(resolved.id, "worker-id");
+});

--- a/project-agent.ts
+++ b/project-agent.ts
@@ -1,0 +1,328 @@
+import { spawn, type ChildProcess } from "child_process";
+import { realpathSync, statSync } from "fs";
+import { resolve } from "path";
+import { sameCwd } from "./cwd.ts";
+import type { SessionInfo } from "./types.ts";
+
+const DEFAULT_PROJECT_AGENT_TIMEOUT_MS = 20_000;
+const DEFAULT_PROJECT_AGENT_POLL_MS = 250;
+
+export type HerdrErrorCode =
+  | "HERDR_UNAVAILABLE"
+  | "HERDR_UNSUPPORTED_VERSION"
+  | "PANE_GONE"
+  | "NOT_FOUND"
+  | "TIMEOUT"
+  | "VALIDATION_ERROR";
+
+export type HerdrResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: { code: HerdrErrorCode; message: string; details?: unknown } };
+
+export interface HerdrClient {
+  run<T = unknown>(args: string[], options?: { timeoutMs?: number; signal?: AbortSignal; textOk?: boolean }): Promise<HerdrResult<T>>;
+}
+
+type SpawnHerdr = (command: string, args: readonly string[], options: { shell: false; windowsHide: true; env: NodeJS.ProcessEnv }) => ChildProcess;
+
+export interface ProjectPaneLaunch {
+  paneId: string;
+  projectRoot: string;
+  command: string;
+  herdrVersion: string;
+}
+
+export interface ProjectTargetResolution {
+  kind: "found" | "missing";
+  session?: SessionInfo;
+  targetCwd: string;
+  reason?: string;
+}
+
+export interface ListSessionsClient {
+  listSessions(options?: { timeoutMs?: number }): Promise<SessionInfo[]>;
+}
+
+function error(code: HerdrErrorCode, message: string, details?: unknown): HerdrResult<never> {
+  return { ok: false, error: { code, message, ...(details !== undefined ? { details } : {}) } };
+}
+
+function parseLastJson(value: string): unknown | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try { return JSON.parse(trimmed) as unknown; } catch {}
+  for (const line of trimmed.split(/\r?\n/).reverse()) {
+    try { return JSON.parse(line) as unknown; } catch {}
+  }
+  return undefined;
+}
+
+function normalizeCode(raw: unknown): HerdrErrorCode {
+  const code = String(raw ?? "").toLowerCase();
+  if (code.includes("timeout") || code.includes("timed_out")) return "TIMEOUT";
+  if (code.includes("gone")) return "PANE_GONE";
+  if (code.includes("not_found") || code.includes("not-found") || code === "no_such_pane") return "NOT_FOUND";
+  return "VALIDATION_ERROR";
+}
+
+export function createHerdrClient(options: { bin?: string; spawn?: SpawnHerdr } = {}): HerdrClient {
+  const bin = options.bin ?? process.env.HERDR_BIN ?? "herdr";
+  const spawnImpl = options.spawn ?? spawn;
+  return {
+    run<T>(args: string[], runOptions: { timeoutMs?: number; signal?: AbortSignal; textOk?: boolean } = {}): Promise<HerdrResult<T>> {
+      return new Promise((resolveResult) => {
+        let child: ChildProcess;
+        try {
+          child = spawnImpl(bin, args, { shell: false, windowsHide: true, env: process.env });
+        } catch (cause) {
+          const code = (cause as NodeJS.ErrnoException | undefined)?.code;
+          resolveResult(error("HERDR_UNAVAILABLE", code === "ENOENT"
+            ? "Herdr is not installed or is not on PATH. Install Herdr 0.7.5+ or set HERDR_BIN."
+            : `Failed to start Herdr: ${cause instanceof Error ? cause.message : String(cause)}`));
+          return;
+        }
+
+        let stdout = "";
+        let stderr = "";
+        let settled = false;
+        const finish = (result: HerdrResult<T>) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          runOptions.signal?.removeEventListener("abort", abort);
+          resolveResult(result);
+        };
+        const abort = () => {
+          try { child.kill(); } catch {}
+          finish(error("TIMEOUT", `Herdr command '${args.join(" ")}' was aborted.`));
+        };
+        const timer = setTimeout(() => {
+          try { child.kill(); } catch {}
+          finish(error("TIMEOUT", `Herdr command '${args.join(" ")}' timed out after ${runOptions.timeoutMs ?? 15_000}ms.`));
+        }, runOptions.timeoutMs ?? 15_000);
+        timer.unref?.();
+
+        if (runOptions.signal?.aborted) abort();
+        else runOptions.signal?.addEventListener("abort", abort, { once: true });
+        child.stdout?.on("data", (chunk) => { stdout += chunk.toString(); });
+        child.stderr?.on("data", (chunk) => { stderr += chunk.toString(); });
+        child.on("error", (cause) => {
+          const code = (cause as NodeJS.ErrnoException).code;
+          finish(error("HERDR_UNAVAILABLE", code === "ENOENT"
+            ? "Herdr is not installed or is not on PATH. Install Herdr 0.7.5+ or set HERDR_BIN."
+            : `Failed to run Herdr: ${cause.message}`));
+        });
+        child.on("close", (exitCode) => {
+          const parsed = parseLastJson(stdout) ?? (exitCode === 0 ? undefined : parseLastJson(stderr));
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && "error" in parsed) {
+            const raw = (parsed as { error?: { code?: unknown; message?: unknown } }).error;
+            finish(error(normalizeCode(raw?.code), String(raw?.message ?? "Herdr command failed."), raw));
+            return;
+          }
+          if (exitCode === 0) {
+            if (parsed !== undefined) {
+              const envelope = parsed as { result?: unknown };
+              finish({ ok: true, data: (envelope.result ?? parsed) as T });
+            } else if (runOptions.textOk) {
+              finish({ ok: true, data: stdout.trim() as T });
+            } else {
+              finish({ ok: true, data: {} as T });
+            }
+            return;
+          }
+          const message = stderr.split(/\r?\n/).find((line) => line.trim())?.trim() ?? `Herdr exited with code ${exitCode}.`;
+          finish(error("VALIDATION_ERROR", message, { exitCode }));
+        });
+      });
+    },
+  };
+}
+
+function formatHerdrError(input: { code: HerdrErrorCode; message: string }): string {
+  return `Herdr project pane error (${input.code}): ${input.message}`;
+}
+
+function parseHerdrVersion(value: string): { major: number; minor: number; patch: number } | undefined {
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(value);
+  return match ? { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) } : undefined;
+}
+
+function supportsRawPanes(version: { major: number; minor: number; patch: number }): boolean {
+  return version.major > 0 || version.minor > 7 || (version.minor === 7 && version.patch >= 5);
+}
+
+async function detectHerdr(client: HerdrClient, signal?: AbortSignal): Promise<HerdrResult<{ versionText: string }>> {
+  const result = await client.run<string>(["--version"], { timeoutMs: 3_000, signal, textOk: true });
+  if (result.ok === false) return result;
+  const versionText = typeof result.data === "string" ? result.data : JSON.stringify(result.data);
+  const version = parseHerdrVersion(versionText);
+  if (!version) return error("VALIDATION_ERROR", `Could not parse the Herdr version from '${versionText}'.`);
+  if (!supportsRawPanes(version)) return error("HERDR_UNSUPPORTED_VERSION", `Herdr ${versionText} does not support raw panes. Upgrade to Herdr 0.7.5 or newer.`);
+  return { ok: true, data: { versionText } };
+}
+
+function extractPaneId(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const pane = record.pane && typeof record.pane === "object" && !Array.isArray(record.pane) ? record.pane as Record<string, unknown> : record;
+  for (const key of ["pane_id", "paneId", "id"]) {
+    if (typeof pane[key] === "string") return pane[key];
+  }
+  return undefined;
+}
+
+function shellQuote(value: string): string {
+  if (process.platform === "win32") return `"${value.replaceAll('"', '\\"')}"`;
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+export function buildProjectPaneCommand(piCommand: string = process.env.PI_INTERCOM_PI_BIN?.trim() || process.env.PI_BIN?.trim() || "pi"): string {
+  return shellQuote(piCommand);
+}
+
+export function resolveProjectRoot(cwd: string): string {
+  const resolved = resolve(cwd);
+  const stat = statSync(resolved);
+  if (!stat.isDirectory()) {
+    throw new Error(`Project target '${resolved}' is not a directory.`);
+  }
+  return realpathSync(resolved);
+}
+
+export function resolveTargetInCwd(input: {
+  sessions: SessionInfo[];
+  currentSessionId: string;
+  targetCwd: string;
+  to?: string;
+}): ProjectTargetResolution {
+  const inCwd = input.sessions.filter((session) => sameCwd(session.cwd, input.targetCwd));
+  const target = input.to?.trim();
+
+  if (!target) {
+    const candidates = inCwd.filter((session) => session.id !== input.currentSessionId);
+    if (candidates.length === 1) {
+      return { kind: "found", session: candidates[0], targetCwd: input.targetCwd };
+    }
+    if (candidates.length === 0) {
+      return { kind: "missing", targetCwd: input.targetCwd, reason: `No other intercom sessions are connected in ${input.targetCwd}.` };
+    }
+    throw new Error(`Multiple intercom sessions are connected in ${input.targetCwd}: ${formatSessionRefs(candidates)}. Specify 'to'.`);
+  }
+
+  const byId = inCwd.find((session) => session.id === target);
+  if (byId) return { kind: "found", session: byId, targetCwd: input.targetCwd };
+
+  const lowerName = target.toLowerCase();
+  const byName = inCwd.filter((session) => session.name?.toLowerCase() === lowerName);
+  if (byName.length === 1) return { kind: "found", session: byName[0], targetCwd: input.targetCwd };
+  if (byName.length > 1) {
+    throw new Error(`Multiple intercom sessions named "${target}" are connected in ${input.targetCwd}: ${formatSessionRefs(byName)}. Address one by session ID.`);
+  }
+
+  const byIdPrefix = inCwd.filter((session) => session.id.startsWith(target));
+  if (byIdPrefix.length === 1) return { kind: "found", session: byIdPrefix[0], targetCwd: input.targetCwd };
+  if (byIdPrefix.length > 1) {
+    throw new Error(`Multiple intercom sessions in ${input.targetCwd} match ID prefix "${target}". Use a longer session ID prefix.`);
+  }
+
+  return { kind: "missing", targetCwd: input.targetCwd, reason: `No intercom session matching "${target}" is connected in ${input.targetCwd}.` };
+}
+
+export async function openProjectPane(input: {
+  cwd: string;
+  focus?: boolean;
+  client?: HerdrClient;
+  signal?: AbortSignal;
+}): Promise<ProjectPaneLaunch> {
+  const projectRoot = resolveProjectRoot(input.cwd);
+  const client = input.client ?? createHerdrClient();
+  const detected = await detectHerdr(client, input.signal);
+  if (detected.ok === false) throw new Error(formatHerdrError(detected.error));
+
+  const splitArgs = ["pane", "split", "--current", "--direction", "right", "--cwd", projectRoot];
+  if (input.focus !== false) splitArgs.push("--focus");
+  const split = await client.run(splitArgs, { timeoutMs: 15_000, signal: input.signal });
+  if (split.ok === false) throw new Error(formatHerdrError(split.error));
+  const paneId = extractPaneId(split.data);
+  if (!paneId) throw new Error("Herdr project pane error (PANE_GONE): pane split returned no pane id.");
+
+  const command = buildProjectPaneCommand();
+  const started = await client.run(["pane", "run", paneId, command], { timeoutMs: 15_000, signal: input.signal });
+  if (started.ok === false) {
+    await client.run(["pane", "close", paneId], { timeoutMs: 5_000 });
+    throw new Error(formatHerdrError(started.error));
+  }
+
+  return { paneId, projectRoot, command, herdrVersion: detected.data.versionText };
+}
+
+export async function waitForProjectSession(client: ListSessionsClient, input: {
+  projectRoot: string;
+  currentSessionId: string;
+  beforeSessionIds: ReadonlySet<string>;
+  to?: string;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  pollMs?: number;
+}): Promise<SessionInfo> {
+  const startedAt = Date.now();
+  const timeoutMs = input.timeoutMs ?? DEFAULT_PROJECT_AGENT_TIMEOUT_MS;
+  const pollMs = input.pollMs ?? DEFAULT_PROJECT_AGENT_POLL_MS;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (input.signal?.aborted) throw new Error("Cancelled");
+    const sessions = await client.listSessions({ timeoutMs: Math.min(5_000, timeoutMs) });
+
+    if (input.to?.trim()) {
+      const resolved = resolveTargetInCwd({
+        sessions,
+        currentSessionId: input.currentSessionId,
+        targetCwd: input.projectRoot,
+        to: input.to,
+      });
+      if (resolved.kind === "found" && resolved.session) return resolved.session;
+      await sleep(pollMs, input.signal);
+      continue;
+    }
+
+    const newInProject = sessions.filter(
+      (session) => !input.beforeSessionIds.has(session.id) && sameCwd(session.cwd, input.projectRoot),
+    );
+    if (newInProject.length === 1) return newInProject[0]!;
+    if (newInProject.length > 1) {
+      throw new Error(`Multiple new intercom sessions registered in ${input.projectRoot}: ${formatSessionRefs(newInProject)}. Address one explicitly.`);
+    }
+
+    await sleep(pollMs, input.signal);
+  }
+
+  throw new Error(`Timed out waiting for a Pi intercom session to register in ${input.projectRoot}. The Herdr pane may still be starting, or pi-intercom may not be loaded there.`);
+}
+
+function formatSessionRefs(sessions: SessionInfo[]): string {
+  return sessions
+    .map((session) => `${session.name || "Unnamed session"} (${session.id.slice(0, 8)})`)
+    .join(", ");
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolveSleep, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("Cancelled"));
+      return;
+    }
+    let timer: NodeJS.Timeout;
+    const cleanup = () => signal?.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      clearTimeout(timer);
+      cleanup();
+      reject(new Error("Cancelled"));
+    };
+    timer = setTimeout(() => {
+      cleanup();
+      resolveSleep();
+    }, ms);
+    timer.unref?.();
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/skills/pi-intercom/SKILL.md
+++ b/skills/pi-intercom/SKILL.md
@@ -23,6 +23,7 @@ This skill covers how to handle those orchestrator-side escalations.
 - **Context handoffs**: Send findings from a research session to an execution session
 - **Clarification loops**: Worker asks questions, planner answers, work continues
 - **Multi-session workflows**: Coordinate between specialized sessions (frontend/backend, research/implementation)
+- **Cross-codebase peer messages**: Message an explicit live peer in another project, or open a visible Herdr project pane when a long-lived conversation is needed
 
 ## Core Patterns
 
@@ -126,7 +127,39 @@ intercom({
 })
 ```
 
-### Pattern 6: Handle Subagent Escalations (Orchestrator Side)
+### Pattern 6: Cross-Codebase Peer Messages
+
+Use `to` alone to message any explicit live peer on the machine, even when it is
+in another codebase. Use `cwd` alone when there should be exactly one live peer
+in that repo. Use `to` plus `cwd` when the directory is a safety guard.
+
+```typescript
+intercom({
+  action: "ask",
+  cwd: "/path/to/other-repo",
+  to: "workbench-agent",
+  message: "Which module owns workbench source slices?"
+})
+```
+
+Only open a Herdr project pane when you need a durable visible peer session in
+that repo. For bounded work, prefer `pi-subagents` with an explicit `cwd`; the
+child can use `contact_supervisor` for owner decisions and regular `intercom`
+for explicit peer coordination.
+
+```typescript
+intercom({
+  action: "send",
+  cwd: "/path/to/other-repo",
+  openProjectPaneIfMissing: true,
+  message: "Let's discuss the workbench API ergonomics in this repo."
+})
+```
+
+If a live session already exists in that `cwd`, intercom reuses it. If multiple
+sessions are active there, pass `to` to select one by name or session ID.
+
+### Pattern 7: Handle Subagent Escalations (Orchestrator Side)
 
 When `pi-subagents` spawns a delegated child and supplies child bridge metadata,
 that child can reach you through `contact_supervisor`. You receive a formatted
@@ -190,7 +223,9 @@ intercom({ action: "reply", to: "subagent-worker-78f659a3-1", message: "Use the 
 **Important:** Only sessions where `pi-subagents` supplied child bridge metadata
 get the `contact_supervisor` tool. Normal sessions use the regular `intercom`
 tool. If you see the formatted supervisor decision/progress update message, treat
-it as a `contact_supervisor` escalation.
+it as a `contact_supervisor` escalation. A subagent may use regular `intercom` for
+peer coordination, including peers in other directories, but owner decisions and
+new visible project panes should go through the supervisor.
 
 ## Key Differences
 
@@ -203,20 +238,22 @@ it as a `contact_supervisor` escalation.
 | `list` | Returns all sessions with live status | You need to discover targets or choose an idle peer |
 | `status` | Returns your connection state | Troubleshooting |
 
-## Optional: Visible Peer Sessions via cmux or tmux
+## Optional: Manual Visible Peer Sessions via cmux or tmux
 
-If no suitable intercom-connected peer session already exists and the task benefits from a long-lived visible conversation, you may spawn a new `pi` session.
+For bounded cross-codebase work, prefer `pi-subagents` with an explicit `cwd`. Use `intercom({ action: "send", cwd: "/path", openProjectPaneIfMissing: true, ... })` only when a long-lived visible peer session is useful.
+
+If Herdr is unavailable and the task still benefits from a long-lived visible conversation, you may start a new `pi` session manually.
 
 Prefer `cmux new-split right` over new surfaces or workspaces so both sessions are visible side by side.
 
 If `cmux` is unavailable, `tmux` is an optional fallback when it is installed and relevant. Use it with a private socket so the session is isolated and observable.
 
-Use spawned peer sessions only for:
-- same-codebase worker/planner splits
-- reference-codebase scouting
-- long-lived visible conversations where the user benefits from watching both sides
+Use visible peer sessions only for:
+- same-codebase worker/planner conversations that should stay visible
+- reference-codebase scouting where a durable conversation helps
+- long-lived project discussions where the user benefits from watching both sides
 
-Do not use this for unrelated repos, trivial questions, or work you can finish cleanly in the current session.
+Do not use this for ordinary bounded subagent work, unrelated repos, trivial questions, or work you can finish cleanly in the current session.
 
 ### Preferred: cmux Worker or Scout Session
 
@@ -295,7 +332,7 @@ Spawn a visible peer session only when all of these are true:
 - the peer session is either in the same codebase or in an intentional reference codebase
 - `cmux` is available, or `tmux` is available as an intentional fallback
 
-If neither `cmux` nor `tmux` is available, skip this path and use normal `intercom` workflows.
+If neither Herdr nor the manual terminal fallback is available, skip this path and use normal `intercom` workflows.
 
 ## Important Constraints
 


### PR DESCRIPTION
## Summary

Adds cwd-scoped `send` and `ask` routing for cross-codebase peer messages:

- `to` alone still resolves globally across live sessions.
- `cwd` alone targets the sole live peer in that directory.
- `to + cwd` requires the target to be in that directory.
- `openProjectPaneIfMissing` opens a visible Herdr project pane, waits for the new Pi session to register with intercom, then delivers through normal intercom routing.

The docs also clarify that project panes are for durable visible peer conversations. Bounded cross-codebase work should still use `pi-subagents` with an explicit `cwd`, while subagents can use regular intercom for explicit peer coordination and `contact_supervisor` for owner decisions.

## Validation

- `npx tsx --test project-agent.test.ts intercom.integration.test.ts` passed, 84/84.
- `npm test` passed, 173/173.
- `git diff --check` passed.
- `npm pack --dry-run --json` confirmed `project-agent.ts` is included.
- Fresh review found one target-guard issue; fixed in the final head.
- Targeted follow-up review found no issues.

No release is part of this PR.
