### PR TITLE
refactor: deslop intercom protocol cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Added
 - Added cwd-scoped `send` and `ask` targeting plus `openProjectPaneIfMissing` for visible cross-codebase peer conversations through Herdr project panes.
 
+### Changed
+- Cleaned intercom tool copy, visible-peer skill guidance, and broker protocol validation structure.
+
 ### Fixed
+- Surface malformed intercom config errors with path context instead of silently falling back to defaults.
 - Fail blocking `ask` and supervisor-decision requests immediately when the target is not connected instead of accepting a mailbox delivery that can wait until timeout.
 - Prevent disconnected mailbox routing from delivering a message back to its sender or transferring mail through runtime-only unnamed-session aliases. Thanks to ELA718 for PR #93.
 - Extend unnamed-session fallback aliases with enough session-ID characters to distinguish UUIDv7 sessions started close together.

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -3,6 +3,7 @@ import { writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
+import { isMessage, isMessageReceipt, isSessionId, isSessionRegistration } from "./protocol.ts";
 import {
   ensureIntercomRuntimeDir,
   getBrokerListenTarget,
@@ -17,7 +18,7 @@ import {
 import { getAskTimeoutMs } from "../config.ts";
 import { sameCwd } from "../cwd.ts";
 import { EXTENSION_BUS_FEATURE } from "../types.ts";
-import type { SessionInfo, Message, Attachment, BrokerMessage, SessionRegistration, ExtensionCapability, MessageControl, MessageReceipt, MessageReceiptStatus } from "../types.ts";
+import type { SessionInfo, Message, BrokerMessage, ExtensionCapability, MessageControl } from "../types.ts";
 import { ExtensionStateManager } from "./extension-state.ts";
 import { assertNoLiveBroker } from "./runtime-claim.ts";
 
@@ -91,127 +92,6 @@ interface MailboxMessage {
   target: SessionInfo;
   message: Message;
   queuedAt: number;
-}
-
-function isMessageReceiptStatus(value: unknown): value is MessageReceiptStatus {
-  return value === "receiver_received"
-    || value === "queued"
-    || value === "injected"
-    || value === "acknowledged"
-    || value === "expired"
-    || value === "cancelled"
-    || value === "superseded"
-    || value === "cancellation_requested";
-}
-
-function isMessageReceipt(value: unknown): value is MessageReceipt {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-  const receipt = value as Record<string, unknown>;
-  if (typeof receipt.messageId !== "string" || !isMessageReceiptStatus(receipt.status) || typeof receipt.timestamp !== "number") {
-    return false;
-  }
-  return receipt.detail === undefined || typeof receipt.detail === "string";
-}
-
-function isAttachment(value: unknown): value is Attachment {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const attachment = value as Record<string, unknown>;
-
-  if (
-    attachment.type !== "file"
-    && attachment.type !== "snippet"
-    && attachment.type !== "context"
-  ) {
-    return false;
-  }
-
-  if (typeof attachment.name !== "string" || typeof attachment.content !== "string") {
-    return false;
-  }
-
-  return attachment.language === undefined || typeof attachment.language === "string";
-}
-
-function isMessage(value: unknown): value is Message {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const message = value as Record<string, unknown>;
-
-  if (typeof message.id !== "string" || typeof message.timestamp !== "number") {
-    return false;
-  }
-
-  for (const key of ["senderSequence", "brokerReceivedAt", "brokerDeliveredAt", "receiverReceivedAt", "injectedAt"] as const) {
-    if (message[key] !== undefined && typeof message[key] !== "number") {
-      return false;
-    }
-  }
-
-  if (message.supersedes !== undefined && typeof message.supersedes !== "string") {
-    return false;
-  }
-
-  if (message.retryOf !== undefined && typeof message.retryOf !== "string") {
-    return false;
-  }
-
-  if (message.replyTo !== undefined && typeof message.replyTo !== "string") {
-    return false;
-  }
-
-  if (message.expectsReply !== undefined && typeof message.expectsReply !== "boolean") {
-    return false;
-  }
-
-  if (typeof message.content !== "object" || message.content === null) {
-    return false;
-  }
-
-  const content = message.content as Record<string, unknown>;
-  if (typeof content.text !== "string") {
-    return false;
-  }
-
-  return content.attachments === undefined
-    || (Array.isArray(content.attachments) && content.attachments.every(isAttachment));
-}
-
-function isSessionId(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function isSessionRegistration(value: unknown): value is SessionRegistration {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-
-  const session = value as Record<string, unknown>;
-
-  if (
-    typeof session.cwd !== "string"
-    || typeof session.model !== "string"
-    || typeof session.pid !== "number"
-    || typeof session.startedAt !== "number"
-    || typeof session.lastActivity !== "number"
-  ) {
-    return false;
-  }
-
-  if (session.name !== undefined && typeof session.name !== "string") {
-    return false;
-  }
-  if (session.runtimeFallbackAlias !== undefined && typeof session.runtimeFallbackAlias !== "boolean") {
-    return false;
-  }
-
-  return session.status === undefined || typeof session.status === "string";
 }
 
 class IntercomBroker {
@@ -1248,12 +1128,10 @@ class IntercomBroker {
       const winner = candidates[0];
       const existing = this.namespaceOwners.get(namespace);
 
-      // Check if owner changed or socket changed
       const ownerChanged = !existing || existing.sessionId !== winner.sessionId;
       const socketChanged = existing && existing.socket !== winner.session.socket;
 
       if (ownerChanged || socketChanged) {
-        // Generate new epoch
         const epoch = randomUUID();
         this.namespaceOwners.set(namespace, {
           sessionId: winner.sessionId,
@@ -1261,7 +1139,6 @@ class IntercomBroker {
           epoch,
         });
 
-        // Broadcast owner change to all capable sessions
         for (const session of this.sessions.values()) {
           if (session.extensions?.length) {
             const isCapable = session.extensions.some((ext) => ext.namespace === namespace);

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -3,6 +3,7 @@ import net from "net";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
 import { getBrokerConnectTarget, type BrokerConnectTarget } from "./paths.ts";
+import { isMessage, isMessageControl, isMessageReceipt, isSessionInfo } from "./protocol.ts";
 import { EXTENSION_BUS_FEATURE } from "../types.ts";
 import type {
   Attachment,
@@ -11,7 +12,6 @@ import type {
   Message,
   MessageControl,
   MessageReceipt,
-  MessageReceiptStatus,
   SessionInfo,
   SessionRegistration,
 } from "../types.ts";
@@ -58,152 +58,6 @@ function connectToBrokerTarget(target: BrokerConnectTarget): net.Socket {
   return typeof target === "string"
     ? net.connect(target)
     : net.connect({ host: target.host, port: target.port });
-}
-
-function isMessageReceiptStatus(value: unknown): value is MessageReceiptStatus {
-  return value === "receiver_received"
-    || value === "queued"
-    || value === "injected"
-    || value === "acknowledged"
-    || value === "expired"
-    || value === "cancelled"
-    || value === "superseded"
-    || value === "cancellation_requested";
-}
-
-function isMessageReceipt(value: unknown): value is MessageReceipt {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-  const receipt = value as Record<string, unknown>;
-  if (typeof receipt.messageId !== "string" || !isMessageReceiptStatus(receipt.status) || typeof receipt.timestamp !== "number") {
-    return false;
-  }
-  return receipt.detail === undefined || typeof receipt.detail === "string";
-}
-
-function isMessageControl(value: unknown): value is MessageControl {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-  const control = value as Record<string, unknown>;
-  if (typeof control.messageId !== "string" || typeof control.timestamp !== "number") {
-    return false;
-  }
-  if (control.action !== "cancel" && control.action !== "supersede") {
-    return false;
-  }
-  if (control.supersededBy !== undefined && typeof control.supersededBy !== "string") {
-    return false;
-  }
-  return control.detail === undefined || typeof control.detail === "string";
-}
-
-function isAttachment(value: unknown): value is Attachment {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const attachment = value as Record<string, unknown>;
-
-  if (
-    attachment.type !== "file"
-    && attachment.type !== "snippet"
-    && attachment.type !== "context"
-  ) {
-    return false;
-  }
-
-  if (typeof attachment.name !== "string" || typeof attachment.content !== "string") {
-    return false;
-  }
-
-  return attachment.language === undefined || typeof attachment.language === "string";
-}
-
-function isMessage(value: unknown): value is Message {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const message = value as Record<string, unknown>;
-
-  if (typeof message.id !== "string" || typeof message.timestamp !== "number") {
-    return false;
-  }
-
-  for (const key of ["senderSequence", "brokerReceivedAt", "brokerDeliveredAt", "receiverReceivedAt", "injectedAt"] as const) {
-    if (message[key] !== undefined && typeof message[key] !== "number") {
-      return false;
-    }
-  }
-
-  if (message.supersedes !== undefined && typeof message.supersedes !== "string") {
-    return false;
-  }
-
-  if (message.retryOf !== undefined && typeof message.retryOf !== "string") {
-    return false;
-  }
-
-  if (message.replyTo !== undefined && typeof message.replyTo !== "string") {
-    return false;
-  }
-
-  if (message.expectsReply !== undefined && typeof message.expectsReply !== "boolean") {
-    return false;
-  }
-
-  if (typeof message.content !== "object" || message.content === null) {
-    return false;
-  }
-
-  const content = message.content as Record<string, unknown>;
-  if (typeof content.text !== "string") {
-    return false;
-  }
-
-  return content.attachments === undefined
-    || (Array.isArray(content.attachments) && content.attachments.every(isAttachment));
-}
-
-function isSessionInfo(value: unknown): value is SessionInfo {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const session = value as Record<string, unknown>;
-
-  if (
-    typeof session.id !== "string"
-    || typeof session.cwd !== "string"
-    || typeof session.model !== "string"
-    || typeof session.pid !== "number"
-    || typeof session.startedAt !== "number"
-    || typeof session.lastActivity !== "number"
-  ) {
-    return false;
-  }
-
-  if (session.name !== undefined && typeof session.name !== "string") {
-    return false;
-  }
-
-  if (session.status !== undefined && typeof session.status !== "string") {
-    return false;
-  }
-
-  if (session.peerUid !== undefined && typeof session.peerUid !== "number") {
-    return false;
-  }
-
-  for (const key of ["contextPct", "contextTokens", "contextWindow"] as const) {
-    if (session[key] !== undefined && typeof session[key] !== "number") {
-      return false;
-    }
-  }
-
-  return session.trustedLocal === undefined || typeof session.trustedLocal === "boolean";
 }
 
 export class IntercomClient extends EventEmitter {

--- a/broker/extension-state.ts
+++ b/broker/extension-state.ts
@@ -15,7 +15,7 @@ import { dirname, join } from "node:path";
 
 const MAX_STATE_BYTES = 64 * 1024;
 
-export interface StateEnvelope {
+interface StateEnvelope {
   formatVersion: 1;
   namespace: string;
   revision: number;
@@ -74,23 +74,34 @@ export class ExtensionStateManager {
       if (!value || typeof value !== "object" || Array.isArray(value)) return null;
 
       const envelope = value as Record<string, unknown>;
+      const revision = envelope.revision;
+      const updatedAt = envelope.updatedAt;
+      const payloadSha256 = envelope.payloadSha256;
       if (
         envelope.formatVersion !== 1
         || envelope.namespace !== namespace
-        || !Number.isSafeInteger(envelope.revision)
-        || (envelope.revision as number) < 0
-        || typeof envelope.updatedAt !== "number"
-        || typeof envelope.payloadSha256 !== "string"
+        || typeof revision !== "number"
+        || !Number.isSafeInteger(revision)
+        || revision < 0
+        || typeof updatedAt !== "number"
+        || typeof payloadSha256 !== "string"
       ) {
         return null;
       }
 
       const payloadJson = serializePayload(envelope.payload);
-      if (payloadJson === null || payloadHash(payloadJson) !== envelope.payloadSha256) {
+      if (payloadJson === null || payloadHash(payloadJson) !== payloadSha256) {
         return null;
       }
 
-      return envelope as unknown as StateEnvelope;
+      return {
+        formatVersion: 1,
+        namespace,
+        revision,
+        updatedAt,
+        payloadSha256,
+        payload: envelope.payload,
+      };
     } catch {
       return null;
     }

--- a/broker/framing.ts
+++ b/broker/framing.ts
@@ -1,6 +1,6 @@
 import type { Socket } from "net";
 
-export const MAX_FRAME_BYTES = 1024 * 1024;
+const MAX_FRAME_BYTES = 1024 * 1024;
 
 /**
  * Write a length-prefixed message to a socket.

--- a/broker/protocol.ts
+++ b/broker/protocol.ts
@@ -1,0 +1,182 @@
+import type {
+  Attachment,
+  Message,
+  MessageControl,
+  MessageReceipt,
+  MessageReceiptStatus,
+  SessionInfo,
+  SessionRegistration,
+} from "../types.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMessageReceiptStatus(value: unknown): value is MessageReceiptStatus {
+  return value === "receiver_received"
+    || value === "queued"
+    || value === "injected"
+    || value === "acknowledged"
+    || value === "expired"
+    || value === "cancelled"
+    || value === "superseded"
+    || value === "cancellation_requested";
+}
+
+export function isMessageReceipt(value: unknown): value is MessageReceipt {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (typeof value.messageId !== "string" || !isMessageReceiptStatus(value.status) || typeof value.timestamp !== "number") {
+    return false;
+  }
+  return value.detail === undefined || typeof value.detail === "string";
+}
+
+export function isMessageControl(value: unknown): value is MessageControl {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (typeof value.messageId !== "string" || typeof value.timestamp !== "number") {
+    return false;
+  }
+  if (value.action !== "cancel" && value.action !== "supersede") {
+    return false;
+  }
+  if (value.supersededBy !== undefined && typeof value.supersededBy !== "string") {
+    return false;
+  }
+  return value.detail === undefined || typeof value.detail === "string";
+}
+
+function isAttachment(value: unknown): value is Attachment {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (
+    value.type !== "file"
+    && value.type !== "snippet"
+    && value.type !== "context"
+  ) {
+    return false;
+  }
+
+  if (typeof value.name !== "string" || typeof value.content !== "string") {
+    return false;
+  }
+
+  return value.language === undefined || typeof value.language === "string";
+}
+
+export function isMessage(value: unknown): value is Message {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (typeof value.id !== "string" || typeof value.timestamp !== "number") {
+    return false;
+  }
+
+  for (const key of ["senderSequence", "brokerReceivedAt", "brokerDeliveredAt", "receiverReceivedAt", "injectedAt"] as const) {
+    if (value[key] !== undefined && typeof value[key] !== "number") {
+      return false;
+    }
+  }
+
+  if (value.supersedes !== undefined && typeof value.supersedes !== "string") {
+    return false;
+  }
+
+  if (value.retryOf !== undefined && typeof value.retryOf !== "string") {
+    return false;
+  }
+
+  if (value.replyTo !== undefined && typeof value.replyTo !== "string") {
+    return false;
+  }
+
+  if (value.expectsReply !== undefined && typeof value.expectsReply !== "boolean") {
+    return false;
+  }
+
+  if (!isRecord(value.content) || typeof value.content.text !== "string") {
+    return false;
+  }
+
+  return value.content.attachments === undefined
+    || (Array.isArray(value.content.attachments) && value.content.attachments.every(isAttachment));
+}
+
+export function isSessionInfo(value: unknown): value is SessionInfo {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (
+    typeof value.id !== "string"
+    || typeof value.cwd !== "string"
+    || typeof value.model !== "string"
+    || typeof value.pid !== "number"
+    || typeof value.startedAt !== "number"
+    || typeof value.lastActivity !== "number"
+  ) {
+    return false;
+  }
+
+  if (value.name !== undefined && typeof value.name !== "string") {
+    return false;
+  }
+
+  if (value.runtimeFallbackAlias !== undefined && typeof value.runtimeFallbackAlias !== "boolean") {
+    return false;
+  }
+
+  if (value.status !== undefined && typeof value.status !== "string") {
+    return false;
+  }
+
+  if (value.peerUid !== undefined && typeof value.peerUid !== "number") {
+    return false;
+  }
+
+  for (const key of ["contextPct", "contextTokens", "contextWindow"] as const) {
+    if (value[key] !== undefined && typeof value[key] !== "number") {
+      return false;
+    }
+  }
+
+  return value.trustedLocal === undefined || typeof value.trustedLocal === "boolean";
+}
+
+export function isSessionId(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function isSessionRegistration(value: unknown): value is SessionRegistration {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (
+    typeof value.cwd !== "string"
+    || typeof value.model !== "string"
+    || typeof value.pid !== "number"
+    || typeof value.startedAt !== "number"
+    || typeof value.lastActivity !== "number"
+  ) {
+    return false;
+  }
+
+  if (value.name !== undefined && typeof value.name !== "string") {
+    return false;
+  }
+  if (value.runtimeFallbackAlias !== undefined && typeof value.runtimeFallbackAlias !== "boolean") {
+    return false;
+  }
+  if (value.extensions !== undefined && !Array.isArray(value.extensions)) {
+    return false;
+  }
+
+  return value.status === undefined || typeof value.status === "string";
+}

--- a/config.test.ts
+++ b/config.test.ts
@@ -73,20 +73,18 @@ test("loadConfig accepts a restart-stable intercom id", async () => {
   }
 });
 
-test("loadConfig rejects invalid inboundTrigger values by failing closed", async () => {
+test("loadConfig rejects invalid inboundTrigger values", async () => {
   const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
   try {
     mkdirSync(join(root, "intercom"), { recursive: true });
     writeFileSync(join(root, "intercom", "config.json"), JSON.stringify({ inboundTrigger: "prompt" }));
-    const previousError = console.error;
-    console.error = () => undefined;
-    try {
-      await withAgentDir(root, () => {
-        assert.equal(loadConfig().inboundTrigger, "never");
-      });
-    } finally {
-      console.error = previousError;
-    }
+
+    await withAgentDir(root, () => {
+      assert.throws(
+        () => loadConfig(),
+        /Failed to load intercom config.*"inboundTrigger" must be "always", "replies", or "never"/,
+      );
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/config.ts
+++ b/config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { getIntercomDirPath } from "./broker/paths.ts";
 
-export const DEFAULT_ASK_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_ASK_TIMEOUT_MS = 10 * 60 * 1000;
 
 export function getAskTimeoutMs(): number {
   const raw = process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
@@ -151,7 +151,7 @@ export function loadConfig(): IntercomConfig {
 
     return config;
   } catch (error) {
-    console.error(`Failed to load intercom config at ${configPath}:`, error);
-    return { ...defaults, inboundTrigger: "never" };
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load intercom config at ${configPath}: ${message}`, { cause: error });
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { defineTool, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
 import { Type } from "typebox";
@@ -96,9 +96,9 @@ function formatAttachments(attachments: Attachment[]): string {
   let text = "";
   for (const att of attachments) {
     if (att.language) {
-      text += `\n\n---\n📎 ${att.name}\n~~~${att.language}\n${att.content}\n~~~`;
+      text += `\n\n---\nAttachment: ${att.name}\n~~~${att.language}\n${att.content}\n~~~`;
     } else {
-      text += `\n\n---\n📎 ${att.name}\n${att.content}`;
+      text += `\n\n---\nAttachment: ${att.name}\n${att.content}`;
     }
   }
   return text;
@@ -890,7 +890,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     pi.sendMessage(
       {
         customType: "intercom_message",
-        content: `**📨 From ${senderDisplay}** (${entry.from.cwd})${replyInstruction}\n\n_${deliveryMetadata}_\n\n${entry.bodyText}`,
+        content: `**From ${senderDisplay}** (${entry.from.cwd})${replyInstruction}\n\n_${deliveryMetadata}_\n\n${entry.bodyText}`,
         display: true,
         details: deliveredEntry,
       },
@@ -1505,7 +1505,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   const childOrchestratorMetadata = readChildOrchestratorMetadata();
   const nativeSupervisorChannelAvailable = Boolean(process.env[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV]?.trim());
   if (childOrchestratorMetadata && !nativeSupervisorChannelAvailable) {
-    pi.registerTool({
+    pi.registerTool(defineTool({
       name: "contact_supervisor",
       label: "Contact Supervisor",
       description: "Subagent-only tool for contacting the supervisor agent that delegated this task. Use need_decision when blocked, uncertain, needing approval, or facing a product/API/scope decision before continuing; this waits for the supervisor's reply. Use interview_request when multiple structured questions need supervisor answers; this also waits for a reply. Use progress_update only for meaningful progress or unexpected discoveries that change the plan; this does not wait for a reply. Do not use for routine completion handoffs.",
@@ -1773,10 +1773,10 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         }
         return new Text(text, 0, 0);
       },
-    } as any);
+    }));
   }
 
-  pi.registerTool({
+  pi.registerTool(defineTool({
     name: "intercom",
     label: "Intercom",
     description: `Send a message to another pi session running on this machine.
@@ -1987,7 +1987,7 @@ Usage:
             const attachmentText = attachments?.length ? formatAttachments(attachments) : "";
             if (confirmSend && cwd && openProjectPaneIfMissing) {
               const confirmed = await ctx.ui.confirm(
-                "Send Message",
+                "Send message",
                 `Send to "${to ?? cwd}":\n\n${message}${attachmentText}`,
               );
               if (!confirmed) {
@@ -2012,7 +2012,7 @@ Usage:
             const effectiveReplyTo = replyTo ?? inferredAsk?.message.id;
             if (confirmSend && !(cwd && openProjectPaneIfMissing)) {
               const confirmed = await ctx.ui.confirm(
-                "Send Message",
+                "Send message",
                 `Send to "${targetDisplay}":\n\n${message}${attachmentText}`,
               );
               if (!confirmed) {
@@ -2328,7 +2328,7 @@ Usage:
       }
       return new Text(text, 0, 0);
     },
-  } as any);
+  }));
 
   function insertIntoEditor(ctx: ExtensionContext, text: string): boolean {
     if (!ctx.hasUI) return false;

--- a/project-agent.ts
+++ b/project-agent.ts
@@ -65,7 +65,7 @@ function normalizeCode(raw: unknown): HerdrErrorCode {
   return "VALIDATION_ERROR";
 }
 
-export function createHerdrClient(options: { bin?: string; spawn?: SpawnHerdr } = {}): HerdrClient {
+function createHerdrClient(options: { bin?: string; spawn?: SpawnHerdr } = {}): HerdrClient {
   const bin = options.bin ?? process.env.HERDR_BIN ?? "herdr";
   const spawnImpl = options.spawn ?? spawn;
   return {
@@ -93,11 +93,11 @@ export function createHerdrClient(options: { bin?: string; spawn?: SpawnHerdr } 
           resolveResult(result);
         };
         const abort = () => {
-          try { child.kill(); } catch {}
+          child.kill();
           finish(error("TIMEOUT", `Herdr command '${args.join(" ")}' was aborted.`));
         };
         const timer = setTimeout(() => {
-          try { child.kill(); } catch {}
+          child.kill();
           finish(error("TIMEOUT", `Herdr command '${args.join(" ")}' timed out after ${runOptions.timeoutMs ?? 15_000}ms.`));
         }, runOptions.timeoutMs ?? 15_000);
         timer.unref?.();
@@ -176,11 +176,7 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-export function buildProjectPaneCommand(piCommand: string = process.env.PI_INTERCOM_PI_BIN?.trim() || process.env.PI_BIN?.trim() || "pi"): string {
-  return shellQuote(piCommand);
-}
-
-export function resolveProjectRoot(cwd: string): string {
+function resolveProjectRoot(cwd: string): string {
   const resolved = resolve(cwd);
   const stat = statSync(resolved);
   if (!stat.isDirectory()) {
@@ -246,7 +242,7 @@ export async function openProjectPane(input: {
   const paneId = extractPaneId(split.data);
   if (!paneId) throw new Error("Herdr project pane error (PANE_GONE): pane split returned no pane id.");
 
-  const command = buildProjectPaneCommand();
+  const command = shellQuote(process.env.PI_INTERCOM_PI_BIN?.trim() || process.env.PI_BIN?.trim() || "pi");
   const started = await client.run(["pane", "run", paneId, command], { timeoutMs: 15_000, signal: input.signal });
   if (started.ok === false) {
     await client.run(["pane", "close", paneId], { timeoutMs: 5_000 });

--- a/skills/pi-intercom/SKILL.md
+++ b/skills/pi-intercom/SKILL.md
@@ -238,101 +238,14 @@ new visible project panes should go through the supervisor.
 | `list` | Returns all sessions with live status | You need to discover targets or choose an idle peer |
 | `status` | Returns your connection state | Troubleshooting |
 
-## Optional: Manual Visible Peer Sessions via cmux or tmux
+## Visible Peer Sessions
 
-For bounded cross-codebase work, prefer `pi-subagents` with an explicit `cwd`. Use `intercom({ action: "send", cwd: "/path", openProjectPaneIfMissing: true, ... })` only when a long-lived visible peer session is useful.
+For bounded cross-codebase work, prefer `pi-subagents` with an explicit `cwd`.
+Use `intercom({ action: "send", cwd: "/path", openProjectPaneIfMissing: true, ... })`
+only when a long-lived visible peer session is useful.
 
-If Herdr is unavailable and the task still benefits from a long-lived visible conversation, you may start a new `pi` session manually.
-
-Prefer `cmux new-split right` over new surfaces or workspaces so both sessions are visible side by side.
-
-If `cmux` is unavailable, `tmux` is an optional fallback when it is installed and relevant. Use it with a private socket so the session is isolated and observable.
-
-Use visible peer sessions only for:
-- same-codebase worker/planner conversations that should stay visible
-- reference-codebase scouting where a durable conversation helps
-- long-lived project discussions where the user benefits from watching both sides
-
-Do not use this for ordinary bounded subagent work, unrelated repos, trivial questions, or work you can finish cleanly in the current session.
-
-### Preferred: cmux Worker or Scout Session
-
-Same codebase:
-
-```bash
-cmux new-split right
-sleep 0.5
-cmux send --surface right 'cd /path/to/current/repo && pi\n'
-```
-
-Reference codebase:
-
-```bash
-cmux new-split right
-sleep 0.5
-cmux send --surface right 'cd /path/to/reference/repo && pi\n'
-```
-
-### Optional Fallback: tmux Worker or Scout Session
-
-Same codebase:
-
-```bash
-SOCKET_DIR=${TMPDIR:-/tmp}/pi-tmux-sockets
-mkdir -p "$SOCKET_DIR"
-SOCKET="$SOCKET_DIR/pi.sock"
-SESSION=pi-worker
-tmux -S "$SOCKET" new -d -s "$SESSION" -c "/path/to/current/repo" 'pi'
-```
-
-Reference codebase:
-
-```bash
-SOCKET_DIR=${TMPDIR:-/tmp}/pi-tmux-sockets
-mkdir -p "$SOCKET_DIR"
-SOCKET="$SOCKET_DIR/pi.sock"
-SESSION=pi-reference-auth
-tmux -S "$SOCKET" new -d -s "$SESSION" -c "/path/to/reference/repo" 'pi'
-```
-
-When you use `tmux`, tell the user how to watch it:
-
-```bash
-tmux -S "$SOCKET" attach -t "$SESSION"
-```
-
-After launch, name the new session clearly so it is easy to target:
-
-```text
-/name worker
-/name reference-auth
-```
-
-Then coordinate from the current session:
-
-```typescript
-intercom({
-  action: "send",
-  to: "worker",
-  message: "Take task X. Ask if blocked."
-})
-
-intercom({
-  action: "ask",
-  to: "reference-auth",
-  message: "How does this repo structure token refresh retries?"
-})
-```
-
-### Spawn Decision Rule
-
-Spawn a visible peer session only when all of these are true:
-- no existing intercom-connected session already fits the need
-- the work benefits from a long-lived visible peer session
-- the peer session is either in the same codebase or in an intentional reference codebase
-- `cmux` is available, or `tmux` is available as an intentional fallback
-
-If neither Herdr nor the manual terminal fallback is available, skip this path and use normal `intercom` workflows.
+If Herdr is unavailable, do not invent a terminal fallback inside this workflow.
+Ask the user before opening another visible surface manually.
 
 ## Important Constraints
 
@@ -387,21 +300,6 @@ intercom({
   message: "PR #123 is ready for review. Key changes in auth.ts."
 });
 // Continue immediately, don't wait
-```
-
-### Include reply hints in messages
-
-Make it easy for recipients to respond:
-
-```typescript
-// GOOD: Recipient sees exact command to reply
-intercom({
-  action: "send",
-  to: "worker",
-  message: `Found the issue in auth.ts:142. Use getUserById() instead of getUser().
-
-Reply with: intercom({ action: "reply", message: "..." })`
-});
 ```
 
 ### Name sessions meaningfully

--- a/test/inline-message.test.ts
+++ b/test/inline-message.test.ts
@@ -115,11 +115,11 @@ test("inline message colors follow the tool-title, text, muted-border, and dim-m
   const lines = component.render(72);
   const rendered = lines.join("\n");
 
-  assert.match(lines[0], /^\u001b\[34m╭\u001b\[0m\u001b\[32m 📨 From:/);
+  assert.match(lines[0], /^\u001b\[34m╭\u001b\[0m\u001b\[32m From:/);
   assert.match(rendered, /\u001b\[34m│\u001b\[0m\u001b\[33mBody copy\u001b\[0m/);
-  assert.match(rendered, /\u001b\[35m ↩ To reply: intercom reply\u001b\[0m/);
-  assert.match(rendered, /\u001b\[35m 📎 note\.txt\u001b\[0m/);
-  assert.match(rendered, /\u001b\[35m ↳ Reply to parent-m\u001b\[0m/);
+  assert.match(rendered, /\u001b\[35m To reply: intercom reply\u001b\[0m/);
+  assert.match(rendered, /\u001b\[35m Attachment: note\.txt\u001b\[0m/);
+  assert.match(rendered, /\u001b\[35m Reply to parent-m\u001b\[0m/);
   assert.match(lines.at(-1)!, /^\u001b\[34m╰─+╯\u001b\[0m$/);
   assert.ok(calls.includes("toolTitle"));
   assert.ok(calls.includes("text"));
@@ -134,9 +134,9 @@ test("collapsed inline messages preserve the same hierarchy without accent", () 
 
   const rendered = component.render(72).join("\n");
 
-  assert.match(rendered, /\u001b\[32m 📨 From:/);
+  assert.match(rendered, /\u001b\[32m From:/);
   assert.match(rendered, /\u001b\[33mThis is a long message/);
-  assert.match(rendered, /\u001b\[35m ↩ To reply:/);
+  assert.match(rendered, /\u001b\[35m To reply:/);
   assert.ok(!calls.includes("accent"));
 });
 
@@ -146,7 +146,7 @@ test("semantic styling remains ANSI- and Unicode-width safe", () => {
     ...message,
     content: { text: "\u001b[36m色付き本文\u001b[0m with emoji 🧪 and a long Unicode tail 計画計画計画" },
   };
-  const component = new InlineMessageComponent(unicodeFrom, unicodeMessage, styledTheme() as any, "返信 📨");
+  const component = new InlineMessageComponent(unicodeFrom, unicodeMessage, styledTheme() as any, "返信");
 
   for (const width of [18, 31, 52]) {
     const lines = component.render(width);
@@ -176,8 +176,8 @@ test("inline messages pick up mutable theme proxy changes on rerender", () => {
   palette.muted = 90;
   const after = component.render(72).join("\n");
 
-  assert.match(before, /\u001b\[32m 📨 From:/);
-  assert.match(after, /\u001b\[96m 📨 From:/);
+  assert.match(before, /\u001b\[32m From:/);
+  assert.match(after, /\u001b\[96m From:/);
   assert.match(after, /\u001b\[97mThis is a long message/);
   assert.match(after, /\u001b\[90m╭/);
   assert.notEqual(before, after);

--- a/ui/inline-message.ts
+++ b/ui/inline-message.ts
@@ -42,7 +42,7 @@ export class InlineMessageComponent implements Component {
     }
     const bodyWidth = Math.max(1, width - 2);
 
-    const header = ` 📨 From: ${senderName} (${this.from.cwd}) `;
+    const header = ` From: ${senderName} (${this.from.cwd}) `;
     const headerText = truncateToWidth(this.collapsed ? `${header} Ctrl+O expands ` : header, bodyWidth, "");
     const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
     lines.push(
@@ -62,12 +62,12 @@ export class InlineMessageComponent implements Component {
       lines.push(frameLine(this.theme.fg("text", this.collapsedPreview)));
 
       const meta: string[] = [];
-      if (this.replyCommand) meta.push(`↩ To reply: ${this.replyCommand}`);
+      if (this.replyCommand) meta.push(`To reply: ${this.replyCommand}`);
       if (this.message.content.attachments?.length) {
         const count = this.message.content.attachments.length;
-        meta.push(`📎 ${count} attachment${count === 1 ? "" : "s"}`);
+        meta.push(`${count} attachment${count === 1 ? "" : "s"}`);
       }
-      if (this.message.replyTo && !this.message.expectsReply) meta.push(`↳ Reply to ${this.message.replyTo.slice(0, 8)}`);
+      if (this.message.replyTo && !this.message.expectsReply) meta.push(`Reply to ${this.message.replyTo.slice(0, 8)}`);
       meta.push("Ctrl+O to expand");
 
       lines.push(frameLine(this.theme.fg("dim", ` ${meta.join(" · ")}`)));
@@ -87,7 +87,7 @@ export class InlineMessageComponent implements Component {
 
     if (this.replyCommand) {
       lines.push(frameLine(""));
-      const replyLines = wrapTextWithAnsi(this.theme.fg("dim", ` ↩ To reply: ${this.replyCommand}`), bodyWidth);
+      const replyLines = wrapTextWithAnsi(this.theme.fg("dim", ` To reply: ${this.replyCommand}`), bodyWidth);
       for (const line of replyLines) {
         lines.push(frameLine(line));
       }
@@ -96,13 +96,13 @@ export class InlineMessageComponent implements Component {
     if (this.message.content.attachments?.length) {
       lines.push(frameLine(""));
       for (const att of this.message.content.attachments) {
-        lines.push(frameLine(this.theme.fg("dim", ` 📎 ${att.name}`)));
+        lines.push(frameLine(this.theme.fg("dim", ` Attachment: ${att.name}`)));
       }
     }
 
     if (this.message.replyTo && !this.message.expectsReply) {
       lines.push(frameLine(""));
-      lines.push(frameLine(this.theme.fg("dim", ` ↳ Reply to ${this.message.replyTo.slice(0, 8)}`)));
+      lines.push(frameLine(this.theme.fg("dim", ` Reply to ${this.message.replyTo.slice(0, 8)}`)));
     }
 
     lines.push(this.theme.fg("muted", `╰${borderChar.repeat(bodyWidth)}╯`));


### PR DESCRIPTION
Deslops the intercom cleanup after the project-pane work.\n\nChanges:\n- Extracts shared broker/client protocol validators into broker/protocol.ts.\n- Surfaces malformed config errors with path context instead of silently falling back.\n- Removes noisy emoji UI labels and trims visible-peer skill guidance.\n- Removes internal-only exports and redundant comments.\n\nValidation:\n- npm test: 173/173 passed.\n- npm pack --dry-run --json passed and includes broker/protocol.ts.\n- git diff --check passed.\n- Fresh review reported no findings.