### PR TITLE
fix: resolve hoisted tsx fallback for broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+- Resolve the default broker `tsx` launcher from flat plugin-store installs when package resolution fails, and include broker stderr when startup exits early. Thanks to Eduardo Marquez (`DocksDocks`) for issue #97.
+
 ## [0.10.0] - 2026-08-09
 
 ### Added

--- a/broker/spawn.test.ts
+++ b/broker/spawn.test.ts
@@ -1,8 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   getBrokerLaunchSpec,
   getBrokerSpawnOptions,
@@ -14,13 +15,45 @@ import {
 } from "./spawn.ts";
 
 test("getTsxCliPath resolves tsx cli via module resolution", () => {
-  const cliPath = getTsxCliPath("C:/repo");
+  const cliPath = getTsxCliPath();
   // getTsxCliPath resolves the tsx package main entry and locates cli.mjs next
   // to it, so the path reflects the real install location (bundled under
   // extensionDir or hoisted by npm) rather than a hardcoded relative path.
   assert.equal(path.basename(cliPath), "cli.mjs");
   assert.equal(path.basename(path.dirname(cliPath)), "dist");
   assert.equal(path.basename(path.dirname(path.dirname(cliPath))), "tsx");
+});
+
+test("getTsxCliPath falls back to a flat sibling tsx install", () => {
+  const storeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-store-"));
+
+  try {
+    const extensionDir = path.join(storeDir, "node_modules", "pi-intercom");
+    const cliPath = path.join(storeDir, "node_modules", "tsx", "dist", "cli.mjs");
+    mkdirSync(extensionDir, { recursive: true });
+    mkdirSync(path.dirname(cliPath), { recursive: true });
+    writeFileSync(cliPath, "");
+
+    assert.equal(getTsxCliPath(extensionDir), cliPath);
+  } finally {
+    rmSync(storeDir, { recursive: true, force: true });
+  }
+});
+
+test("getTsxCliPath keeps the nested fallback when no sibling tsx cli exists", () => {
+  const storeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-store-"));
+
+  try {
+    const extensionDir = path.join(storeDir, "pi-intercom");
+    mkdirSync(extensionDir, { recursive: true });
+
+    assert.equal(
+      getTsxCliPath(extensionDir),
+      path.join(extensionDir, "node_modules", "tsx", "dist", "cli.mjs"),
+    );
+  } finally {
+    rmSync(storeDir, { recursive: true, force: true });
+  }
 });
 
 test("getWindowsHiddenLauncherPath points at the broker launcher script", () => {
@@ -65,6 +98,7 @@ test("getBrokerLaunchSpec uses wscript launcher on Windows without writing files
     assert.equal(spec.kind, "windows-launcher");
     const expectedTsxPath = getTsxCliPath("C:/repo");
     assert.equal(spec.launcherCommandLine, `"C:/Program Files/nodejs/node.exe" "${expectedTsxPath}" "C:/repo/broker.ts"`);
+    assert.equal(spec.captureStartupStderr, false);
     assert.equal(existsSync(path.join(intercomDir, "broker-launch.vbs")), false);
   } finally {
     rmSync(intercomDir, { recursive: true, force: true });
@@ -112,6 +146,7 @@ test("getBrokerLaunchSpec uses node + resolved tsx for the default non-Windows l
     "C:/repo/broker.ts",
   ]);
   assert.equal(spec.kind, "direct");
+  assert.equal(spec.captureStartupStderr, true);
 });
 
 test("getBrokerLaunchSpec falls back to PATH node for a standalone Pi executable on non-Windows", () => {
@@ -137,19 +172,27 @@ test("getBrokerLaunchSpec uses custom broker command on non-Windows", () => {
   assert.equal(spec.command, "bun");
   assert.deepEqual(spec.args, ["/repo/broker.ts"]);
   assert.equal(spec.kind, "direct");
+  assert.equal(spec.captureStartupStderr, false);
 });
 
 test("getBrokerSpawnOptions hides the broker console window on Windows", () => {
   const options = getBrokerSpawnOptions("C:/repo");
   assert.equal(options.windowsHide, true);
   assert.equal(options.detached, true);
-  assert.equal(options.stdio, "ignore");
+  assert.deepEqual(options.stdio, ["ignore", "ignore", "pipe"]);
   assert.equal(options.cwd, "C:/repo");
 });
 
 test("getBrokerSpawnOptions keeps portable defaults on non-Windows platforms", () => {
   const options = getBrokerSpawnOptions("/repo");
   assert.equal(options.windowsHide, true);
+  assert.equal(options.detached, true);
+  assert.deepEqual(options.stdio, ["ignore", "ignore", "pipe"]);
+  assert.equal(options.cwd, "/repo");
+});
+
+test("getBrokerSpawnOptions can keep custom broker stderr ignored", () => {
+  const options = getBrokerSpawnOptions("/repo", process.env, false);
   assert.equal(options.detached, true);
   assert.equal(options.stdio, "ignore");
   assert.equal(options.cwd, "/repo");
@@ -158,6 +201,44 @@ test("getBrokerSpawnOptions keeps portable defaults on non-Windows platforms", (
 test("getBrokerSpawnOptions passes an absolute PI_CODING_AGENT_DIR to the broker", () => {
   const options = getBrokerSpawnOptions("/repo", { PI_CODING_AGENT_DIR: "relative-agent" });
   assert.equal(options.env.PI_CODING_AGENT_DIR, path.resolve("relative-agent"));
+});
+
+test("spawnBrokerIfNeeded includes stderr from default broker startup failures", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "pi-intercom-spawn-"));
+  const extensionDir = path.join(root, "pi-intercom");
+  const brokerDir = path.join(extensionDir, "broker");
+  const fakeTsxCli = path.join(extensionDir, "node_modules", "tsx", "dist", "cli.mjs");
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+  try {
+    mkdirSync(brokerDir, { recursive: true });
+    mkdirSync(path.dirname(fakeTsxCli), { recursive: true });
+    writeFileSync(path.join(extensionDir, "package.json"), JSON.stringify({ type: "module" }));
+    writeFileSync(fakeTsxCli, "process.stderr.write('fake tsx failed\\n'); process.exit(1);\n");
+
+    const sourceDir = path.dirname(fileURLToPath(import.meta.url));
+    for (const fileName of ["spawn.ts", "framing.ts", "paths.ts"]) {
+      cpSync(path.join(sourceDir, fileName), path.join(brokerDir, fileName));
+    }
+
+    process.env.PI_CODING_AGENT_DIR = path.join(root, "agent");
+    const moduleUrl = `${pathToFileURL(path.join(brokerDir, "spawn.ts")).href}?case=${Date.now()}`;
+    const imported = await import(moduleUrl) as typeof import("./spawn.ts");
+
+    await assert.rejects(
+      () => imported.spawnBrokerIfNeeded("npx", ["--no-install", "tsx"]),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /Intercom broker exited before startup with code 1/);
+        assert.match(error.message, /Broker stderr:\nfake tsx failed/);
+        return true;
+      },
+    );
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("isBrokerHealthOkMessage requires the intercom protocol marker", () => {

--- a/broker/spawn.ts
+++ b/broker/spawn.ts
@@ -22,12 +22,14 @@ const INTERCOM_DIR = getIntercomDirPath();
 const EXTENSION_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
 const BROKER_PID = join(INTERCOM_DIR, "broker.pid");
 const BROKER_SPAWN_LOCK = join(INTERCOM_DIR, "broker.spawn.lock");
+const BROKER_STARTUP_STDERR_LIMIT = 4_000;
 
 type BrokerLaunchSpec =
   | {
     kind: "direct";
     command: string;
     args: string[];
+    captureStartupStderr: boolean;
   }
   | {
     kind: "windows-launcher";
@@ -35,6 +37,7 @@ type BrokerLaunchSpec =
     args: string[];
     launcherPath: string;
     launcherCommandLine: string;
+    captureStartupStderr: boolean;
   };
 
 function sleep(ms: number): Promise<void> {
@@ -46,12 +49,17 @@ export function getTsxCliPath(extensionDir: string = EXTENSION_DIR): string {
   // tsx is bundled under extensionDir/node_modules or hoisted to a workspace
   // root by npm. We resolve the tsx package main entry (its "exports" field
   // does not expose ./dist/cli.mjs as a subpath) and then locate cli.mjs next
-  // to it. Falls back to the legacy relative path if resolution fails.
+  // to it. If resolution fails, prefer the flat plugin-store layout before the
+  // legacy nested fallback.
   try {
-    const requireFromExtension = createRequire(import.meta.url);
+    const requireFromExtension = createRequire(join(extensionDir, "package.json"));
     const tsxMain = requireFromExtension.resolve("tsx");
     return join(dirname(tsxMain), "cli.mjs");
   } catch {
+    const siblingTsxCli = join(extensionDir, "..", "tsx", "dist", "cli.mjs");
+    if (existsSync(siblingTsxCli)) {
+      return siblingTsxCli;
+    }
     return join(extensionDir, "node_modules", "tsx", "dist", "cli.mjs");
   }
 }
@@ -142,6 +150,7 @@ export function getBrokerLaunchSpec(
       args: [launcherPath],
       launcherPath,
       launcherCommandLine: getWindowsBrokerCommandLine(brokerPath, extensionDir, nodePath, brokerCommand, brokerArgs),
+      captureStartupStderr: false,
     };
   }
 
@@ -150,6 +159,7 @@ export function getBrokerLaunchSpec(
       kind: "direct",
       command: getNodeCommand(nodePath),
       args: [getTsxCliPath(extensionDir), brokerPath],
+      captureStartupStderr: true,
     };
   }
 
@@ -157,22 +167,24 @@ export function getBrokerLaunchSpec(
     kind: "direct",
     command: brokerCommand,
     args: [...brokerArgs, brokerPath],
+    captureStartupStderr: false,
   };
 }
 
 export function getBrokerSpawnOptions(
   extensionDir: string = EXTENSION_DIR,
   env: NodeJS.ProcessEnv = process.env,
+  captureStderr = true,
 ): {
   detached: true;
-  stdio: "ignore";
+  stdio: "ignore" | ["ignore", "ignore", "pipe"];
   cwd: string;
   env: NodeJS.ProcessEnv;
   windowsHide: true;
 } {
   return {
     detached: true,
-    stdio: "ignore",
+    stdio: captureStderr ? ["ignore", "ignore", "pipe"] : "ignore",
     cwd: extensionDir,
     env: { ...env, PI_CODING_AGENT_DIR: getAgentDirPath(env), NODE_NO_WARNINGS: "1" },
     windowsHide: true,
@@ -206,18 +218,31 @@ export async function spawnBrokerIfNeeded(brokerCommand: string, brokerArgs: str
     if (launch.kind === "windows-launcher") {
       writeWindowsHiddenLauncher(launch.launcherCommandLine, launch.launcherPath);
     }
-    const child = spawn(launch.command, launch.args, getBrokerSpawnOptions());
+    const child = spawn(launch.command, launch.args, getBrokerSpawnOptions(EXTENSION_DIR, process.env, launch.captureStartupStderr));
+    let brokerStderr = "";
+    const rememberBrokerStderr = (chunk: Buffer | string) => {
+      brokerStderr = `${brokerStderr}${chunk.toString()}`.slice(-BROKER_STARTUP_STDERR_LIMIT);
+    };
+    const brokerStartupError = (message: string, cause?: unknown) => {
+      const stderr = brokerStderr.trim();
+      const errorMessage = stderr ? `${message}\nBroker stderr:\n${stderr}` : message;
+      return cause === undefined ? new Error(errorMessage) : new Error(errorMessage, { cause });
+    };
+    child.stderr?.on("data", rememberBrokerStderr);
+    child.stderr?.unref();
     child.unref();
 
     await new Promise<void>((resolve, reject) => {
       const cleanup = () => {
+        child.stderr?.off("data", rememberBrokerStderr);
+        child.stderr?.resume();
         child.off("error", onError);
-        child.off("exit", onExit);
+        child.off("close", onExit);
       };
 
       const onError = (error: Error) => {
         cleanup();
-        reject(new Error(`Failed to spawn intercom broker: ${error.message}`, { cause: error }));
+        reject(brokerStartupError(`Failed to spawn intercom broker: ${error.message}`, error));
       };
 
       const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
@@ -226,20 +251,21 @@ export async function spawnBrokerIfNeeded(brokerCommand: string, brokerArgs: str
         }
         cleanup();
         if (signal) {
-          reject(new Error(`Intercom broker exited before startup with signal ${signal}`));
+          reject(brokerStartupError(`Intercom broker exited before startup with signal ${signal}`));
           return;
         }
-        reject(new Error(`Intercom broker exited before startup with code ${code ?? "unknown"}`));
+        reject(brokerStartupError(`Intercom broker exited before startup with code ${code ?? "unknown"}`));
       };
 
       child.once("error", onError);
-      child.once("exit", onExit);
+      child.once("close", onExit);
       waitForBroker().then(() => {
         cleanup();
         resolve();
       }, (error) => {
         cleanup();
-        reject(toError(error));
+        const startupError = toError(error);
+        reject(brokerStartupError(startupError.message, startupError));
       });
     });
   } finally {


### PR DESCRIPTION
## Summary

Fixes #97.

This updates the default broker launcher fallback so a flat plugin-store install can use the sibling `tsx/dist/cli.mjs` path when package resolution fails. It keeps the legacy nested fallback when no sibling CLI exists.

It also captures bounded stderr for the default non-Windows broker startup path, so early launcher failures include the broker stderr in the startup error. Custom broker commands and the Windows `wscript` launcher keep stderr ignored.

## Validation

- `./node_modules/.bin/tsx --test broker/spawn.test.ts`
- `npm test`
