### PR TITLE
fix: preserve reply attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ### Fixed
 - Resolve the default broker `tsx` launcher from flat plugin-store installs when package resolution fails, and include broker stderr when startup exits early. Thanks to Eduardo Marquez (`DocksDocks`) for issue #97.
+- Preserve attachments when replying through `intercom({ action: "reply" })`. Thanks to Ruoshan Huang (`ruoshan`) for issue #99.
 
 ## [0.10.0] - 2026-08-09
 

--- a/index.ts
+++ b/index.ts
@@ -2216,6 +2216,7 @@ Usage:
             }
             const result = await connectedClient.send(target.from.id, {
               text: message,
+              attachments,
               replyTo: target.message.id,
             });
             if (!result.delivered) {
@@ -2231,7 +2232,7 @@ Usage:
             dismissIncomingAsk(target.message.id);
             pi.appendEntry("intercom_sent", {
               to: target.from.name || target.from.id,
-              message: { text: message, replyTo: target.message.id },
+              message: { text: message, attachments, replyTo: target.message.id },
               messageId: result.id,
               timestamp: Date.now(),
             });

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -2346,6 +2346,42 @@ test("intercom reply targets exact replyTo when multiple asks are pending", { co
   }
 });
 
+test("intercom reply sends attachments", { concurrency: false }, async () => {
+  const { planner, cleanup } = await setupClients();
+  const { default: piIntercomExtension } = await import("./index.ts");
+  const harness = createExtensionHarness("reply-attachment-worker");
+
+  try {
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    const worker = await waitForSessionByName(planner, "reply-attachment-worker");
+
+    const askId = "reply-attachment-ask";
+    assert.equal((await planner.send(worker.id, { messageId: askId, text: "Send details?", expectsReply: true })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
+    const attachments = [{ type: "snippet" as const, name: "details.md", content: "attached details", language: "md" }];
+    const replyReceived = waitForReply(planner, askId);
+    const result = await intercomTool.execute("reply-with-attachment", {
+      action: "reply",
+      message: "Here are details.",
+      attachments,
+    }, new AbortController().signal, undefined, harness.ctx);
+
+    assert.equal(result.details?.delivered, true);
+    const reply = await replyReceived;
+    assert.equal(reply.message.content.text, "Here are details.");
+    assert.deepEqual(reply.message.content.attachments, attachments);
+
+    const sentEntry = harness.entries.find((entry) => entry.type === "intercom_sent");
+    assert.deepEqual((sentEntry?.data as { message?: { attachments?: unknown } }).message?.attachments, attachments);
+  } finally {
+    await harness.emitLifecycle("session_shutdown");
+    await cleanup();
+  }
+});
+
 test("intercom reply targets one of multiple pending asks by short session ID", { concurrency: false }, async () => {
   const { planner, orchestrator, cleanup } = await setupClients();
   const { default: piIntercomExtension } = await import("./index.ts");


### PR DESCRIPTION
## Summary

Fixes #99.

This forwards `attachments` through the `intercom({ action: "reply" })` path, and preserves those attachments in the `intercom_sent` session entry for the reply.

## Validation

- `./node_modules/.bin/tsx --test intercom.integration.test.ts`
- `npm test`
