### PR TITLE
feat: surface a session's tmux pane id in the roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Added
+- Added tmux pane IDs to the roster. Thanks to [@odfalik](https://github.com/odfalik) for issue #102 and PR #101.
+
 ## [0.10.1] - 2026-08-12
 
 ### Fixed

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -362,6 +362,7 @@ class IntercomBroker {
           startedAt: session.startedAt,
           lastActivity: session.lastActivity,
           ...(session.status !== undefined ? { status: session.status } : {}),
+          ...(session.tmuxPane !== undefined ? { tmuxPane: session.tmuxPane } : {}),
           trustedLocal: typeof LISTEN_TARGET === "string" && process.platform !== "win32",
         };
 

--- a/broker/protocol.ts
+++ b/broker/protocol.ts
@@ -146,6 +146,10 @@ export function isSessionInfo(value: unknown): value is SessionInfo {
     }
   }
 
+  if (value.tmuxPane !== undefined && typeof value.tmuxPane !== "string") {
+    return false;
+  }
+
   return value.trustedLocal === undefined || typeof value.trustedLocal === "boolean";
 }
 
@@ -175,6 +179,9 @@ export function isSessionRegistration(value: unknown): value is SessionRegistrat
     return false;
   }
   if (value.extensions !== undefined && !Array.isArray(value.extensions)) {
+    return false;
+  }
+  if (value.tmuxPane !== undefined && typeof value.tmuxPane !== "string") {
     return false;
   }
 

--- a/index.ts
+++ b/index.ts
@@ -434,6 +434,14 @@ function buildPresenceIdentity(pi: ExtensionAPI, sessionId: string): { name: str
 function resolveConfiguredIntercomSessionId(piSessionId: string, config: IntercomConfig): string {
   return process.env[STABLE_INTERCOM_SESSION_ID_ENV]?.trim() || config.stableId || piSessionId;
 }
+// The tmux pane id (e.g. "%212") the session was launched in. $TMUX_PANE is
+// inherited at process start and immutable for the lifetime — moving the pane
+// between windows keeps its id — so it is a stable join key a peer can use to
+// live-resolve the current window via tmux. Absent outside tmux.
+function currentTmuxPane(): string | undefined {
+  const pane = process.env.TMUX_PANE?.trim();
+  return pane ? pane : undefined;
+}
 function formatIntercomContactSnippet(sessionId: string): string {
   return `Use pi-intercom: intercom({ action: "send", to: "${sessionId}", message: "..." })`;
 }
@@ -450,7 +458,8 @@ function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: 
   const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `• ${name} (${idPrefix}) — ${session.cwd} (${session.model}${formatContextUsage(session)})${suffix}`;
+  const pane = session.tmuxPane ? ` · tmux ${session.tmuxPane}` : "";
+  return `• ${name} (${idPrefix}) — ${session.cwd} (${session.model}${formatContextUsage(session)}${pane})${suffix}`;
 }
 function previewText(value: unknown, maxLength = 72): string | undefined {
   if (typeof value !== "string") {
@@ -770,6 +779,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     }
 
     const identity = buildPresenceIdentity(pi, currentIntercomSessionId ?? currentSessionId);
+    const tmuxPane = currentTmuxPane();
     return {
       ...identity,
       cwd: liveContext.cwd,
@@ -778,6 +788,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       startedAt: sessionStartedAt,
       lastActivity: Date.now(),
       status: currentStatus(),
+      ...(tmuxPane ? { tmuxPane } : {}),
       ...(localExtensions.size > 0
         ? {
             extensions: currentExtensionCapabilities(),

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -558,6 +558,49 @@ test("broker accepts caller supplied stable IDs across reconnect", { concurrency
   }
 });
 
+test("broker propagates a session's tmux pane id into the roster", { concurrency: false }, async () => {
+  const { planner, cleanup } = await setupClients();
+  const worker = new IntercomClient();
+
+  try {
+    await worker.connect({
+      name: "tmux-worker",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+      tmuxPane: "%212",
+    });
+    const session = await waitForSessionByName(planner, "tmux-worker");
+    assert.equal(session.tmuxPane, "%212");
+  } finally {
+    await worker.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("broker omits tmux pane id for sessions outside tmux", { concurrency: false }, async () => {
+  const { planner, cleanup } = await setupClients();
+  const worker = new IntercomClient();
+
+  try {
+    await worker.connect({
+      name: "paneless-worker",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    });
+    const session = await waitForSessionByName(planner, "paneless-worker");
+    assert.equal(session.tmuxPane, undefined);
+  } finally {
+    await worker.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
 test("broker owns local trust metadata instead of trusting registration payloads", { concurrency: false }, async () => {
   const { planner, cleanup } = await setupClients();
   const raw = await connectRawRegistered("trust-metadata-worker-id", "trust-metadata-worker", {

--- a/types.ts
+++ b/types.ts
@@ -21,6 +21,13 @@ export interface SessionInfo {
   contextPct?: number;
   contextTokens?: number;
   contextWindow?: number;
+  /** tmux pane id (e.g. "%212") of the session's terminal, read from
+   *  $TMUX_PANE at registration. Present only when the session runs inside a
+   *  tmux pane; absent for cloud, headless, IDE-embedded, or Herdr sessions.
+   *  The pane id is immutable for the process lifetime — unlike the window
+   *  name, which is mutable — so a peer can live-resolve the current window
+   *  from it via tmux when it needs to introspect or drive that pane. */
+  tmuxPane?: string;
 }
 
 export interface Message {


### PR DESCRIPTION
Discussion: #102

## What

When a pi session runs inside a tmux pane, surface its pane id (e.g. `%212`) in the intercom roster so a session's terminal location is **discoverable**. The list row renders `· tmux %212` alongside the model/context columns:

```
• alice (01a00119) — /work/repo (claude-opus-4-8 · 0% ctx · tmux %212) [same cwd, idle]
```

## Why

The roster tells you a peer's session id, name, cwd, model, and live status, but not **which pane** its terminal is in. When several pi sessions run side by side in tmux, there's no way from intercom to tell them apart at the terminal level. You eyeball window titles or `ps` your way there. `$TMUX_PANE` is already sitting in each session's environment, so surfacing it answers "which pane is this session?". That's useful for a human jumping to the right window, or for tooling that correlates a session with its terminal.

The pane id is the right identifier for this. `$TMUX_PANE` is inherited at process start and stays stable for the process lifetime (moving a pane between windows keeps its `%NNN` id), unlike the mutable window *name*. Snapshotting the window name would reintroduce staleness. A consumer that wants the current window can live-resolve it from the pane id via tmux.

This is purely additive metadata. It does not change how messages flow.

## How

- `types.ts`: add optional `tmuxPane?: string` to `SessionInfo` (auto-flows into `SessionRegistration`).
- `index.ts`: read `$TMUX_PANE` in `buildRegistration()` (via `currentTmuxPane()`), render in `formatSessionListRow()`. Flows only at registration/reconnect, not on every presence heartbeat, since the value never changes for the process lifetime.
- `broker/broker.ts`: copy the field in the `register` handler, matching the existing optional-field pattern.
- `broker/protocol.ts`: guard `tmuxPane` type in `isSessionInfo` + `isSessionRegistration`.
- Absent for cloud, headless, IDE-embedded, and Herdr sessions (no `$TMUX_PANE`). The field is simply omitted, so nothing changes for those.

## Open design questions (see #102)

Since intercom is deliberately host-agnostic, happy to reshape before merge:
1. Bare `tmuxPane` on `SessionInfo`, or gated behind a config flag (opt-in)?
2. Or a generic `terminal`/`host` sub-object in case other multiplexers get added later?

## Tests

Covered by integration tests: pane id propagates through registration into the roster, and is omitted for sessions outside tmux. Full suite green (180 pass).
