### PR TITLE
docs: clarify stale intercom session IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Added
 - Added tmux pane IDs to the roster. Thanks to [@odfalik](https://github.com/odfalik) for issue #102 and PR #101.
 
+### Changed
+- Clarified that agents should re-list stale intercom session IDs and skip self-targets.
+
 ## [0.10.1] - 2026-08-12
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -1795,7 +1795,7 @@ Use this to communicate findings, request help, or coordinate work with other se
 
 Target a session by name, full session ID, or the short id shown in parentheses
 by "list" (a leading prefix of the ID is enough). Prefer the short id when two
-sessions share a name.
+sessions share a name. Re-list before reusing a session ID; skip if it resolves to self.
 
 Usage:
   intercom({ action: "list" })                    → List active sessions


### PR DESCRIPTION
## Summary

- Clarify that agents should re-list before reusing a remembered intercom session ID.
- Tell agents to skip targets that resolve to the current session.
- Add the changelog entry.

## Validation

- Fresh review: no issues found.
- `git diff --check`
