### PR TITLE
feat: persist pending blocking ask records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ## [Unreleased]
 
 ### Added
+- Added local pending-ask observability records for delivered blocking asks. Thanks to [@bcanvural](https://github.com/bcanvural) for issue #104.
 - Added tmux pane IDs to the roster. Thanks to [@odfalik](https://github.com/odfalik) for issue #102 and PR #101.
 
 ### Changed

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -1,5 +1,5 @@
 import net from "net";
-import { writeFileSync, unlinkSync } from "fs";
+import { chmodSync, mkdirSync, readdirSync, readFileSync, writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
@@ -9,6 +9,7 @@ import {
   getBrokerListenTarget,
   getBrokerPortFilePath,
   getIntercomDirPath,
+  INTERCOM_DIR_MODE,
   INTERCOM_PROTOCOL_NAME,
   INTERCOM_PROTOCOL_VERSION,
   INTERCOM_RUNTIME_FILE_MODE,
@@ -26,6 +27,7 @@ const INTERCOM_DIR = getIntercomDirPath();
 const LISTEN_TARGET = getBrokerListenTarget();
 const PID_PATH = join(INTERCOM_DIR, "broker.pid");
 const PORT_PATH = getBrokerPortFilePath(INTERCOM_DIR);
+const PENDING_ASKS_DIR = join(INTERCOM_DIR, "pending-asks");
 const BROKER_STATE_ID = randomUUID();
 const MAX_SESSIONS = 128;
 const MAX_UNREGISTERED_CONNECTIONS = 32;
@@ -76,6 +78,16 @@ interface AskEdge {
   createdAt: number;
 }
 
+interface PendingAskRecord {
+  askId: string;
+  messageId: string;
+  asker: { sessionId: string; name: string | null };
+  target: { sessionId: string; name: string | null };
+  question: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
 interface MessageReceiptRoute {
   from: string;
   to: string;
@@ -92,6 +104,37 @@ interface MailboxMessage {
   target: SessionInfo;
   message: Message;
   queuedAt: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPendingAskRecord(value: unknown): value is PendingAskRecord {
+  if (!isRecord(value) || !isRecord(value.asker) || !isRecord(value.target)) {
+    return false;
+  }
+  return typeof value.askId === "string"
+    && typeof value.messageId === "string"
+    && typeof value.asker.sessionId === "string"
+    && (typeof value.asker.name === "string" || value.asker.name === null)
+    && typeof value.target.sessionId === "string"
+    && (typeof value.target.name === "string" || value.target.name === null)
+    && typeof value.question === "string"
+    && Number.isSafeInteger(value.createdAt)
+    && Number.isSafeInteger(value.expiresAt)
+    && value.expiresAt >= value.createdAt;
+}
+
+function pendingAskRecordPath(messageId: string): string {
+  return join(PENDING_ASKS_DIR, `${encodeURIComponent(messageId)}.json`);
+}
+
+function ensurePendingAskRecordDir(): void {
+  mkdirSync(PENDING_ASKS_DIR, { recursive: true, mode: INTERCOM_DIR_MODE });
+  if (process.platform !== "win32") {
+    chmodSync(PENDING_ASKS_DIR, INTERCOM_DIR_MODE);
+  }
 }
 
 class IntercomBroker {
@@ -112,6 +155,8 @@ class IntercomBroker {
   constructor() {
     ensureIntercomRuntimeDir(INTERCOM_DIR);
     assertNoLiveBroker(PID_PATH);
+    ensurePendingAskRecordDir();
+    this.prunePendingAskRecords();
     this.extensionStateManager = new ExtensionStateManager(INTERCOM_DIR);
     if (typeof LISTEN_TARGET === "string" && process.platform !== "win32") {
       try {
@@ -552,7 +597,8 @@ class IntercomBroker {
               });
               break;
             }
-            this.askEdges.set(message.id, { from: currentId, to: target.info.id, createdAt: Date.now() });
+            this.writePendingAskRecord(message, fromSession.info, target.info, brokerReceivedAt);
+            this.askEdges.set(message.id, { from: currentId, to: target.info.id, createdAt: brokerReceivedAt });
           }
           const deliveredMessage: Message = {
             ...message,
@@ -579,6 +625,7 @@ class IntercomBroker {
           });
           if (message.replyTo) {
             this.askEdges.delete(message.replyTo);
+            this.removePendingAskRecord(message.replyTo);
           }
           this.messageReceiptRoutes.set(message.id, { from: currentId, to: target.info.id, createdAt: brokerReceivedAt });
           writeMessage(socket, { type: "delivered", messageId: message.id });
@@ -656,6 +703,7 @@ class IntercomBroker {
           }
           if (message.replyTo) {
             this.askEdges.delete(message.replyTo);
+            this.removePendingAskRecord(message.replyTo);
           }
           writeMessage(socket, { type: "delivered", messageId: message.id });
           break;
@@ -715,6 +763,7 @@ class IntercomBroker {
           const edge = this.askEdges.get(clientMessage.messageId);
           if (edge?.from === currentId) {
             this.askEdges.delete(clientMessage.messageId);
+            this.removePendingAskRecord(clientMessage.messageId);
           }
           writeMessage(socket, { type: "delivered", messageId: clientMessage.messageId });
           break;
@@ -741,6 +790,7 @@ class IntercomBroker {
         const edge = this.askEdges.get(clientMessage.messageId);
         if (edge?.from === currentId) {
           this.askEdges.delete(clientMessage.messageId);
+          this.removePendingAskRecord(clientMessage.messageId);
         }
         writeMessage(socket, { type: "delivered", messageId: clientMessage.messageId });
         break;
@@ -757,6 +807,7 @@ class IntercomBroker {
         const edge = this.askEdges.get(clientMessage.messageId);
         if (session?.socket === socket && edge?.from === currentId) {
           this.askEdges.delete(clientMessage.messageId);
+          this.removePendingAskRecord(clientMessage.messageId);
         }
         break;
       }
@@ -881,6 +932,7 @@ class IntercomBroker {
       if (now - entry.queuedAt > MAILBOX_MESSAGE_RETENTION_MS) {
         if (entry.message.expectsReply) {
           this.askEdges.delete(entry.message.id);
+          this.removePendingAskRecord(entry.message.id);
         }
         this.messageReceiptRoutes.delete(entry.message.id);
         this.mailboxMessages.splice(index, 1);
@@ -895,6 +947,7 @@ class IntercomBroker {
       if (!evicted) break;
       if (evicted.message.expectsReply) {
         this.askEdges.delete(evicted.message.id);
+        this.removePendingAskRecord(evicted.message.id);
       }
       this.messageReceiptRoutes.delete(evicted.message.id);
     }
@@ -954,9 +1007,11 @@ class IntercomBroker {
   }
 
   private pruneAskEdges(now = Date.now()): void {
+    this.prunePendingAskRecords(now);
     for (const [messageId, edge] of this.askEdges) {
       if (now - edge.createdAt > this.askTimeoutMs) {
         this.askEdges.delete(messageId);
+        this.removePendingAskRecord(messageId);
       }
     }
   }
@@ -965,6 +1020,53 @@ class IntercomBroker {
     for (const [messageId, edge] of this.askEdges) {
       if (edge.from === sessionId || edge.to === sessionId) {
         this.askEdges.delete(messageId);
+        this.removePendingAskRecord(messageId);
+      }
+    }
+  }
+
+  private writePendingAskRecord(message: Message, from: SessionInfo, target: SessionInfo, createdAt: number): void {
+    ensurePendingAskRecordDir();
+    const record: PendingAskRecord = {
+      askId: message.id,
+      messageId: message.id,
+      asker: { sessionId: from.id, name: from.name ?? null },
+      target: { sessionId: target.id, name: target.name ?? null },
+      question: message.content.text,
+      createdAt,
+      expiresAt: createdAt + this.askTimeoutMs,
+    };
+    const filePath = pendingAskRecordPath(message.id);
+    writeFileSync(filePath, `${JSON.stringify(record, null, 2)}\n`, { mode: INTERCOM_RUNTIME_FILE_MODE });
+    restrictIntercomRuntimeFile(filePath);
+  }
+
+  private removePendingAskRecord(messageId: string): void {
+    try {
+      unlinkSync(pendingAskRecordPath(messageId));
+    } catch (error) {
+      if (!isRecord(error) || error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  private prunePendingAskRecords(now = Date.now()): void {
+    ensurePendingAskRecordDir();
+    for (const entry of readdirSync(PENDING_ASKS_DIR, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) {
+        continue;
+      }
+      const filePath = join(PENDING_ASKS_DIR, entry.name);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+      } catch {
+        unlinkSync(filePath);
+        continue;
+      }
+      if (!isPendingAskRecord(parsed) || now > parsed.expiresAt) {
+        unlinkSync(filePath);
       }
     }
   }

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { EventEmitter, once } from "node:events";
@@ -28,6 +28,7 @@ process.env.HOME = sharedHomeDir;
 process.env.USERPROFILE = sharedHomeDir;
 const { IntercomClient } = await import("./broker/client.ts");
 const { getTsxCliPath } = await import("./broker/spawn.ts");
+const { getAskTimeoutMs } = await import("./config.ts");
 process.on("exit", () => {
   process.env.HOME = previousHome;
   process.env.USERPROFILE = previousUserProfile;
@@ -426,6 +427,26 @@ function waitForReply(client: InstanceType<typeof IntercomClient>, replyTo: stri
     };
     client.on("message", handler);
   });
+}
+
+function pendingAskRecordPath(messageId: string): string {
+  return path.join(sharedHomeDir, ".pi", "agent", "intercom", "pending-asks", `${encodeURIComponent(messageId)}.json`);
+}
+
+function readPendingAskRecord(messageId: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(pendingAskRecordPath(messageId), "utf-8")) as Record<string, unknown>;
+}
+
+async function waitForPendingAskRecordRemoved(messageId: string): Promise<void> {
+  const filePath = pendingAskRecordPath(messageId);
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (!existsSync(filePath)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  assert.equal(existsSync(filePath), false);
 }
 
 async function waitForSessionByName(client: InstanceType<typeof IntercomClient>, name: string): Promise<SessionInfo> {
@@ -2081,6 +2102,103 @@ test("regular intercom asks fail safely when started concurrently", { concurrenc
     assert.equal(results.filter((result) => /First answer/.test(result.content[0]?.text ?? "")).length, 1);
     await harness.emitLifecycle("session_shutdown");
   } finally {
+    await cleanup();
+  }
+});
+
+test("broker writes a local pending ask record for delivered blocking asks", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const askId = "pending-record-live-ask";
+
+  try {
+    const result = await planner.send(orchestrator.sessionId!, {
+      messageId: askId,
+      text: "Can you decide?",
+      expectsReply: true,
+    });
+
+    assert.equal(result.delivered, true);
+    const record = readPendingAskRecord(askId);
+    assert.equal(record.askId, askId);
+    assert.equal(record.messageId, askId);
+    assert.deepEqual(record.asker, { sessionId: planner.sessionId, name: "planner" });
+    assert.deepEqual(record.target, { sessionId: orchestrator.sessionId, name: "orchestrator" });
+    assert.equal(record.question, "Can you decide?");
+    assert.equal(Number(record.expiresAt) - Number(record.createdAt), getAskTimeoutMs());
+    if (process.platform !== "win32") {
+      assert.equal(statSync(pendingAskRecordPath(askId)).mode & 0o777, 0o600);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test("broker removes a pending ask record after a delivered reply", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const askId = "pending-record-replied-ask";
+
+  try {
+    assert.equal((await planner.send(orchestrator.sessionId!, {
+      messageId: askId,
+      text: "Can you answer?",
+      expectsReply: true,
+    })).delivered, true);
+    assert.equal(existsSync(pendingAskRecordPath(askId)), true);
+
+    assert.equal((await orchestrator.send(planner.sessionId!, {
+      text: "Answered.",
+      replyTo: askId,
+    })).delivered, true);
+
+    assert.equal(existsSync(pendingAskRecordPath(askId)), false);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("broker removes a pending ask record after asker cancellation", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const askId = "pending-record-cancelled-ask";
+
+  try {
+    assert.equal((await planner.send(orchestrator.sessionId!, {
+      messageId: askId,
+      text: "Should I stop?",
+      expectsReply: true,
+    })).delivered, true);
+    assert.equal(existsSync(pendingAskRecordPath(askId)), true);
+
+    planner.cancelAsk(askId);
+    await waitForPendingAskRecordRemoved(askId);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("broker removes a pending ask record during timeout pruning", { concurrency: false }, async () => {
+  const previousTimeout = process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+  process.env.PI_INTERCOM_ASK_TIMEOUT_MS = "50";
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const askId = "pending-record-timeout-ask";
+
+  try {
+    assert.equal((await planner.send(orchestrator.sessionId!, {
+      messageId: askId,
+      text: "Will this expire?",
+      expectsReply: true,
+    })).delivered, true);
+    assert.equal(existsSync(pendingAskRecordPath(askId)), true);
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal((await planner.send(orchestrator.sessionId!, { text: "Prune asks." })).delivered, true);
+
+    assert.equal(existsSync(pendingAskRecordPath(askId)), false);
+  } finally {
+    if (previousTimeout === undefined) {
+      delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+    } else {
+      process.env.PI_INTERCOM_ASK_TIMEOUT_MS = previousTimeout;
+    }
     await cleanup();
   }
 });


### PR DESCRIPTION
## Summary

Persist local observability records for delivered blocking intercom asks under the intercom runtime directory. Records include asker, target, question text, creation time, and expiry, and are removed on reply, cancellation, or timeout.

Closes #104.

## Validation

- `./node_modules/.bin/tsx --test intercom.integration.test.ts`
- `npm test`
- `git diff --check origin/main..HEAD`

Thanks to [@bcanvural](https://github.com/bcanvural) for issue #104.