### PR TITLE
feat: add broker-enforced channel-v1 local delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,9 +348,10 @@ The supervisor can reply with plain JSON or a fenced `json` block. If the reply 
 | `intended` | string | Optional channel-local identity declaration. A configured identity must resolve to the same exact endpoint as `to`. |
 
 Every send/ask is one recipient and establishes or reuses one broker channel. A
-reconnect that should receive queued channel mail must reuse the same stable
-session ID; a same-name session with a new ID is intentionally not treated as
-the old member.
+reconnect that should receive queued channel mail within the same broker
+lifetime must reuse the same stable session ID; a same-name session with a new
+ID is intentionally not treated as the old member. Broker restart preserves
+channel membership only, not queued mail or old message-ID records.
 
 ### contact_supervisor
 
@@ -549,20 +550,26 @@ known failure includes an error code, retryability, and whether the outcome is
 known. A send timeout is reported as `E_DELIVERY_TIMEOUT_UNKNOWN`; callers
 should not blindly create a second message. Reusing a message ID with the same
 authored payload is idempotent, while changing its payload or recipient returns
-`E_MESSAGE_ID_REUSE`. There is no automatic unbounded retry.
+`E_MESSAGE_ID_REUSE`. A queued message that was cancelled, expired, or
+superseded is terminal and returns `E_MESSAGE_CANCELLED`, `E_MESSAGE_EXPIRED`,
+or `E_MESSAGE_SUPERSEDED` on same-ID retry. There is no automatic unbounded
+retry.
 
 Projects may additionally place `.pi/intercom-channel.json` above their cwd to
-restrict the local extension to configured members. Members with an `id` are
-matched by exact ID; their `name` is the channel-local identity. The optional
-`intended` tool field checks that a declared identity resolves to the same
-configured ID. This file is a policy guard, not a substitute for broker
-channel authorization.
+restrict the local extension to configured members. Every member must have a
+stable `id` (the session ID); `name` is only the channel-local identity. The
+optional `allowNameOnly: true` is an explicit legacy compatibility opt-in and
+uses a weaker live-name binding. The optional `intended` tool field checks that
+a declared identity resolves to the same configured ID. This file is a policy
+guard, not a substitute for broker channel authorization.
 
 Channel membership state is retained in the local intercom runtime directory
 (`channels.json`) so a broker restart does not silently create a new identity.
-A reconnect must use the same stable session ID to resume a queued channel
-message; a same-name process with a different ID is never treated as the same
-member.
+The in-memory mailbox and idempotency records are not persisted: broker restart
+can discard queued messages and does not preserve the old broker's message-ID
+knowledge. Within one broker lifetime, a reconnect must use the same stable
+session ID to resume a queued channel message; a same-name process with a
+different ID is never treated as the same member.
 
 ## Design Decisions
 
@@ -619,4 +626,4 @@ Use pi-messenger for multi-agent swarms working on a shared task. Use pi-interco
 - **Only connected sessions appear** — The list shows Pi sessions that have loaded `pi-intercom` and successfully registered with the broker, not every open Pi process on the machine
 - **Broker lifecycle** — The broker auto-spawns on first use and exits when idle; sessions reconnect automatically if the broker restarts
 - **Single-recipient first round** — There is intentionally no broadcast or transactional multi-recipient message; callers must send separately so every recipient has an independent message ID and delivery state
-- **Bounded runtime mailbox** — Channel membership is persisted, but queued message records and idempotency records are currently bounded broker runtime state; a future iteration can add durable replay across broker replacement
+- **Bounded runtime mailbox** — Channel membership is persisted, but queued messages and idempotency records are broker-runtime state only. A broker restart may discard queued messages and forget prior message IDs; durable replay/status is a future iteration

--- a/README.md
+++ b/README.md
@@ -345,6 +345,12 @@ The supervisor can reply with plain JSON or a fenced `json` block. If the reply 
 | `cwd` | string | Working directory filter for `list-cwd`. For send/ask, scopes target lookup to that directory; without `to`, selects the sole live peer there. |
 | `openProjectPaneIfMissing` | boolean | For `send`/`ask` with `cwd`, open a visible Herdr project pane and launch Pi when no matching live session exists |
 | `focus` | boolean | For `openProjectPaneIfMissing`, focus the new Herdr pane. Defaults to true |
+| `intended` | string | Optional channel-local identity declaration. A configured identity must resolve to the same exact endpoint as `to`. |
+
+Every send/ask is one recipient and establishes or reuses one broker channel. A
+reconnect that should receive queued channel mail must reuse the same stable
+session ID; a same-name session with a new ID is intentionally not treated as
+the old member.
 
 ### contact_supervisor
 
@@ -366,7 +372,7 @@ Only registered in sessions where `pi-subagents` supplied the required child bri
 
 **`list`** — Returns the current session plus other active intercom-connected sessions with name, short ID, working directory, model, and live status. Status is derived automatically from Pi lifecycle events: `idle`, `thinking`, or `tool:<name>`.
 
-**`send`** — Sends a message to the specified session and returns immediately after delivery. If the destination has exactly one pending inbound ask, `send` infers the message is its answer and returns `Reply sent to <target> (inferred from pending ask)`; zero or multiple matches remain unthreaded sends. Set `confirmSend: true` to confirm ordinary and inferred sends. A caller-supplied `replyTo` skips confirmation. `to` alone resolves globally across all live sessions. `cwd` alone targets the sole live peer in that directory. `to` plus `cwd` requires that peer to be in the directory. With `openProjectPaneIfMissing: true`, pi-intercom opens a visible Herdr project pane, starts Pi there, waits for that session to register, then delivers the message through normal intercom routing.
+**`send`** — Establishes or reuses a broker channel, then sends one message to one exact member and returns the broker delivery state. If the destination has exactly one pending inbound ask, `send` infers the message is its answer and returns `Reply sent to <target> (inferred from pending ask)`; zero or multiple matches remain unthreaded sends. Set `confirmSend: true` to confirm ordinary and inferred sends. A caller-supplied `replyTo` skips confirmation. The result details expose `errorCode`, `deliveryState`, `retryable`, `outcomeKnown`, and `channelId` when available. Do not blindly resend after `E_DELIVERY_TIMEOUT_UNKNOWN`; retry with the same `messageId` only after deliberate inspection. `to` alone resolves globally across all live sessions. `cwd` alone targets the sole live peer in that directory. `to` plus `cwd` requires that peer to be in the directory. With `openProjectPaneIfMissing: true`, pi-intercom opens a visible Herdr project pane, starts Pi there, waits for that session to register, then delivers the message through normal intercom routing.
 
 **`ask`** — Requires a currently connected recipient, sends a message, and waits for the recipient to reply (10-minute timeout by default; configurable with `PI_INTERCOM_ASK_TIMEOUT_MS`). A disconnected target fails immediately rather than queueing a blocking request. The reply is returned as the tool result. No confirmation dialog. Only one pending `ask` is allowed per session at a time. Use this when the agent needs the answer to continue working. The same `to`, `cwd`, and `openProjectPaneIfMissing` targeting rules apply.
 
@@ -508,8 +514,55 @@ Runtime files live at `~/.pi/agent/intercom/` by default, or `$PI_CODING_AGENT_D
 - `broker.spawn.lock` — Auto-spawn lock file
 - `broker.port.json` — Dynamic localhost TCP endpoint, only when Windows TCP transport is explicitly enabled
 - `config.json` — User configuration
+- `channels.json` — Broker-owned channel membership and lifecycle state
 
 Supported `config.json` keys include `stableId` for restart-stable addressing, `status` for a custom status suffix, `inboundTrigger` (`always`, `replies`, or `never`), `replyHint`, `confirmSend`, and advanced broker launch overrides.
+
+## Channel-v1 safety boundary
+
+Conversational delivery now uses a broker-enforced logical channel before a
+message is routed. `IntercomClient.send()` resolves a target to an exact
+session ID, performs `channel_open` (which creates or reuses a channel), and
+sends a single-recipient `channel_send` containing:
+
+- `channelId` + channel epoch
+- sender and target member IDs
+- the target binding epoch
+- a broker-resolved channel identity (`执行者-N` for an unnamed member)
+
+A channel member's `memberId` is the stable logical identity inside that
+channel; `sessionId` is only its current runtime endpoint. Unnamed members are
+assigned `执行者-1`, `执行者-2`, ... in successful broker join order. Ordinals
+are not reused. A default channel is `ephemeral` with an idle TTL; opening it
+again reuses the same channel while active. `reusable` is available at the
+client API for workflows that need a longer-lived channel.
+
+The broker validates membership, epoch, sender binding, target binding, reply
+edges, and recipient identity in the same delivery path. A legacy wire `send`
+is upgraded only for an exact session ID; name/prefix-only legacy sends fail
+closed with `E_CHANNEL_REQUIRED`. A disconnected member can receive queued
+ordinary messages only through its exact channel member/session binding;
+blocking `ask` requests are not queued.
+
+Delivery results distinguish `socket_delivered`, `queued`, and `failed`. A
+known failure includes an error code, retryability, and whether the outcome is
+known. A send timeout is reported as `E_DELIVERY_TIMEOUT_UNKNOWN`; callers
+should not blindly create a second message. Reusing a message ID with the same
+authored payload is idempotent, while changing its payload or recipient returns
+`E_MESSAGE_ID_REUSE`. There is no automatic unbounded retry.
+
+Projects may additionally place `.pi/intercom-channel.json` above their cwd to
+restrict the local extension to configured members. Members with an `id` are
+matched by exact ID; their `name` is the channel-local identity. The optional
+`intended` tool field checks that a declared identity resolves to the same
+configured ID. This file is a policy guard, not a substitute for broker
+channel authorization.
+
+Channel membership state is retained in the local intercom runtime directory
+(`channels.json`) so a broker restart does not silently create a new identity.
+A reconnect must use the same stable session ID to resume a queued channel
+message; a same-name process with a different ID is never treated as the same
+member.
 
 ## Design Decisions
 
@@ -517,7 +570,7 @@ Supported `config.json` keys include `stableId` for restart-stable addressing, `
 
 **Auto-spawn with file lock.** The broker starts on first connection and exits after 5 seconds idle. There is no daemon to manage. A spawn lock file, keyed by PID and timestamp, prevents duplicate brokers when multiple sessions start at once.
 
-**`ask` stays client-side.** The broker still routes plain messages; it does not have a special request/response mode for `ask`. The client waits for a matching reply before it triggers a new turn, then returns that reply as the tool result. Reply hints make that flow practical by showing the recipient the exact `send` call to use. Separately, `list` / `sessions` now carry a `requestId` so a delayed session-list reply cannot be mistaken for a newer one.
+**`ask` stays client-side.** The broker enforces the same channel delivery path for an `ask`; it does not have a separate conversational request/response transport. The client waits for a matching channel-bound reply before it triggers a new turn, then returns that reply as the tool result. Reply hints make that flow practical by showing the recipient the exact `send` call to use. Separately, `list` / `sessions` now carry a `requestId` so a delayed session-list reply cannot be mistaken for a newer one.
 
 ## pi-intercom vs pi-messenger
 
@@ -542,7 +595,8 @@ Use pi-messenger for multi-agent swarms working on a shared task. Use pi-interco
 ├── project-agent.ts      # Herdr project-pane launch and cwd target resolution
 ├── broker/
 │   ├── broker.ts         # Broker process
-│   ├── client.ts         # IntercomClient class
+│   ├── client.ts         # IntercomClient class and channel handshake
+│   ├── channel.ts        # Broker channel lifecycle and identity helpers
 │   ├── framing.ts        # Length-prefixed JSON protocol
 │   ├── paths.ts          # Platform-specific socket/pipe paths
 │   ├── spawn.ts          # Auto-spawn logic with lock file
@@ -564,3 +618,5 @@ Use pi-messenger for multi-agent swarms working on a shared task. Use pi-interco
 - **No attachments UI** — `file`, `snippet`, and `context` attachments are supported in the protocol, but not in the compose overlay
 - **Only connected sessions appear** — The list shows Pi sessions that have loaded `pi-intercom` and successfully registered with the broker, not every open Pi process on the machine
 - **Broker lifecycle** — The broker auto-spawns on first use and exits when idle; sessions reconnect automatically if the broker restarts
+- **Single-recipient first round** — There is intentionally no broadcast or transactional multi-recipient message; callers must send separately so every recipient has an independent message ID and delivery state
+- **Bounded runtime mailbox** — Channel membership is persisted, but queued message records and idempotency records are currently bounded broker runtime state; a future iteration can add durable replay across broker replacement

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -63,6 +63,11 @@ const MESSAGE_RECEIPT_ROUTE_RETENTION_MS = 60 * 60 * 1000;
 const DISCONNECTED_SESSION_RETENTION_MS = 24 * 60 * 60 * 1000;
 const MAILBOX_MESSAGE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const MAX_MAILBOX_MESSAGES = 256;
+
+function mailboxMessageRetentionMs(): number {
+  const configured = Number.parseInt(process.env.PI_INTERCOM_MAILBOX_MESSAGE_RETENTION_MS ?? "", 10);
+  return Number.isSafeInteger(configured) && configured > 0 ? configured : MAILBOX_MESSAGE_RETENTION_MS;
+}
 const MAX_CHANNELS = 1024;
 const MAX_CHANNEL_MESSAGE_RECORDS = 4096;
 
@@ -130,12 +135,14 @@ interface MailboxMessage {
   channel?: ChannelAddress;
 }
 
+type ChannelMessageState = DeliveryState | "cancelled" | "expired" | "superseded";
+
 interface ChannelMessageRecord {
   fingerprint: string;
   channelId: string;
   fromMemberId: string;
   toMemberId: string;
-  state: DeliveryState;
+  state: ChannelMessageState;
   createdAt: number;
   message: Message;
 }
@@ -171,7 +178,7 @@ function ensurePendingAskRecordDir(): void {
   }
 }
 
-class IntercomBroker {
+export class IntercomBroker {
   private sessions = new Map<string, ConnectedSession>();
   private askEdges = new Map<string, AskEdge>();
   private messageReceiptRoutes = new Map<string, MessageReceiptRoute>();
@@ -433,8 +440,10 @@ class IntercomBroker {
           }
         }
 
-        this.pruneDisconnectedSessions();
-        this.pruneMailboxMessages();
+        const now = Date.now();
+        this.pruneDisconnectedSessions(now);
+        this.pruneChannels(now);
+        this.pruneMailboxMessages(now);
         const previous = this.sessions.get(id);
         if (!previous && this.sessions.size >= MAX_SESSIONS) {
           writeMessage(socket, { type: "error", error: "Too many registered intercom sessions" });
@@ -470,7 +479,7 @@ class IntercomBroker {
         };
         this.sessions.set(id, connectedSession);
         this.disconnectedSessions.delete(id);
-        this.rebindChannelsForSession(connectedSession);
+        this.rebindChannelsForSession(connectedSession, now);
         
         if (this.shutdownTimer) {
           clearTimeout(this.shutdownTimer);
@@ -488,7 +497,7 @@ class IntercomBroker {
         this.broadcast({ type: "session_joined", session: info }, id);
 
         this.recomputeNamespaceOwners();
-        this.flushMailboxForSession(connectedSession);
+        this.flushMailboxForSession(connectedSession, now);
 
         if (extensions) {
           for (const ext of extensions) {
@@ -831,7 +840,8 @@ class IntercomBroker {
         const sender = this.sessions.get(currentId);
         const queuedIndex = this.mailboxMessages.findIndex(entry => entry.message.id === clientMessage.messageId && entry.from.id === currentId);
         if (queuedIndex >= 0 && sender?.socket === socket) {
-          this.mailboxMessages.splice(queuedIndex, 1);
+          const [entry] = this.mailboxMessages.splice(queuedIndex, 1);
+          if (entry) this.terminalizeMailboxEntry(entry, "cancelled");
           const edge = this.askEdges.get(clientMessage.messageId);
           if (edge?.from === currentId) {
             this.askEdges.delete(clientMessage.messageId);
@@ -1097,6 +1107,10 @@ class IntercomBroker {
       ?? null;
   }
 
+  private isCurrentSessionSocket(sessionId: string | null, socket: net.Socket): boolean {
+    return Boolean(sessionId && this.sessions.get(sessionId)?.socket === socket);
+  }
+
   private getOrCreatePairChannel(
     senderId: string,
     targetId: string,
@@ -1145,6 +1159,10 @@ class IntercomBroker {
     if (typeof requestId !== "string" || requestId.length === 0 || typeof targetSessionId !== "string" || targetSessionId.length === 0) {
       throw new Error("Invalid channel_open message");
     }
+    if (!this.isCurrentSessionSocket(currentId, socket)) {
+      this.channelOpenError(socket, requestId, "E_SESSION_REPLACED: this socket is no longer the current session endpoint", "E_SESSION_REPLACED");
+      return;
+    }
     if (targetSessionId === currentId) {
       this.channelOpenError(socket, requestId, "E_TARGET_SELF: a channel needs two different sessions", "E_TARGET_SELF");
       return;
@@ -1182,6 +1200,10 @@ class IntercomBroker {
     if (typeof requestId !== "string" || typeof channelId !== "string" || typeof channelEpoch !== "string") {
       throw new Error("Invalid channel_close message");
     }
+    if (!this.isCurrentSessionSocket(currentId, socket)) {
+      this.channelOpenError(socket, requestId, "E_SESSION_REPLACED: this socket is no longer the current session endpoint", "E_SESSION_REPLACED");
+      return;
+    }
     const channel = this.channels.get(channelId);
     const member = channel ? channelMemberForSession(channel, currentId) : undefined;
     if (!channel || channel.epoch !== channelEpoch || !member) {
@@ -1217,7 +1239,7 @@ class IntercomBroker {
   private pruneChannelMessageRecords(now = Date.now()): void {
     for (const [key, record] of this.channelMessageRecords) {
       const channel = this.channels.get(record.channelId);
-      if (!channel || (channel.expiresAt !== undefined && channel.expiresAt < now - MAILBOX_MESSAGE_RETENTION_MS)) {
+      if (!channel || (channel.expiresAt !== undefined && channel.expiresAt < now - mailboxMessageRetentionMs())) {
         this.channelMessageRecords.delete(key);
       }
     }
@@ -1230,6 +1252,64 @@ class IntercomBroker {
 
   private sendChannelSuccess(socket: net.Socket, messageId: string, state: DeliveryState, channelId: string): void {
     writeMessage(socket, { type: "delivered", messageId, state, channelId });
+  }
+
+  private terminalizeMailboxEntry(entry: MailboxMessage, state: Extract<ChannelMessageState, "cancelled" | "expired" | "superseded">): void {
+    if (entry.channel) {
+      const key = this.messageRecordKey(entry.channel, entry.message.id);
+      const record = this.channelMessageRecords.get(key);
+      if (record && record.state === "queued") {
+        record.state = state;
+      }
+    }
+    if (entry.message.expectsReply) {
+      this.askEdges.delete(entry.message.id);
+      this.removePendingAskRecord(entry.message.id);
+    }
+    this.messageReceiptRoutes.delete(entry.message.id);
+  }
+
+  private removeQueuedChannelMessage(
+    channelId: string,
+    fromMemberId: string,
+    toMemberId: string,
+    messageId: string,
+    state: Extract<ChannelMessageState, "superseded" | "cancelled" | "expired">,
+  ): boolean {
+    const index = this.mailboxMessages.findIndex((entry) => {
+      return entry.message.id === messageId
+        && entry.channel?.channelId === channelId
+        && entry.channel.fromMemberId === fromMemberId
+        && entry.channel.toMemberId === toMemberId;
+    });
+    if (index < 0) return false;
+    const [entry] = this.mailboxMessages.splice(index, 1);
+    if (entry) this.terminalizeMailboxEntry(entry, state);
+    return Boolean(entry);
+  }
+
+  private channelRecordFailure(
+    socket: net.Socket,
+    messageId: string,
+    record: ChannelMessageRecord,
+  ): void {
+    const terminal = record.state === "cancelled" || record.state === "expired" || record.state === "superseded"
+      ? record.state
+      : "failed";
+    const code = terminal === "cancelled"
+      ? "E_MESSAGE_CANCELLED"
+      : terminal === "expired"
+        ? "E_MESSAGE_EXPIRED"
+        : terminal === "superseded"
+          ? "E_MESSAGE_SUPERSEDED"
+          : "E_DELIVERY_FAILED";
+    this.channelError(
+      socket,
+      messageId,
+      `${code}: previous message record is terminal (${terminal})`,
+      code,
+      { channelId: record.channelId },
+    );
   }
 
   private handleChannelSend(socket: net.Socket, currentId: string | null, msg: Record<string, unknown>): void {
@@ -1248,6 +1328,10 @@ class IntercomBroker {
     const message = msg.message;
     const messageId = isMessage(message) ? message.id : "unknown";
     if (!currentId || typeof msg.to !== "string" || !isMessage(message)) return false;
+    if (!this.isCurrentSessionSocket(currentId, socket)) {
+      this.channelError(socket, messageId, "E_SESSION_REPLACED: this socket is no longer the current session endpoint", "E_SESSION_REPLACED");
+      return true;
+    }
     const targetId = msg.to;
     // Legacy wire clients cannot safely express a channel-local name. Exact
     // IDs are upgraded; fuzzy names/prefixes fail closed with a useful code.
@@ -1272,6 +1356,7 @@ class IntercomBroker {
 
   private routeChannelMessage(socket: net.Socket, currentId: string, address: ChannelAddress, message: Message): void {
     this.pruneChannels();
+    this.pruneMailboxMessages();
     this.pruneChannelMessageRecords();
     const channel = this.channels.get(address.channelId);
     const messageId = message.id;
@@ -1307,7 +1392,7 @@ class IntercomBroker {
       } else if (existing.state === "queued" || existing.state === "socket_delivered") {
         this.sendChannelSuccess(socket, messageId, existing.state, channel.channelId);
       } else {
-        this.channelError(socket, messageId, "E_DELIVERY_FAILED: previous delivery failed", "E_DELIVERY_FAILED", { channelId: channel.channelId });
+        this.channelRecordFailure(socket, messageId, existing);
       }
       return;
     }
@@ -1392,6 +1477,15 @@ class IntercomBroker {
       this.channelError(socket, messageId, "E_QUEUE_FULL: channel mailbox is full", "E_QUEUE_FULL", { retryable: true, channelId: channel.channelId });
       return;
     }
+    if (message.supersedes) {
+      this.removeQueuedChannelMessage(
+        channel.channelId,
+        fromMember.memberId,
+        targetMember.memberId,
+        message.supersedes,
+        "superseded",
+      );
+    }
     this.queueMailboxMessage(sender.info, targetMember.sessionId ? (this.disconnectedSessions.get(targetMember.sessionId)?.info ?? { ...sender.info, id: targetMember.sessionId }) : sender.info, deliveredMessage, brokerReceivedAt, address);
     this.messageReceiptRoutes.set(message.id, { from: currentId, to: targetMember.sessionId, createdAt: brokerReceivedAt });
     this.channelMessageRecords.set(recordKey, { fingerprint, channelId: channel.channelId, fromMemberId: fromMember.memberId, toMemberId: targetMember.memberId, state: "queued", createdAt: brokerReceivedAt, message: deliveredMessage });
@@ -1420,12 +1514,8 @@ class IntercomBroker {
   private pruneMailboxMessages(now = Date.now()): void {
     for (let index = this.mailboxMessages.length - 1; index >= 0; index -= 1) {
       const entry = this.mailboxMessages[index]!;
-      if (now - entry.queuedAt > MAILBOX_MESSAGE_RETENTION_MS) {
-        if (entry.message.expectsReply) {
-          this.askEdges.delete(entry.message.id);
-          this.removePendingAskRecord(entry.message.id);
-        }
-        this.messageReceiptRoutes.delete(entry.message.id);
+      if (now - entry.queuedAt > mailboxMessageRetentionMs()) {
+        this.terminalizeMailboxEntry(entry, "expired");
         this.mailboxMessages.splice(index, 1);
       }
     }
@@ -1436,11 +1526,7 @@ class IntercomBroker {
     while (this.mailboxMessages.length >= MAX_MAILBOX_MESSAGES) {
       const evicted = this.mailboxMessages.shift();
       if (!evicted) break;
-      if (evicted.message.expectsReply) {
-        this.askEdges.delete(evicted.message.id);
-        this.removePendingAskRecord(evicted.message.id);
-      }
-      this.messageReceiptRoutes.delete(evicted.message.id);
+      this.terminalizeMailboxEntry(evicted, "expired");
     }
     this.mailboxMessages.push({
       from: { ...from },
@@ -1462,10 +1548,14 @@ class IntercomBroker {
         const channel = this.channels.get(entry.channel.channelId);
         const targetMember = channel ? channelMemberById(channel, entry.channel.toMemberId) : undefined;
         if (!channel || channel.state !== "active" || !targetMember || targetMember.sessionId !== session.info.id) {
+          if (channel && isChannelExpired(channel, now)) {
+            this.terminalizeMailboxEntry(entry, "expired");
+            this.mailboxMessages.splice(index, 1);
+            continue;
+          }
           index += 1;
           continue;
         }
-        this.mailboxMessages.splice(index, 1);
         const edge = this.askEdges.get(entry.message.id);
         if (edge?.to === entry.target.id) edge.to = session.info.id;
         const refreshedAddress = { ...entry.channel, targetBindingEpoch: targetMember.bindingEpoch };
@@ -1476,7 +1566,13 @@ class IntercomBroker {
           channelTargetName: targetMember.agentName,
           brokerDeliveredAt: Date.now(),
         };
-        writeMessage(session.socket, { type: "message", from: entry.from, message: deliveredMessage });
+        try {
+          writeMessage(session.socket, { type: "message", from: entry.from, message: deliveredMessage });
+        } catch {
+          index += 1;
+          continue;
+        }
+        this.mailboxMessages.splice(index, 1);
         const key = this.messageRecordKey(entry.channel, entry.message.id);
         const record = this.channelMessageRecords.get(key);
         if (record) {
@@ -1512,7 +1608,6 @@ class IntercomBroker {
         continue;
       }
 
-      this.mailboxMessages.splice(index, 1);
       const edge = this.askEdges.get(entry.message.id);
       if (edge?.to === entry.target.id) {
         edge.to = session.info.id;
@@ -1521,11 +1616,17 @@ class IntercomBroker {
         ...entry.message,
         brokerDeliveredAt: Date.now(),
       };
-      writeMessage(session.socket, {
-        type: "message",
-        from: entry.from,
-        message: deliveredMessage,
-      });
+      try {
+        writeMessage(session.socket, {
+          type: "message",
+          from: entry.from,
+          message: deliveredMessage,
+        });
+      } catch {
+        index += 1;
+        continue;
+      }
+      this.mailboxMessages.splice(index, 1);
       this.messageReceiptRoutes.set(entry.message.id, {
         from: entry.from.id,
         to: session.info.id,
@@ -2066,4 +2167,10 @@ class IntercomBroker {
   }
 }
 
-new IntercomBroker().start();
+const invokedAsBroker = process.argv.some((argument) => {
+  const normalized = argument.replaceAll("\\", "/");
+  return normalized === "broker.ts" || normalized.endsWith("/broker.ts");
+});
+if (invokedAsBroker) {
+  new IntercomBroker().start();
+}

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -1,9 +1,9 @@
 import net from "net";
-import { chmodSync, mkdirSync, readdirSync, readFileSync, writeFileSync, unlinkSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
-import { isMessage, isMessageReceipt, isSessionId, isSessionRegistration } from "./protocol.ts";
+import { isChannelAddress, isChannelInfo, isMessage, isMessageReceipt, isSessionId, isSessionRegistration } from "./protocol.ts";
 import {
   ensureIntercomRuntimeDir,
   getBrokerListenTarget,
@@ -18,8 +18,28 @@ import {
 } from "./paths.ts";
 import { getAskTimeoutMs } from "../config.ts";
 import { sameCwd } from "../cwd.ts";
-import { EXTENSION_BUS_FEATURE } from "../types.ts";
-import type { SessionInfo, Message, BrokerMessage, ExtensionCapability, MessageControl } from "../types.ts";
+import { CHANNEL_BUS_FEATURE, EXTENSION_BUS_FEATURE } from "../types.ts";
+import type {
+  ChannelAddress,
+  ChannelInfo,
+  ChannelLifecycle,
+  DeliveryState,
+  SessionInfo,
+  Message,
+  BrokerMessage,
+  ExtensionCapability,
+  MessageControl,
+} from "../types.ts";
+import {
+  channelAddress,
+  channelForPair,
+  channelMemberById,
+  channelMemberForSession,
+  cloneChannel,
+  createPairChannel,
+  isChannelExpired,
+  touchChannel,
+} from "./channel.ts";
 import { ExtensionStateManager } from "./extension-state.ts";
 import { assertNoLiveBroker } from "./runtime-claim.ts";
 
@@ -28,6 +48,7 @@ const LISTEN_TARGET = getBrokerListenTarget();
 const PID_PATH = join(INTERCOM_DIR, "broker.pid");
 const PORT_PATH = getBrokerPortFilePath(INTERCOM_DIR);
 const PENDING_ASKS_DIR = join(INTERCOM_DIR, "pending-asks");
+const CHANNELS_STATE_PATH = join(INTERCOM_DIR, "channels.json");
 const BROKER_STATE_ID = randomUUID();
 const MAX_SESSIONS = 128;
 const MAX_UNREGISTERED_CONNECTIONS = 32;
@@ -42,6 +63,8 @@ const MESSAGE_RECEIPT_ROUTE_RETENTION_MS = 60 * 60 * 1000;
 const DISCONNECTED_SESSION_RETENTION_MS = 24 * 60 * 60 * 1000;
 const MAILBOX_MESSAGE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const MAX_MAILBOX_MESSAGES = 256;
+const MAX_CHANNELS = 1024;
+const MAX_CHANNEL_MESSAGE_RECORDS = 4096;
 
 function serializedPayloadSize(payload: unknown): number | null {
   try {
@@ -104,6 +127,17 @@ interface MailboxMessage {
   target: SessionInfo;
   message: Message;
   queuedAt: number;
+  channel?: ChannelAddress;
+}
+
+interface ChannelMessageRecord {
+  fingerprint: string;
+  channelId: string;
+  fromMemberId: string;
+  toMemberId: string;
+  state: DeliveryState;
+  createdAt: number;
+  message: Message;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -143,6 +177,8 @@ class IntercomBroker {
   private messageReceiptRoutes = new Map<string, MessageReceiptRoute>();
   private disconnectedSessions = new Map<string, DisconnectedSession>();
   private mailboxMessages: MailboxMessage[] = [];
+  private channels = new Map<string, ChannelInfo>();
+  private channelMessageRecords = new Map<string, ChannelMessageRecord>();
   private connections = new Set<net.Socket>();
   private unregisteredConnections = new Set<net.Socket>();
   private server: net.Server;
@@ -157,6 +193,7 @@ class IntercomBroker {
     assertNoLiveBroker(PID_PATH);
     ensurePendingAskRecordDir();
     this.prunePendingAskRecords();
+    this.loadChannels();
     this.extensionStateManager = new ExtensionStateManager(INTERCOM_DIR);
     if (typeof LISTEN_TARGET === "string" && process.platform !== "win32") {
       try {
@@ -169,8 +206,20 @@ class IntercomBroker {
   }
 
   start(): void {
+    let socketHardeningAttempts = 0;
     const onListening = () => {
       if (typeof LISTEN_TARGET === "string") {
+        // Node can emit `listening` one tick before the Unix socket directory
+        // entry is visible on some macOS filesystems. Retry the permission
+        // hardening instead of crashing the broker during startup.
+        if (!existsSync(LISTEN_TARGET)) {
+          socketHardeningAttempts += 1;
+          if (socketHardeningAttempts > 100) {
+            throw new Error(`Intercom broker socket did not become visible at ${LISTEN_TARGET}`);
+          }
+          setTimeout(onListening, 5).unref?.();
+          return;
+        }
         restrictIntercomRuntimeFile(LISTEN_TARGET);
       } else {
         const address = this.server.address();
@@ -259,6 +308,7 @@ class IntercomBroker {
         const existing = this.sessions.get(sessionId);
         if (existing?.socket === socket) {
           this.rememberDisconnectedSession(existing.info);
+          this.markChannelsOffline(sessionId);
           this.sessions.delete(sessionId);
           this.clearMessageReceiptRoutesForSession(sessionId);
           this.broadcast({ type: "session_left", sessionId }, sessionId);
@@ -420,6 +470,7 @@ class IntercomBroker {
         };
         this.sessions.set(id, connectedSession);
         this.disconnectedSessions.delete(id);
+        this.rebindChannelsForSession(connectedSession);
         
         if (this.shutdownTimer) {
           clearTimeout(this.shutdownTimer);
@@ -432,7 +483,7 @@ class IntercomBroker {
         writeMessage(socket, {
           type: "registered",
           sessionId: id,
-          features: [EXTENSION_BUS_FEATURE],
+          features: [EXTENSION_BUS_FEATURE, CHANNEL_BUS_FEATURE],
         });
         this.broadcast({ type: "session_joined", session: info }, id);
 
@@ -468,6 +519,7 @@ class IntercomBroker {
         const existing = this.sessions.get(currentId);
         if (existing?.socket === socket) {
           this.rememberDisconnectedSession(existing.info);
+          this.markChannelsOffline(currentId);
           this.sessions.delete(currentId);
           this.clearMessageReceiptRoutesForSession(currentId);
           this.broadcast({ type: "session_left", sessionId: currentId }, currentId);
@@ -527,7 +579,27 @@ class IntercomBroker {
         break;
       }
 
+      case "channel_open": {
+        this.handleChannelOpen(socket, currentId, clientMessage);
+        break;
+      }
+
+      case "channel_close": {
+        this.handleChannelClose(socket, currentId, clientMessage);
+        break;
+      }
+
+      case "channel_send": {
+        this.handleChannelSend(socket, currentId, clientMessage);
+        break;
+      }
+
       case "send": {
+        // Legacy clients are upgraded only when they address an exact session
+        // ID. Name/prefix routing never crosses into the broker delivery seam.
+        if (this.handleLegacySend(socket, currentId, clientMessage)) {
+          break;
+        }
         if (!currentId) {
           throw new Error("Received send before register");
         }
@@ -913,6 +985,425 @@ class IntercomBroker {
     }
   }
 
+  private loadChannels(): void {
+    try {
+      if (!existsSync(CHANNELS_STATE_PATH)) {
+        return;
+      }
+      const parsed: unknown = JSON.parse(readFileSync(CHANNELS_STATE_PATH, "utf8"));
+      if (!isRecord(parsed) || !Array.isArray(parsed.channels)) return;
+      for (const value of parsed.channels) {
+        if (isChannelInfo(value)) {
+          this.channels.set(value.channelId, cloneChannel(value));
+        }
+      }
+      this.pruneChannels(Date.now(), false);
+    } catch (error) {
+      // A corrupt optional channel state must not prevent ordinary intercom
+      // startup. It is quarantined by ignoring it; the next channel open will
+      // create a fresh epoch rather than risk reusing ambiguous membership.
+      console.error(`Failed to load intercom channels: ${error instanceof Error ? error.message : String(error)}`);
+      this.channels.clear();
+    }
+  }
+
+  private persistChannels(): void {
+    try {
+      const payload = JSON.stringify({ version: 1, channels: [...this.channels.values()] }, null, 2);
+      const tempPath = `${CHANNELS_STATE_PATH}.${process.pid}.tmp`;
+      writeFileSync(tempPath, `${payload}\n`, { mode: INTERCOM_RUNTIME_FILE_MODE });
+      restrictIntercomRuntimeFile(tempPath);
+      renameSync(tempPath, CHANNELS_STATE_PATH);
+      restrictIntercomRuntimeFile(CHANNELS_STATE_PATH);
+    } catch (error) {
+      console.error(`Failed to persist intercom channels: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private pruneChannels(now = Date.now(), persist = true): void {
+    let changed = false;
+    for (const channel of this.channels.values()) {
+      if (channel.state === "active" && isChannelExpired(channel, now)) {
+        channel.state = "expired";
+        changed = true;
+      }
+    }
+    if (changed && persist) this.persistChannels();
+  }
+
+  private markChannelsOffline(sessionId: string, now = Date.now()): void {
+    let changed = false;
+    for (const channel of this.channels.values()) {
+      for (const member of channel.members) {
+        if (member.sessionId === sessionId && member.state === "online") {
+          member.state = "offline";
+          member.lastSeenAt = now;
+          changed = true;
+        }
+      }
+    }
+    if (changed) this.persistChannels();
+  }
+
+  private rebindChannelsForSession(session: ConnectedSession, now = Date.now()): void {
+    let changed = false;
+    for (const channel of this.channels.values()) {
+      if (channel.state !== "active") continue;
+      for (const member of channel.members) {
+        if (member.sessionId !== session.info.id || member.state === "left") continue;
+        // A reconnect is a new endpoint binding even when the stable session
+        // ID is retained. Callers must refresh the channel handshake before
+        // sending, so an old socket cannot silently receive new traffic.
+        member.bindingEpoch = randomUUID();
+        member.state = "online";
+        member.lastSeenAt = now;
+        changed = true;
+      }
+    }
+    if (changed) this.persistChannels();
+  }
+
+  private channelError(
+    socket: net.Socket,
+    messageId: string,
+    reason: string,
+    code: string,
+    options: { retryable?: boolean; outcomeKnown?: boolean; channelId?: string } = {},
+  ): void {
+    writeMessage(socket, {
+      type: "delivery_failed",
+      messageId,
+      reason,
+      code,
+      retryable: options.retryable ?? false,
+      outcomeKnown: options.outcomeKnown ?? true,
+      ...(options.channelId ? { channelId: options.channelId } : {}),
+    });
+  }
+
+  private channelOpenError(
+    socket: net.Socket,
+    requestId: string,
+    reason: string,
+    code: string,
+    retryable = false,
+  ): void {
+    writeMessage(socket, { type: "channel_open_failed", requestId, reason, code, retryable });
+  }
+
+  private sessionInfoForChannel(sessionId: string): SessionInfo | null {
+    return this.sessions.get(sessionId)?.info
+      ?? this.disconnectedSessions.get(sessionId)?.info
+      ?? null;
+  }
+
+  private getOrCreatePairChannel(
+    senderId: string,
+    targetId: string,
+    lifecycle: ChannelLifecycle = "ephemeral",
+    now = Date.now(),
+  ): ChannelInfo {
+    this.pruneChannels(now);
+    const existing = channelForPair(this.channels.values(), senderId, targetId);
+    if (existing) {
+      touchChannel(existing, now);
+      for (const member of existing.members) {
+        if (member.sessionId === senderId && this.sessions.has(senderId)) member.state = "online";
+        if (member.sessionId === targetId && this.sessions.has(targetId)) member.state = "online";
+      }
+      this.persistChannels();
+      return existing;
+    }
+    if (this.channels.size >= MAX_CHANNELS) {
+      throw Object.assign(new Error("E_CHANNEL_LIMIT: too many active channels"), { code: "E_CHANNEL_LIMIT" });
+    }
+    const sender = this.sessionInfoForChannel(senderId);
+    const target = this.sessionInfoForChannel(targetId);
+    if (!sender || !target) {
+      throw Object.assign(new Error("E_TARGET_NOT_FOUND: Session not found; target session is not connected or known"), { code: "E_TARGET_NOT_FOUND" });
+    }
+    let channel: ChannelInfo;
+    try {
+      channel = createPairChannel(sender, target, lifecycle, now);
+    } catch (error) {
+      throw Object.assign(new Error(error instanceof Error ? error.message : String(error)), { code: "E_NAME_CONFLICT" });
+    }
+    if (!this.sessions.has(targetId)) {
+      const targetMember = channelMemberForSession(channel, targetId);
+      if (targetMember) targetMember.state = "offline";
+    }
+    this.channels.set(channel.channelId, channel);
+    this.persistChannels();
+    return channel;
+  }
+
+  private handleChannelOpen(socket: net.Socket, currentId: string | null, msg: Record<string, unknown>): void {
+    if (!currentId) throw new Error("Received channel_open before register");
+    const requestId = msg.requestId;
+    const targetSessionId = msg.targetSessionId;
+    const lifecycle = msg.lifecycle === undefined ? "ephemeral" : msg.lifecycle;
+    if (typeof requestId !== "string" || requestId.length === 0 || typeof targetSessionId !== "string" || targetSessionId.length === 0) {
+      throw new Error("Invalid channel_open message");
+    }
+    if (targetSessionId === currentId) {
+      this.channelOpenError(socket, requestId, "E_TARGET_SELF: a channel needs two different sessions", "E_TARGET_SELF");
+      return;
+    }
+    if (lifecycle !== "ephemeral" && lifecycle !== "reusable") {
+      this.channelOpenError(socket, requestId, "E_CHANNEL_LIFECYCLE: lifecycle must be ephemeral or reusable", "E_CHANNEL_LIFECYCLE");
+      return;
+    }
+    try {
+      const channel = this.getOrCreatePairChannel(currentId, targetSessionId, lifecycle as ChannelLifecycle);
+      const self = channelMemberForSession(channel, currentId);
+      const target = channel.members.find((member) => member.sessionId === targetSessionId && member.state !== "left");
+      if (!self || !target) {
+        this.channelOpenError(socket, requestId, "E_MEMBER_NOT_FOUND: channel membership is incomplete", "E_MEMBER_NOT_FOUND");
+        return;
+      }
+      writeMessage(socket, {
+        type: "channel_opened",
+        requestId,
+        channel: cloneChannel(channel),
+        selfMemberId: self.memberId,
+        targetMemberId: target.memberId,
+      });
+    } catch (error) {
+      const code = (error as { code?: unknown }).code;
+      this.channelOpenError(socket, requestId, error instanceof Error ? error.message : String(error), typeof code === "string" ? code : "E_CHANNEL_OPEN", code === "E_TARGET_NOT_FOUND");
+    }
+  }
+
+  private handleChannelClose(socket: net.Socket, currentId: string | null, msg: Record<string, unknown>): void {
+    if (!currentId) throw new Error("Received channel_close before register");
+    const requestId = msg.requestId;
+    const channelId = msg.channelId;
+    const channelEpoch = msg.channelEpoch;
+    if (typeof requestId !== "string" || typeof channelId !== "string" || typeof channelEpoch !== "string") {
+      throw new Error("Invalid channel_close message");
+    }
+    const channel = this.channels.get(channelId);
+    const member = channel ? channelMemberForSession(channel, currentId) : undefined;
+    if (!channel || channel.epoch !== channelEpoch || !member) {
+      this.channelOpenError(socket, requestId, "E_CHANNEL_NOT_FOUND: channel close authorization failed", "E_CHANNEL_NOT_FOUND");
+      return;
+    }
+    channel.state = "closed";
+    this.persistChannels();
+    writeMessage(socket, { type: "channel_closed", requestId, channelId });
+  }
+
+  private messageRecordKey(address: ChannelAddress, messageId: string): string {
+    return `${address.channelId}\0${address.fromMemberId}\0${messageId}`;
+  }
+
+  private messageFingerprint(message: Message): string {
+    const {
+      timestamp: _timestamp,
+      senderSequence: _senderSequence,
+      brokerReceivedAt: _brokerReceivedAt,
+      brokerDeliveredAt: _brokerDeliveredAt,
+      receiverReceivedAt: _receiverReceivedAt,
+      injectedAt: _injectedAt,
+      channel: rawChannel,
+      ...authoredMessage
+    } = message;
+    const channel = rawChannel
+      ? { ...rawChannel, targetBindingEpoch: "<binding>" }
+      : undefined;
+    return createHash("sha256").update(JSON.stringify({ ...authoredMessage, channel })).digest("hex");
+  }
+
+  private pruneChannelMessageRecords(now = Date.now()): void {
+    for (const [key, record] of this.channelMessageRecords) {
+      const channel = this.channels.get(record.channelId);
+      if (!channel || (channel.expiresAt !== undefined && channel.expiresAt < now - MAILBOX_MESSAGE_RETENTION_MS)) {
+        this.channelMessageRecords.delete(key);
+      }
+    }
+    while (this.channelMessageRecords.size > MAX_CHANNEL_MESSAGE_RECORDS) {
+      const oldest = this.channelMessageRecords.keys().next().value;
+      if (typeof oldest !== "string") break;
+      this.channelMessageRecords.delete(oldest);
+    }
+  }
+
+  private sendChannelSuccess(socket: net.Socket, messageId: string, state: DeliveryState, channelId: string): void {
+    writeMessage(socket, { type: "delivered", messageId, state, channelId });
+  }
+
+  private handleChannelSend(socket: net.Socket, currentId: string | null, msg: Record<string, unknown>): void {
+    if (!currentId) throw new Error("Received channel_send before register");
+    const address = msg.channel;
+    const message = msg.message;
+    const messageId = isMessage(message) ? message.id : "unknown";
+    if (!isChannelAddress(address) || !isMessage(message) || !message.channel || JSON.stringify(address) !== JSON.stringify(message.channel)) {
+      this.channelError(socket, messageId, "E_CHANNEL_MESSAGE_FORMAT: channel address and message metadata must match", "E_CHANNEL_MESSAGE_FORMAT");
+      return;
+    }
+    this.routeChannelMessage(socket, currentId, address, message);
+  }
+
+  private handleLegacySend(socket: net.Socket, currentId: string | null, msg: Record<string, unknown>): boolean {
+    const message = msg.message;
+    const messageId = isMessage(message) ? message.id : "unknown";
+    if (!currentId || typeof msg.to !== "string" || !isMessage(message)) return false;
+    const targetId = msg.to;
+    // Legacy wire clients cannot safely express a channel-local name. Exact
+    // IDs are upgraded; fuzzy names/prefixes fail closed with a useful code.
+    const target = this.sessions.get(targetId) ?? this.disconnectedSessions.get(targetId);
+    if (!target || target.info.id !== targetId) {
+      this.channelError(socket, messageId, "E_CHANNEL_REQUIRED: resolve an exact session ID and establish channel-v1 before sending", "E_CHANNEL_REQUIRED");
+      return true;
+    }
+    try {
+      const channel = this.getOrCreatePairChannel(currentId, targetId);
+      const fromMember = channelMemberForSession(channel, currentId);
+      const toMember = channelMemberForSession(channel, targetId);
+      if (!fromMember || !toMember) throw new Error("E_MEMBER_NOT_FOUND: channel membership is incomplete");
+      const address = channelAddress(channel, fromMember, toMember);
+      this.routeChannelMessage(socket, currentId, address, { ...message, channel: address });
+    } catch (error) {
+      const code = (error as { code?: unknown }).code;
+      this.channelError(socket, messageId, error instanceof Error ? error.message : String(error), typeof code === "string" ? code : "E_CHANNEL_REQUIRED");
+    }
+    return true;
+  }
+
+  private routeChannelMessage(socket: net.Socket, currentId: string, address: ChannelAddress, message: Message): void {
+    this.pruneChannels();
+    this.pruneChannelMessageRecords();
+    const channel = this.channels.get(address.channelId);
+    const messageId = message.id;
+    if (!channel) {
+      this.channelError(socket, messageId, "E_CHANNEL_NOT_FOUND: channel does not exist", "E_CHANNEL_NOT_FOUND");
+      return;
+    }
+    if (channel.state !== "active") {
+      this.channelError(socket, messageId, `E_CHANNEL_${channel.state.toUpperCase()}: channel is not active`, `E_CHANNEL_${channel.state.toUpperCase()}`);
+      return;
+    }
+    if (channel.epoch !== address.channelEpoch) {
+      this.channelError(socket, messageId, "E_CHANNEL_STALE_EPOCH: channel epoch is stale", "E_CHANNEL_STALE_EPOCH");
+      return;
+    }
+    const fromMember = channelMemberById(channel, address.fromMemberId);
+    const targetMember = channelMemberById(channel, address.toMemberId);
+    const sender = this.sessions.get(currentId);
+    if (!sender || sender.socket !== socket || !fromMember || fromMember.sessionId !== currentId || fromMember.state !== "online") {
+      this.channelError(socket, messageId, "E_SENDER_NOT_MEMBER: sender is not the bound channel member", "E_SENDER_NOT_MEMBER");
+      return;
+    }
+    if (!targetMember || targetMember.state === "left" || targetMember.memberId === fromMember.memberId) {
+      this.channelError(socket, messageId, "E_TARGET_NOT_MEMBER: target is not a channel member", "E_TARGET_NOT_MEMBER", { channelId: channel.channelId });
+      return;
+    }
+    const recordKey = this.messageRecordKey(address, messageId);
+    const fingerprint = this.messageFingerprint(message);
+    const existing = this.channelMessageRecords.get(recordKey);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint || existing.toMemberId !== targetMember.memberId) {
+        this.channelError(socket, messageId, "E_MESSAGE_ID_REUSE: message ID was already used for different content or recipient", "E_MESSAGE_ID_REUSE", { channelId: channel.channelId });
+      } else if (existing.state === "queued" || existing.state === "socket_delivered") {
+        this.sendChannelSuccess(socket, messageId, existing.state, channel.channelId);
+      } else {
+        this.channelError(socket, messageId, "E_DELIVERY_FAILED: previous delivery failed", "E_DELIVERY_FAILED", { channelId: channel.channelId });
+      }
+      return;
+    }
+    if (address.targetBindingEpoch !== targetMember.bindingEpoch) {
+      this.channelError(socket, messageId, "E_TARGET_REBOUND: target endpoint binding changed; reopen the channel and retry deliberately", "E_TARGET_REBOUND", { retryable: true, channelId: channel.channelId });
+      return;
+    }
+
+    const brokerReceivedAt = Date.now();
+    this.pruneAskEdges(brokerReceivedAt);
+    this.pruneMessageReceiptRoutes(brokerReceivedAt);
+    const replyEdge = message.replyTo ? this.askEdges.get(message.replyTo) : undefined;
+    const target = this.sessions.get(targetMember.sessionId);
+    if (message.replyTo && (!replyEdge || replyEdge.to !== currentId || replyEdge.from !== targetMember.sessionId)) {
+      this.channelError(socket, messageId, "E_REPLY_CHANNEL_MISMATCH: reply does not match a pending ask in this channel", "E_REPLY_CHANNEL_MISMATCH", { channelId: channel.channelId });
+      return;
+    }
+    if (message.supersedes) {
+      const supersededRoute = this.messageReceiptRoutes.get(message.supersedes);
+      if (!supersededRoute || supersededRoute.from !== currentId || supersededRoute.to !== targetMember.sessionId) {
+        this.channelError(socket, messageId, "E_SUPERSEDE_TARGET: supersede target does not match a previous message from the same sender and receiver", "E_SUPERSEDE_TARGET", { channelId: channel.channelId });
+        return;
+      }
+    }
+    if (message.expectsReply) {
+      const reverseEdge = Array.from(this.askEdges.entries()).find(([edgeMessageId, edge]) => edgeMessageId !== message.replyTo && edge.from === targetMember.sessionId && edge.to === currentId);
+      if (reverseEdge) {
+        this.channelError(socket, messageId, "Mutual ask refused: target session is already waiting for a reply from this session.", "E_MUTUAL_ASK", { channelId: channel.channelId });
+        return;
+      }
+      if (!target) {
+        this.channelError(socket, messageId, "E_TARGET_OFFLINE: target session is not currently connected; blocking asks are not queued", "E_TARGET_OFFLINE", { retryable: true, channelId: channel.channelId });
+        return;
+      }
+      this.writePendingAskRecord(message, sender.info, target.info, brokerReceivedAt);
+      this.askEdges.set(message.id, { from: currentId, to: targetMember.sessionId, createdAt: brokerReceivedAt });
+    }
+
+    const deliveredMessage: Message = {
+      ...message,
+      channel: { ...address, targetBindingEpoch: targetMember.bindingEpoch },
+      channelSenderName: fromMember.agentName,
+      channelTargetName: targetMember.agentName,
+      brokerReceivedAt,
+      ...(target ? { brokerDeliveredAt: Date.now() } : {}),
+    };
+    if (target) {
+      try {
+        if (message.supersedes) {
+          writeMessage(target.socket, {
+            type: "message_control",
+            from: sender.info,
+            control: { action: "supersede", messageId: message.supersedes, supersededBy: message.id, timestamp: Date.now() },
+          });
+        }
+        writeMessage(target.socket, { type: "message", from: sender.info, message: deliveredMessage });
+      } catch (error) {
+        if (message.expectsReply) {
+          this.askEdges.delete(message.id);
+          this.removePendingAskRecord(message.id);
+        }
+        this.channelError(socket, messageId, `E_DELIVERY_UNKNOWN: broker could not confirm socket write (${error instanceof Error ? error.message : String(error)})`, "E_DELIVERY_UNKNOWN", { retryable: false, outcomeKnown: false, channelId: channel.channelId });
+        return;
+      }
+      if (message.replyTo) {
+        this.askEdges.delete(message.replyTo);
+        this.removePendingAskRecord(message.replyTo);
+      }
+      this.messageReceiptRoutes.set(message.id, { from: currentId, to: targetMember.sessionId, createdAt: brokerReceivedAt });
+      this.channelMessageRecords.set(recordKey, { fingerprint, channelId: channel.channelId, fromMemberId: fromMember.memberId, toMemberId: targetMember.memberId, state: "socket_delivered", createdAt: brokerReceivedAt, message: deliveredMessage });
+      touchChannel(channel, brokerReceivedAt);
+      this.persistChannels();
+      this.sendChannelSuccess(socket, messageId, "socket_delivered", channel.channelId);
+      return;
+    }
+
+    if (this.mailboxMessages.length >= MAX_MAILBOX_MESSAGES) {
+      if (message.expectsReply) {
+        this.askEdges.delete(message.id);
+        this.removePendingAskRecord(message.id);
+      }
+      this.channelError(socket, messageId, "E_QUEUE_FULL: channel mailbox is full", "E_QUEUE_FULL", { retryable: true, channelId: channel.channelId });
+      return;
+    }
+    this.queueMailboxMessage(sender.info, targetMember.sessionId ? (this.disconnectedSessions.get(targetMember.sessionId)?.info ?? { ...sender.info, id: targetMember.sessionId }) : sender.info, deliveredMessage, brokerReceivedAt, address);
+    this.messageReceiptRoutes.set(message.id, { from: currentId, to: targetMember.sessionId, createdAt: brokerReceivedAt });
+    this.channelMessageRecords.set(recordKey, { fingerprint, channelId: channel.channelId, fromMemberId: fromMember.memberId, toMemberId: targetMember.memberId, state: "queued", createdAt: brokerReceivedAt, message: deliveredMessage });
+    if (message.replyTo) {
+      this.askEdges.delete(message.replyTo);
+      this.removePendingAskRecord(message.replyTo);
+    }
+    touchChannel(channel, brokerReceivedAt);
+    this.persistChannels();
+    this.sendChannelSuccess(socket, messageId, "queued", channel.channelId);
+  }
+
   private rememberDisconnectedSession(info: SessionInfo, now = Date.now()): void {
     this.disconnectedSessions.set(info.id, { info: { ...info }, disconnectedAt: now });
     this.pruneDisconnectedSessions(now);
@@ -940,7 +1431,7 @@ class IntercomBroker {
     }
   }
 
-  private queueMailboxMessage(from: SessionInfo, target: SessionInfo, message: Message, brokerReceivedAt: number): void {
+  private queueMailboxMessage(from: SessionInfo, target: SessionInfo, message: Message, brokerReceivedAt: number, channel?: ChannelAddress): void {
     this.pruneMailboxMessages(brokerReceivedAt);
     while (this.mailboxMessages.length >= MAX_MAILBOX_MESSAGES) {
       const evicted = this.mailboxMessages.shift();
@@ -956,6 +1447,7 @@ class IntercomBroker {
       target: { ...target },
       message: { ...message, brokerReceivedAt },
       queuedAt: brokerReceivedAt,
+      ...(channel ? { channel: { ...channel } } : {}),
     });
   }
 
@@ -966,6 +1458,42 @@ class IntercomBroker {
 
     for (let index = 0; index < this.mailboxMessages.length;) {
       const entry = this.mailboxMessages[index]!;
+      if (entry.channel) {
+        const channel = this.channels.get(entry.channel.channelId);
+        const targetMember = channel ? channelMemberById(channel, entry.channel.toMemberId) : undefined;
+        if (!channel || channel.state !== "active" || !targetMember || targetMember.sessionId !== session.info.id) {
+          index += 1;
+          continue;
+        }
+        this.mailboxMessages.splice(index, 1);
+        const edge = this.askEdges.get(entry.message.id);
+        if (edge?.to === entry.target.id) edge.to = session.info.id;
+        const refreshedAddress = { ...entry.channel, targetBindingEpoch: targetMember.bindingEpoch };
+        const deliveredMessage: Message = {
+          ...entry.message,
+          channel: refreshedAddress,
+          channelSenderName: entry.message.channelSenderName ?? channelMemberById(channel, entry.channel.fromMemberId)?.agentName,
+          channelTargetName: targetMember.agentName,
+          brokerDeliveredAt: Date.now(),
+        };
+        writeMessage(session.socket, { type: "message", from: entry.from, message: deliveredMessage });
+        const key = this.messageRecordKey(entry.channel, entry.message.id);
+        const record = this.channelMessageRecords.get(key);
+        if (record) {
+          record.state = "socket_delivered";
+          record.message = deliveredMessage;
+        }
+        targetMember.state = "online";
+        targetMember.lastSeenAt = now;
+        touchChannel(channel, now);
+        this.messageReceiptRoutes.set(entry.message.id, {
+          from: entry.from.id,
+          to: session.info.id,
+          createdAt: entry.message.brokerReceivedAt ?? entry.queuedAt,
+        });
+        this.persistChannels();
+        continue;
+      }
       const matchesId = entry.target.id === session.info.id;
       const matchesSenderIdentity = Boolean(
         sessionName

--- a/broker/channel.test.ts
+++ b/broker/channel.test.ts
@@ -6,14 +6,14 @@ import path from "node:path";
 import { once } from "node:events";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { IntercomClient } from "./client.ts";
-import type { Message, SessionInfo } from "../types.ts";
+import type { ChannelAddress, Message, SessionInfo, SessionRegistration } from "../types.ts";
 
 const repoDir = process.cwd();
 
-async function startBroker(agentDir: string): Promise<ChildProcessWithoutNullStreams> {
+async function startBroker(agentDir: string, extraEnv: NodeJS.ProcessEnv = {}): Promise<ChildProcessWithoutNullStreams> {
   const broker = spawn(process.execPath, [path.join(repoDir, "node_modules/tsx/dist/cli.mjs"), path.join(repoDir, "broker/broker.ts")], {
     cwd: repoDir,
-    env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
+    env: { ...process.env, ...extraEnv, PI_CODING_AGENT_DIR: agentDir },
     stdio: ["ignore", "pipe", "pipe"],
   });
   let stderr = "";
@@ -53,9 +53,91 @@ async function closeBroker(broker: ChildProcessWithoutNullStreams | null): Promi
   await once(broker, "exit").catch(() => undefined);
 }
 
-function registration(name: string, cwd: string) {
+function registration(name: string, cwd: string): SessionRegistration {
   return { name, cwd, model: "test", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() };
 }
+
+test("stable-session takeover rejects stale channel control and send frames", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icstale-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const { IntercomBroker } = await import("./broker.ts");
+    const broker = new IntercomBroker();
+    const frames = new WeakMap<object, any[]>();
+    const fakeSocket = () => {
+      const output: any[] = [];
+      const socket = {
+        write(frame: Buffer) {
+          output.push(JSON.parse(frame.subarray(4).toString("utf8")));
+          return true;
+        },
+        end() { return this; },
+      } as any;
+      frames.set(socket, output);
+      return socket;
+    };
+    const invoke = (socket: any, message: unknown, currentId: string | null, setId: (id: string | null) => void) => {
+      (broker as any).handleMessage(socket, message, currentId, setId);
+    };
+    const oldSocket = fakeSocket();
+    const initialTargetSocket = fakeSocket();
+    let oldId: string | null = null;
+    let targetId: string | null = null;
+    invoke(oldSocket, { type: "register", session: registration("sender", agentDir), sessionId: "stale-sender" }, null, (id) => { oldId = id; });
+    invoke(initialTargetSocket, { type: "register", session: registration("receiver", agentDir), sessionId: "stale-receiver" }, null, (id) => { targetId = id; });
+    assert.equal(oldId, "stale-sender");
+    assert.equal(targetId, "stale-receiver");
+
+    invoke(oldSocket, { type: "channel_open", requestId: "initial-open", targetSessionId: "stale-receiver" }, oldId, () => undefined);
+    const initial = frames.get(oldSocket)!.find((frame) => frame.type === "channel_opened" && frame.requestId === "initial-open");
+    assert.ok(initial);
+    const channel = initial.channel as { channelId: string; epoch: string; members: Array<{ memberId: string; sessionId: string; bindingEpoch: string }> };
+    const self = channel.members.find((member) => member.sessionId === "stale-sender")!;
+    const target = channel.members.find((member) => member.sessionId === "stale-receiver")!;
+
+    const staleAddress: ChannelAddress = {
+      channelId: channel.channelId,
+      channelEpoch: channel.epoch,
+      fromMemberId: self.memberId,
+      toMemberId: target.memberId,
+      targetBindingEpoch: target.bindingEpoch,
+    };
+    const replacementTargetSocket = fakeSocket();
+    let replacementTargetId: string | null = null;
+    invoke(replacementTargetSocket, { type: "register", session: registration("receiver-new", agentDir), sessionId: "stale-receiver" }, null, (id) => { replacementTargetId = id; });
+    assert.equal(replacementTargetId, "stale-receiver");
+    invoke(oldSocket, { type: "channel_send", channel: staleAddress, message: { id: "stale-target-message", timestamp: Date.now(), channel: staleAddress, content: { text: "target rebound" } } }, oldId, () => undefined);
+    assert.equal(frames.get(oldSocket)!.at(-1)?.code, "E_TARGET_REBOUND");
+
+    const newSocket = fakeSocket();
+    let replacementId: string | null = null;
+    invoke(newSocket, { type: "register", session: registration("sender-new", agentDir), sessionId: "stale-sender" }, null, (id) => { replacementId = id; });
+    assert.equal(replacementId, "stale-sender");
+
+    invoke(oldSocket, { type: "channel_open", requestId: "stale-open", targetSessionId: "stale-receiver" }, oldId, () => undefined);
+    assert.equal(frames.get(oldSocket)!.at(-1)?.code, "E_SESSION_REPLACED");
+    invoke(oldSocket, { type: "channel_close", requestId: "stale-close", channelId: channel.channelId, channelEpoch: channel.epoch }, oldId, () => undefined);
+    assert.equal(frames.get(oldSocket)!.at(-1)?.code, "E_SESSION_REPLACED");
+
+    invoke(oldSocket, { type: "channel_send", channel: staleAddress, message: { id: "stale-message", timestamp: Date.now(), channel: staleAddress, content: { text: "must reject" } } }, oldId, () => undefined);
+    assert.equal(frames.get(oldSocket)!.at(-1)?.code, "E_SENDER_NOT_MEMBER");
+
+    invoke(newSocket, { type: "channel_open", requestId: "replacement-open", targetSessionId: "stale-receiver" }, replacementId, () => undefined);
+    const rebound = frames.get(newSocket)!.find((frame) => frame.type === "channel_opened" && frame.requestId === "replacement-open");
+    assert.ok(rebound);
+    const reboundChannel = rebound.channel as { channelId: string; epoch: string; members: Array<{ memberId: string; sessionId: string; bindingEpoch: string }> };
+    const reboundSelf = reboundChannel.members.find((member) => member.sessionId === "stale-sender")!;
+    const reboundTarget = reboundChannel.members.find((member) => member.sessionId === "stale-receiver")!;
+    const reboundAddress: ChannelAddress = { channelId: reboundChannel.channelId, channelEpoch: reboundChannel.epoch, fromMemberId: reboundSelf.memberId, toMemberId: reboundTarget.memberId, targetBindingEpoch: reboundTarget.bindingEpoch };
+    invoke(newSocket, { type: "channel_send", channel: reboundAddress, message: { id: "fresh-message", timestamp: Date.now(), channel: reboundAddress, content: { text: "fresh" } } }, replacementId, () => undefined);
+    assert.ok(frames.get(replacementTargetSocket)!.some((frame) => frame.type === "message" && frame.message.id === "fresh-message"));
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
 
 test("channel-v1 establishes exact endpoint bindings and assigns executor identities", { timeout: 30_000 }, async () => {
   const agentDir = mkdtempSync(path.join(tmpdir(), "icv1-"));
@@ -207,6 +289,122 @@ test("static project channel policy rejects same-name endpoint swaps and outside
     await sender.disconnect().catch(() => undefined);
     await receiver.disconnect().catch(() => undefined);
     await outsider.disconnect().catch(() => undefined);
+    await closeBroker(broker);
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("expired ephemeral queued mail is not flushed after TTL without channel traffic", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icttl-"));
+  const broker = await startBroker(agentDir, { PI_INTERCOM_EPHEMERAL_CHANNEL_TTL_MS: "50" });
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const sender = new IntercomClient();
+  const receiver = new IntercomClient();
+  const received: Message[] = [];
+  try {
+    await sender.connect(registration("sender", agentDir), "ttl-sender");
+    await receiver.connect(registration("receiver", agentDir), "ttl-receiver");
+    await sender.openChannel("ttl-receiver");
+    receiver.on("message", (_from, message) => received.push(message));
+    await receiver.disconnect();
+    const queued = await sender.send("ttl-receiver", { messageId: "ttl-message", text: "must expire" });
+    assert.equal(queued.state, "queued");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const replacement = new IntercomClient();
+    await replacement.connect(registration("receiver", agentDir), "ttl-receiver");
+    replacement.on("message", (_from, message) => received.push(message));
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.deepEqual(received, []);
+    await replacement.disconnect();
+  } finally {
+    await sender.disconnect().catch(() => undefined);
+    await receiver.disconnect().catch(() => undefined);
+    await closeBroker(broker);
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("queued cancellation and offline supersede terminalize old message records", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icterminal-"));
+  const broker = await startBroker(agentDir);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const sender = new IntercomClient();
+  const receiver = new IntercomClient();
+  const received: string[] = [];
+  try {
+    await sender.connect(registration("sender", agentDir), "terminal-sender");
+    await receiver.connect(registration("receiver", agentDir), "terminal-receiver");
+    await sender.openChannel("terminal-receiver");
+    receiver.on("message", (_from, message) => received.push(message.content.text));
+    await receiver.disconnect();
+
+    const cancelled = await sender.send("terminal-receiver", { messageId: "cancelled-message", text: "cancel me" });
+    assert.equal(cancelled.state, "queued");
+    assert.equal((await sender.cancelMessage("cancelled-message")).delivered, true);
+    const cancelledRetry = await sender.send("terminal-receiver", { messageId: "cancelled-message", text: "cancel me" });
+    assert.equal(cancelledRetry.delivered, false);
+    assert.equal(cancelledRetry.code, "E_MESSAGE_CANCELLED");
+
+    const first = await sender.send("terminal-receiver", { messageId: "superseded-old", text: "old" });
+    assert.equal(first.state, "queued");
+    const replacement = await sender.send("terminal-receiver", {
+      messageId: "superseded-new",
+      text: "new",
+      supersedes: "superseded-old",
+    });
+    assert.equal(replacement.state, "queued");
+
+    const reconnect = new IntercomClient();
+    const delivered = waitForMessage(reconnect, (_from, message) => message.id === "superseded-new");
+    await reconnect.connect(registration("receiver", agentDir), "terminal-receiver");
+    const [, deliveredMessage] = await delivered;
+    assert.equal(deliveredMessage.content.text, "new");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.deepEqual(received, []);
+    // The old queued payload must not be delivered, and its same-ID retry must
+    // not be reported as if it were still in the mailbox.
+    const oldRetry = await sender.send("terminal-receiver", { messageId: "superseded-old", text: "old" });
+    assert.equal(oldRetry.delivered, false);
+    assert.equal(oldRetry.code, "E_MESSAGE_SUPERSEDED");
+    await reconnect.disconnect();
+  } finally {
+    await sender.disconnect().catch(() => undefined);
+    await receiver.disconnect().catch(() => undefined);
+    await closeBroker(broker);
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("mailbox retention terminalizes a queued message record", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icmailttl-"));
+  const broker = await startBroker(agentDir, { PI_INTERCOM_MAILBOX_MESSAGE_RETENTION_MS: "50" });
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const sender = new IntercomClient();
+  const receiver = new IntercomClient();
+  try {
+    await sender.connect(registration("sender", agentDir), "mailttl-sender");
+    await receiver.connect(registration("receiver", agentDir), "mailttl-receiver");
+    await sender.openChannel("mailttl-receiver");
+    await receiver.disconnect();
+    const queued = await sender.send("mailttl-receiver", { messageId: "expired-mail", text: "expire" });
+    assert.equal(queued.state, "queued");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const retry = await sender.send("mailttl-receiver", { messageId: "expired-mail", text: "expire" });
+    assert.equal(retry.delivered, false);
+    assert.equal(retry.code, "E_MESSAGE_EXPIRED");
+  } finally {
+    await sender.disconnect().catch(() => undefined);
+    await receiver.disconnect().catch(() => undefined);
     await closeBroker(broker);
     rmSync(agentDir, { recursive: true, force: true });
     if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;

--- a/broker/channel.test.ts
+++ b/broker/channel.test.ts
@@ -1,0 +1,248 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { IntercomClient } from "./client.ts";
+import type { Message, SessionInfo } from "../types.ts";
+
+const repoDir = process.cwd();
+
+async function startBroker(agentDir: string): Promise<ChildProcessWithoutNullStreams> {
+  const broker = spawn(process.execPath, [path.join(repoDir, "node_modules/tsx/dist/cli.mjs"), path.join(repoDir, "broker/broker.ts")], {
+    cwd: repoDir,
+    env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  broker.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`broker startup timeout${stderr ? `: ${stderr}` : ""}`)), 10_000);
+    broker.stdout.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("Intercom broker started")) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    broker.once("exit", (code, signal) => reject(new Error(`broker exited (${code ?? signal})${stderr ? `: ${stderr}` : ""}`)));
+  });
+  return broker;
+}
+
+async function waitForMessage(client: IntercomClient, predicate: (from: SessionInfo, message: Message) => boolean): Promise<[SessionInfo, Message]> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      client.off("message", onMessage);
+      reject(new Error("message timeout"));
+    }, 5_000);
+    const onMessage = (from: SessionInfo, message: Message) => {
+      if (!predicate(from, message)) return;
+      clearTimeout(timeout);
+      client.off("message", onMessage);
+      resolve([from, message]);
+    };
+    client.on("message", onMessage);
+  });
+}
+
+async function closeBroker(broker: ChildProcessWithoutNullStreams | null): Promise<void> {
+  if (!broker) return;
+  broker.kill("SIGTERM");
+  await once(broker, "exit").catch(() => undefined);
+}
+
+function registration(name: string, cwd: string) {
+  return { name, cwd, model: "test", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() };
+}
+
+test("channel-v1 establishes exact endpoint bindings and assigns executor identities", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icv1-"));
+  const broker = await startBroker(agentDir);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const sender = new IntercomClient();
+  const receiver = new IntercomClient();
+  try {
+    await sender.connect(registration("planner", agentDir), "planner-id");
+    await receiver.connect({ ...registration("runtime-alias", agentDir), runtimeFallbackAlias: true }, "receiver-id");
+    const binding = await sender.openChannel("receiver-id");
+    const self = binding.channel.members.find((member) => member.memberId === binding.selfMemberId)!;
+    const target = binding.channel.members.find((member) => member.memberId === binding.targetMemberId)!;
+    assert.equal(self.agentName, "planner");
+    assert.equal(target.agentName, "执行者-2");
+    assert.equal(target.sessionId, "receiver-id");
+    assert.equal(binding.channel.lifecycle, "ephemeral");
+
+    const received = waitForMessage(receiver, (_from, message) => message.content.text === "hello");
+    const result = await sender.send("receiver-id", { messageId: "channel-message-1", text: "hello" });
+    assert.equal(result.delivered, true);
+    assert.equal(result.state, "socket_delivered");
+    const [, message] = await received;
+    assert.equal(message.channel?.channelId, binding.channel.channelId);
+    assert.equal(message.channel?.fromMemberId, binding.selfMemberId);
+    assert.equal(message.channel?.toMemberId, binding.targetMemberId);
+
+    // A second send performs a broker handshake but reuses the same logical channel.
+    const reused = await sender.openChannel("receiver-id");
+    assert.equal(reused.channel.channelId, binding.channel.channelId);
+    assert.equal(reused.selfMemberId, binding.selfMemberId);
+    assert.equal(reused.targetMemberId, binding.targetMemberId);
+
+    await sender.closeChannel(reused);
+    const reopened = await sender.openChannel("receiver-id");
+    assert.notEqual(reopened.channel.channelId, binding.channel.channelId);
+  } finally {
+    await sender.disconnect().catch(() => undefined);
+    await receiver.disconnect().catch(() => undefined);
+    await closeBroker(broker);
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("channel-v1 makes duplicate IDs idempotent and rejects changed payloads", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icid-"));
+  const broker = await startBroker(agentDir);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const sender = new IntercomClient();
+  const receiver = new IntercomClient();
+  const received: string[] = [];
+  receiver.on("message", (_from, message) => received.push(message.content.text));
+  try {
+    await sender.connect(registration("sender", agentDir), "sender-id");
+    await receiver.connect(registration("receiver", agentDir), "receiver-id");
+    const first = await sender.send("receiver-id", { messageId: "same-id", text: "same payload" });
+    const duplicate = await sender.send("receiver-id", { messageId: "same-id", text: "same payload" });
+    const reuse = await sender.send("receiver-id", { messageId: "same-id", text: "different payload" });
+    assert.equal(first.delivered, true, JSON.stringify(first));
+    assert.equal(duplicate.delivered, true, JSON.stringify(duplicate));
+    assert.equal(reuse.delivered, false, JSON.stringify(reuse));
+    assert.equal(reuse.code, "E_MESSAGE_ID_REUSE");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.deepEqual(received, ["same payload"]);
+  } finally {
+    await sender.disconnect().catch(() => undefined);
+    await receiver.disconnect().catch(() => undefined);
+    await closeBroker(broker);
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("channel membership and executor ordinals survive a broker restart", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icrestart-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  let broker = await startBroker(agentDir);
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const firstSender = new IntercomClient();
+  const firstReceiver = new IntercomClient();
+  let channelId = "";
+  let epoch = "";
+  try {
+    await firstSender.connect(registration("planner", agentDir), "restart-sender");
+    await firstReceiver.connect({ ...registration("runtime", agentDir), runtimeFallbackAlias: true }, "restart-receiver");
+    const binding = await firstSender.openChannel("restart-receiver");
+    channelId = binding.channel.channelId;
+    epoch = binding.channel.epoch;
+    await firstSender.disconnect();
+    await firstReceiver.disconnect();
+    await closeBroker(broker);
+
+    broker = await startBroker(agentDir);
+    const sender = new IntercomClient();
+    const receiver = new IntercomClient();
+    try {
+      await sender.connect(registration("planner", agentDir), "restart-sender");
+      await receiver.connect({ ...registration("runtime", agentDir), runtimeFallbackAlias: true }, "restart-receiver");
+      const rebound = await sender.openChannel("restart-receiver");
+      assert.equal(rebound.channel.channelId, channelId);
+      assert.equal(rebound.channel.epoch, epoch);
+      assert.deepEqual(rebound.channel.members.map((member) => member.joinOrdinal), [1, 2]);
+      assert.deepEqual(rebound.channel.members.map((member) => member.agentName), ["planner", "执行者-2"]);
+    } finally {
+      await sender.disconnect().catch(() => undefined);
+      await receiver.disconnect().catch(() => undefined);
+    }
+  } finally {
+    await firstSender.disconnect().catch(() => undefined);
+    await firstReceiver.disconnect().catch(() => undefined);
+    await closeBroker(broker);
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("static project channel policy rejects same-name endpoint swaps and outsiders", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icpolicy-"));
+  mkdirSync(path.join(agentDir, ".pi"), { recursive: true });
+  writeFileSync(path.join(agentDir, ".pi", "intercom-channel.json"), JSON.stringify({
+    name: "policy",
+    members: [
+      { name: "planner", id: "sender-id" },
+      { name: "receiver", id: "receiver-id" },
+    ],
+  }));
+  const broker = await startBroker(agentDir);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const sender = new IntercomClient();
+  const receiver = new IntercomClient();
+  const outsider = new IntercomClient();
+  try {
+    await sender.connect(registration("planner", agentDir), "sender-id");
+    await receiver.connect(registration("receiver", agentDir), "receiver-id");
+    await outsider.connect(registration("outsider", agentDir), "outsider-id");
+    const allowed = await sender.send("receiver-id", { text: "allowed" });
+    const rejected = await sender.send("outsider-id", { text: "outside" });
+    assert.equal(allowed.delivered, true);
+    assert.equal(rejected.delivered, false);
+    assert.equal(rejected.code, "E_TARGET_NOT_MEMBER");
+  } finally {
+    await sender.disconnect().catch(() => undefined);
+    await receiver.disconnect().catch(() => undefined);
+    await outsider.disconnect().catch(() => undefined);
+    await closeBroker(broker);
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("channel-v1 queues only for the exact offline member and flushes after reconnect", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(path.join(tmpdir(), "icq-"));
+  const broker = await startBroker(agentDir);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const sender = new IntercomClient();
+  const receiver = new IntercomClient();
+  try {
+    await sender.connect(registration("sender", agentDir), "sender-id");
+    await receiver.connect(registration("receiver", agentDir), "receiver-id");
+    const binding = await sender.openChannel("receiver-id");
+    await receiver.disconnect();
+    const queued = await sender.send("receiver-id", { messageId: "queued-message", text: "offline hello" });
+    assert.equal(queued.delivered, true);
+    assert.equal(queued.state, "queued");
+
+    const replacement = new IntercomClient();
+    const received = waitForMessage(replacement, (_from, message) => message.id === "queued-message");
+    await replacement.connect(registration("receiver", agentDir), "receiver-id");
+    const [, message] = await received;
+    assert.equal(message.content.text, "offline hello");
+    assert.equal(message.channel?.channelId, binding.channel.channelId);
+    await replacement.disconnect();
+  } finally {
+    await sender.disconnect().catch(() => undefined);
+    await receiver.disconnect().catch(() => undefined);
+    await closeBroker(broker);
+    rmSync(agentDir, { recursive: true, force: true });
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});

--- a/broker/channel.ts
+++ b/broker/channel.ts
@@ -10,6 +10,11 @@ import type {
 export const DEFAULT_EPHEMERAL_CHANNEL_TTL_MS = 30 * 60 * 1000;
 export const CHANNEL_STATE_FILE_VERSION = 1;
 
+function ephemeralChannelTtlMs(): number {
+  const configured = Number.parseInt(process.env.PI_INTERCOM_EPHEMERAL_CHANNEL_TTL_MS ?? "", 10);
+  return Number.isSafeInteger(configured) && configured > 0 ? configured : DEFAULT_EPHEMERAL_CHANNEL_TTL_MS;
+}
+
 export function cloneChannel(channel: ChannelInfo): ChannelInfo {
   return {
     ...channel,
@@ -91,7 +96,7 @@ export function createPairChannel(
     state: "active",
     createdAt: now,
     lastActivityAt: now,
-    ...(lifecycle === "ephemeral" ? { expiresAt: now + DEFAULT_EPHEMERAL_CHANNEL_TTL_MS } : {}),
+    ...(lifecycle === "ephemeral" ? { expiresAt: now + ephemeralChannelTtlMs() } : {}),
     members: [],
   };
   channel.members.push(allocateChannelMember(channel, sender, 1, now));
@@ -116,7 +121,7 @@ export function channelAddress(
 export function touchChannel(channel: ChannelInfo, now = Date.now()): void {
   channel.lastActivityAt = now;
   if (channel.lifecycle === "ephemeral") {
-    channel.expiresAt = now + DEFAULT_EPHEMERAL_CHANNEL_TTL_MS;
+    channel.expiresAt = now + ephemeralChannelTtlMs();
   }
 }
 

--- a/broker/channel.ts
+++ b/broker/channel.ts
@@ -1,0 +1,126 @@
+import { randomUUID } from "node:crypto";
+import type {
+  ChannelAddress,
+  ChannelInfo,
+  ChannelLifecycle,
+  ChannelMemberInfo,
+  SessionInfo,
+} from "../types.ts";
+
+export const DEFAULT_EPHEMERAL_CHANNEL_TTL_MS = 30 * 60 * 1000;
+export const CHANNEL_STATE_FILE_VERSION = 1;
+
+export function cloneChannel(channel: ChannelInfo): ChannelInfo {
+  return {
+    ...channel,
+    members: channel.members.map((member) => ({ ...member })),
+  };
+}
+
+export function channelMemberById(channel: ChannelInfo, memberId: string): ChannelMemberInfo | undefined {
+  return channel.members.find((member) => member.memberId === memberId);
+}
+
+export function channelMemberForSession(channel: ChannelInfo, sessionId: string): ChannelMemberInfo | undefined {
+  return channel.members.find((member) => member.sessionId === sessionId && member.state !== "left");
+}
+
+export function channelForPair(
+  channels: Iterable<ChannelInfo>,
+  firstSessionId: string,
+  secondSessionId: string,
+): ChannelInfo | undefined {
+  return [...channels].find((channel) => {
+    if (channel.state !== "active") return false;
+    const first = channelMemberForSession(channel, firstSessionId);
+    const second = channelMemberForSession(channel, secondSessionId);
+    return Boolean(first && second && first.memberId !== second.memberId);
+  });
+}
+
+export function channelNameForSession(session: SessionInfo, ordinal: number): string {
+  const explicitName = session.runtimeFallbackAlias ? "" : session.name?.trim() ?? "";
+  return explicitName || `执行者-${ordinal}`;
+}
+
+export function allocateChannelMember(
+  channel: Pick<ChannelInfo, "members">,
+  session: SessionInfo,
+  joinOrdinal: number,
+  now = Date.now(),
+): ChannelMemberInfo {
+  const usedNames = new Set(channel.members.map((member) => member.agentName.toLocaleLowerCase()));
+  let agentName = channelNameForSession(session, joinOrdinal);
+  if (usedNames.has(agentName.toLocaleLowerCase())) {
+    if (session.runtimeFallbackAlias || !session.name?.trim()) {
+      // Explicit names reserve their spelling; unnamed members skip a colliding
+      // generated label while retaining their monotonically increasing ordinal.
+      let suffix = joinOrdinal;
+      do {
+        suffix += 1;
+        agentName = `执行者-${suffix}`;
+      } while (usedNames.has(agentName.toLocaleLowerCase()));
+    } else {
+      throw new Error(`E_NAME_CONFLICT: agent name "${agentName}" is already used in this channel`);
+    }
+  }
+
+  return {
+    memberId: randomUUID(),
+    agentName,
+    joinOrdinal,
+    sessionId: session.id,
+    bindingEpoch: randomUUID(),
+    state: "online",
+    joinedAt: now,
+    lastSeenAt: now,
+  };
+}
+
+export function createPairChannel(
+  sender: SessionInfo,
+  target: SessionInfo,
+  lifecycle: ChannelLifecycle = "ephemeral",
+  now = Date.now(),
+): ChannelInfo {
+  const channel: ChannelInfo = {
+    schemaVersion: 1,
+    channelId: randomUUID(),
+    epoch: randomUUID(),
+    lifecycle,
+    state: "active",
+    createdAt: now,
+    lastActivityAt: now,
+    ...(lifecycle === "ephemeral" ? { expiresAt: now + DEFAULT_EPHEMERAL_CHANNEL_TTL_MS } : {}),
+    members: [],
+  };
+  channel.members.push(allocateChannelMember(channel, sender, 1, now));
+  channel.members.push(allocateChannelMember(channel, target, 2, now));
+  return channel;
+}
+
+export function channelAddress(
+  channel: ChannelInfo,
+  fromMember: ChannelMemberInfo,
+  toMember: ChannelMemberInfo,
+): ChannelAddress {
+  return {
+    channelId: channel.channelId,
+    channelEpoch: channel.epoch,
+    fromMemberId: fromMember.memberId,
+    toMemberId: toMember.memberId,
+    targetBindingEpoch: toMember.bindingEpoch,
+  };
+}
+
+export function touchChannel(channel: ChannelInfo, now = Date.now()): void {
+  channel.lastActivityAt = now;
+  if (channel.lifecycle === "ephemeral") {
+    channel.expiresAt = now + DEFAULT_EPHEMERAL_CHANNEL_TTL_MS;
+  }
+}
+
+export function isChannelExpired(channel: ChannelInfo, now = Date.now()): boolean {
+  return channel.state === "expired"
+    || (channel.state === "active" && channel.expiresAt !== undefined && channel.expiresAt <= now);
+}

--- a/broker/client.test.ts
+++ b/broker/client.test.ts
@@ -35,6 +35,23 @@ test("registered feature negotiation rejects non-string feature entries", () => 
   );
 });
 
+test("channel-v1 client fails closed on old-broker conversational messages", () => {
+  const client = new IntercomClient();
+  (client as any)._sessionId = "session-1";
+  const from = { id: "session-2", cwd: "/test", model: "test", pid: 2, startedAt: 1, lastActivity: 1 };
+  const message = { id: "legacy-message", timestamp: 1, content: { text: "legacy" } };
+
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "message", from, message }),
+    /E_CHANNEL_REQUIRED/,
+  );
+  (client as any)._features = new Set(["channel-v1"]);
+  assert.throws(
+    () => (client as any).handleBrokerMessage({ type: "message", from, message }),
+    /E_CHANNEL_REQUIRED/,
+  );
+});
+
 test("malformed extension broker messages are rejected", () => {
   const client = new IntercomClient();
   (client as any)._sessionId = "session-1";

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -3,12 +3,17 @@ import net from "net";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
 import { getBrokerConnectTarget, type BrokerConnectTarget } from "./paths.ts";
-import { isMessage, isMessageControl, isMessageReceipt, isSessionInfo } from "./protocol.ts";
-import { EXTENSION_BUS_FEATURE } from "../types.ts";
+import { channelMemberFor, channelRejectsSession, findChannelFile, loadChannel, resolveBoundId } from "../channel.ts";
+import { isChannelInfo, isMessage, isMessageControl, isMessageReceipt, isSessionInfo } from "./protocol.ts";
+import { CHANNEL_BUS_FEATURE, EXTENSION_BUS_FEATURE } from "../types.ts";
 import type {
   Attachment,
   BrokerMessage,
+  ChannelInfo,
+  ChannelLifecycle,
+  ChannelAddress,
   ClientMessage,
+  DeliveryState,
   Message,
   MessageControl,
   MessageReceipt,
@@ -16,7 +21,7 @@ import type {
   SessionRegistration,
 } from "../types.ts";
 
-interface SendOptions {
+export interface SendOptions {
   text: string;
   attachments?: Attachment[];
   replyTo?: string;
@@ -24,12 +29,31 @@ interface SendOptions {
   messageId?: string;
   supersedes?: string;
   retryOf?: string;
+  /** Optional declared identity; static project channel policy verifies it. */
+  intended?: string;
 }
 
-interface SendResult {
+export interface SendResult {
   id: string;
   delivered: boolean;
+  state?: DeliveryState;
   reason?: string;
+  code?: string;
+  retryable?: boolean;
+  outcomeKnown?: boolean;
+  channelId?: string;
+}
+
+export interface ChannelBinding {
+  channel: ChannelInfo;
+  selfMemberId: string;
+  targetMemberId: string;
+  targetSessionId: string;
+}
+
+interface PendingChannelOpen {
+  resolve: (binding: ChannelBinding) => void;
+  reject: (error: Error) => void;
 }
 
 function toError(error: unknown): Error {
@@ -66,6 +90,10 @@ export class IntercomClient extends EventEmitter {
   private _features = new Set<string>();
   private pendingSends = new Map<string, { resolve: (r: SendResult) => void; reject: (e: Error) => void }>();
   private pendingLists = new Map<string, { resolve: (sessions: SessionInfo[]) => void; reject: (e: Error) => void }>();
+  private pendingChannelOpens = new Map<string, PendingChannelOpen>();
+  private pendingChannelCloses = new Map<string, { resolve: () => void; reject: (error: Error) => void }>();
+  private channelBindings = new Map<string, ChannelBinding>();
+  private registration: SessionRegistration | null = null;
   private nextSenderSequence = 1;
   private disconnecting = false;
   private disconnectError: Error | null = null;
@@ -81,6 +109,15 @@ export class IntercomClient extends EventEmitter {
       pending.reject(error);
     }
     this.pendingLists.clear();
+    for (const pending of this.pendingChannelOpens.values()) {
+      pending.reject(error);
+    }
+    this.pendingChannelOpens.clear();
+    for (const pending of this.pendingChannelCloses.values()) {
+      pending.reject(error);
+    }
+    this.pendingChannelCloses.clear();
+    this.channelBindings.clear();
   }
 
   get sessionId(): string | null {
@@ -173,6 +210,7 @@ export class IntercomClient extends EventEmitter {
         return;
       }
       this.socket = socket;
+      this.registration = session;
       this.disconnectError = null;
       let settled = false;
       const timeout = setTimeout(() => {
@@ -222,6 +260,7 @@ export class IntercomClient extends EventEmitter {
         }
         this._sessionId = null;
         this._features.clear();
+        this.registration = null;
         this.disconnectError = null;
         if (connectionEstablished && !wasDisconnecting) {
           this.emit("disconnected", disconnectError);
@@ -355,6 +394,75 @@ export class IntercomClient extends EventEmitter {
         break;
       }
 
+      case "channel_opened": {
+        const { requestId, channel, selfMemberId, targetMemberId } = brokerMessage;
+        if (
+          typeof requestId !== "string"
+          || !isChannelInfo(channel)
+          || typeof selfMemberId !== "string"
+          || typeof targetMemberId !== "string"
+        ) {
+          throw new Error("Invalid channel_opened message");
+        }
+        const pending = this.pendingChannelOpens.get(requestId);
+        if (!pending) return;
+        this.pendingChannelOpens.delete(requestId);
+        const self = channel.members.find((member) => member.memberId === selfMemberId);
+        const target = channel.members.find((member) => member.memberId === targetMemberId);
+        if (!self || !target) {
+          pending.reject(new Error("Invalid channel_opened membership"));
+          return;
+        }
+        const binding: ChannelBinding = {
+          channel,
+          selfMemberId,
+          targetMemberId,
+          targetSessionId: target.sessionId,
+        };
+        this.channelBindings.set(target.sessionId, binding);
+        pending.resolve(binding);
+        break;
+      }
+
+      case "channel_closed": {
+        if (typeof brokerMessage.requestId !== "string" || typeof brokerMessage.channelId !== "string") {
+          throw new Error("Invalid channel_closed message");
+        }
+        for (const [targetId, binding] of this.channelBindings) {
+          if (binding.channel.channelId === brokerMessage.channelId) this.channelBindings.delete(targetId);
+        }
+        const pending = this.pendingChannelCloses.get(brokerMessage.requestId);
+        if (pending) {
+          this.pendingChannelCloses.delete(brokerMessage.requestId);
+          pending.resolve();
+        }
+        break;
+      }
+
+      case "channel_open_failed": {
+        const { requestId, reason, code, retryable } = brokerMessage;
+        if (typeof requestId !== "string" || typeof reason !== "string") {
+          throw new Error("Invalid channel_open_failed message");
+        }
+        const pending = this.pendingChannelOpens.get(requestId);
+        if (pending) {
+          this.pendingChannelOpens.delete(requestId);
+          const error = new Error(reason) as Error & { code?: string; retryable?: boolean };
+          if (typeof code === "string") error.code = code;
+          if (typeof retryable === "boolean") error.retryable = retryable;
+          pending.reject(error);
+          break;
+        }
+        const closePending = this.pendingChannelCloses.get(requestId);
+        if (!closePending) return;
+        this.pendingChannelCloses.delete(requestId);
+        const error = new Error(reason) as Error & { code?: string; retryable?: boolean };
+        if (typeof code === "string") error.code = code;
+        if (typeof retryable === "boolean") error.retryable = retryable;
+        closePending.reject(error);
+        break;
+      }
+
       case "message": {
         const { from, message } = brokerMessage;
         if (!isSessionInfo(from) || !isMessage(message)) {
@@ -378,7 +486,12 @@ export class IntercomClient extends EventEmitter {
         }
 
         this.pendingSends.delete(messageId);
-        pending.resolve({ id: messageId, delivered: true });
+        pending.resolve({
+          id: messageId,
+          delivered: true,
+          state: brokerMessage.state === "queued" || brokerMessage.state === "socket_delivered" ? brokerMessage.state : "socket_delivered",
+          ...(typeof brokerMessage.channelId === "string" ? { channelId: brokerMessage.channelId } : {}),
+        });
         break;
       }
 
@@ -395,7 +508,16 @@ export class IntercomClient extends EventEmitter {
         }
 
         this.pendingSends.delete(messageId);
-        pending.resolve({ id: messageId, delivered: false, reason });
+        pending.resolve({
+          id: messageId,
+          delivered: false,
+          state: "failed",
+          reason,
+          ...(typeof brokerMessage.code === "string" ? { code: brokerMessage.code } : {}),
+          ...(typeof brokerMessage.retryable === "boolean" ? { retryable: brokerMessage.retryable } : {}),
+          ...(typeof brokerMessage.outcomeKnown === "boolean" ? { outcomeKnown: brokerMessage.outcomeKnown } : {}),
+          ...(typeof brokerMessage.channelId === "string" ? { channelId: brokerMessage.channelId } : {}),
+        });
         break;
       }
 
@@ -613,15 +735,180 @@ export class IntercomClient extends EventEmitter {
     });
   }
 
-  send(to: string, options: SendOptions): Promise<SendResult> {
+  private async resolveExactTarget(target: string): Promise<{ id: string; sessions: SessionInfo[] }> {
+    const sessions = await this.listSessions();
+    const byId = sessions.find((session) => session.id === target);
+    if (byId) return { id: byId.id, sessions };
+    const lower = target.toLowerCase();
+    const byName = sessions.filter((session) => session.name?.toLowerCase() === lower);
+    if (byName.length === 1) return { id: byName[0]!.id, sessions };
+    if (byName.length > 1) throw Object.assign(new Error(`Multiple sessions named "${target}"; use an exact session ID.`), { code: "E_TARGET_AMBIGUOUS" });
+    const byPrefix = sessions.filter((session) => session.id.startsWith(target));
+    if (byPrefix.length === 1) return { id: byPrefix[0]!.id, sessions };
+    if (byPrefix.length > 1) throw Object.assign(new Error(`Multiple sessions match ID prefix "${target}"; use a longer ID.`), { code: "E_TARGET_AMBIGUOUS" });
+    // An exact stable ID may refer to a disconnected channel member. The
+    // broker will accept it only when it can prove the prior membership.
+    return { id: target, sessions };
+  }
+
+  private enforceLocalChannelPolicy(targetSessionId: string, sessions: SessionInfo[], intended?: string): void {
+    const registration = this.registration;
+    if (!registration?.cwd) return;
+    const channelFile = findChannelFile(registration.cwd);
+    if (!channelFile) return;
+    const config = loadChannel(channelFile);
+    const selfSession = sessions.find((session) => session.id === this._sessionId) ?? { id: this._sessionId ?? "" };
+    if (!channelMemberFor(config, selfSession)) {
+      const error = new Error(`E_SENDER_NOT_MEMBER: current session is not a member of channel "${config.name}"`) as Error & { code?: string };
+      error.code = "E_SENDER_NOT_MEMBER";
+      throw error;
+    }
+    const targetSession = sessions.find((session) => session.id === targetSessionId) ?? { id: targetSessionId };
+    // For a disconnected member only its exact configured ID is admissible;
+    // a name-only entry cannot be proven against a missing endpoint.
+    const rejection = channelRejectsSession(config, targetSession);
+    if (rejection) {
+      const error = new Error(`E_TARGET_NOT_MEMBER: ${rejection}`) as Error & { code?: string };
+      error.code = "E_TARGET_NOT_MEMBER";
+      throw error;
+    }
+    if (!intended) return;
+    const boundId = resolveBoundId(config, intended);
+    if (boundId && boundId !== targetSessionId) {
+      const error = new Error(`E_BINDING_MISMATCH: intended identity "${intended}" is bound to ${boundId}, not ${targetSessionId}`) as Error & { code?: string };
+      error.code = "E_BINDING_MISMATCH";
+      throw error;
+    }
+    if (!boundId) {
+      const targetMember = channelMemberFor(config, targetSession);
+      if (!targetMember || targetMember.name?.trim().toLowerCase() !== intended.trim().toLowerCase()) {
+        const error = new Error(`E_BINDING_MISMATCH: intended identity "${intended}" does not match the channel target`) as Error & { code?: string };
+        error.code = "E_BINDING_MISMATCH";
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Open or reuse a broker-owned channel. The target must already be resolved
+   * to an exact session ID; names never cross this handshake boundary.
+   */
+  openChannel(targetSessionId: string, lifecycle: ChannelLifecycle = "ephemeral"): Promise<ChannelBinding> {
     let socket: net.Socket;
     try {
       socket = this.requireActiveSocket();
     } catch (error) {
       return Promise.reject(toError(error));
     }
-    
+    if (!this.supportsFeature(CHANNEL_BUS_FEATURE)) {
+      const error = new Error("E_CHANNEL_REQUIRED: connected broker does not support channel-v1") as Error & { code?: string };
+      error.code = "E_CHANNEL_REQUIRED";
+      return Promise.reject(error);
+    }
+    const requestId = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this.pendingChannelOpens.has(requestId)) return;
+        this.pendingChannelOpens.delete(requestId);
+        const error = new Error("Channel open timeout") as Error & { code?: string; retryable?: boolean };
+        error.code = "E_CHANNEL_OPEN_TIMEOUT";
+        error.retryable = true;
+        reject(error);
+      }, 10000);
+      this.pendingChannelOpens.set(requestId, {
+        resolve: (binding) => {
+          clearTimeout(timeout);
+          resolve(binding);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
+      try {
+        writeMessage(socket, { type: "channel_open", requestId, targetSessionId, lifecycle });
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pendingChannelOpens.delete(requestId);
+        reject(toError(error));
+      }
+    });
+  }
+
+  closeChannel(binding: ChannelBinding): Promise<void> {
+    let socket: net.Socket;
+    try {
+      socket = this.requireActiveSocket();
+    } catch (error) {
+      return Promise.reject(toError(error));
+    }
+    const requestId = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this.pendingChannelCloses.has(requestId)) return;
+        this.pendingChannelCloses.delete(requestId);
+        reject(new Error("Channel close timeout"));
+      }, 5000);
+      this.pendingChannelCloses.set(requestId, {
+        resolve: () => {
+          clearTimeout(timeout);
+          resolve();
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
+      try {
+        writeMessage(socket, {
+          type: "channel_close",
+          requestId,
+          channelId: binding.channel.channelId,
+          channelEpoch: binding.channel.epoch,
+        });
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pendingChannelCloses.delete(requestId);
+        reject(toError(error));
+      }
+    });
+  }
+
+  async send(to: string, options: SendOptions): Promise<SendResult> {
     const messageId = options.messageId ?? randomUUID();
+    let targetSessionId: string;
+    let binding: ChannelBinding;
+    try {
+      const target = await this.resolveExactTarget(to);
+      targetSessionId = target.id;
+      this.enforceLocalChannelPolicy(targetSessionId, target.sessions, options.intended);
+      binding = await this.openChannel(targetSessionId);
+    } catch (error) {
+      const normalized = error as Error & { code?: string; retryable?: boolean };
+      if (normalized.code?.startsWith("E_")) {
+        return {
+          id: messageId,
+          delivered: false,
+          state: "failed",
+          reason: normalized.message,
+          code: normalized.code,
+          retryable: normalized.retryable,
+          outcomeKnown: true,
+        };
+      }
+      throw error;
+    }
+    const socket = this.requireActiveSocket();
+    const self = binding.channel.members.find((member) => member.memberId === binding.selfMemberId);
+    const target = binding.channel.members.find((member) => member.memberId === binding.targetMemberId);
+    if (!self || !target) throw new Error("E_CHANNEL_NOT_FOUND: channel membership is incomplete");
+    const address: ChannelAddress = {
+      channelId: binding.channel.channelId,
+      channelEpoch: binding.channel.epoch,
+      fromMemberId: self.memberId,
+      toMemberId: target.memberId,
+      targetBindingEpoch: target.bindingEpoch,
+    };
     const message: Message = {
       id: messageId,
       timestamp: Date.now(),
@@ -630,6 +917,7 @@ export class IntercomClient extends EventEmitter {
       retryOf: options.retryOf,
       replyTo: options.replyTo,
       expectsReply: options.expectsReply,
+      channel: address,
       content: {
         text: options.text,
         attachments: options.attachments,
@@ -637,6 +925,10 @@ export class IntercomClient extends EventEmitter {
     };
 
     return new Promise((resolve, reject) => {
+      if (this.pendingSends.has(messageId)) {
+        reject(new Error(`Message ${messageId} is already being sent`));
+        return;
+      }
       const wrappedResolve = (result: SendResult) => {
         clearTimeout(timeout);
         resolve(result);
@@ -648,13 +940,22 @@ export class IntercomClient extends EventEmitter {
       const timeout = setTimeout(() => {
         if (this.pendingSends.has(messageId)) {
           this.pendingSends.delete(messageId);
-          wrappedReject(new Error("Send timeout"));
+          const error = new Error(`E_DELIVERY_TIMEOUT_UNKNOWN: send outcome for ${messageId} is unknown`) as Error & {
+            code?: string;
+            retryable?: boolean;
+            outcomeKnown?: boolean;
+            messageId?: string;
+          };
+          error.code = "E_DELIVERY_TIMEOUT_UNKNOWN";
+          error.retryable = false;
+          error.outcomeKnown = false;
+          error.messageId = messageId;
+          wrappedReject(error);
         }
       }, 10000);
       this.pendingSends.set(messageId, { resolve: wrappedResolve, reject: wrappedReject });
-
       try {
-        writeMessage(socket, { type: "send", to, message });
+        writeMessage(socket, { type: "channel_send", channel: address, message });
       } catch (error) {
         clearTimeout(timeout);
         this.pendingSends.delete(messageId);

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -468,6 +468,9 @@ export class IntercomClient extends EventEmitter {
         if (!isSessionInfo(from) || !isMessage(message)) {
           throw new Error("Invalid message event");
         }
+        if (!this.supportsFeature(CHANNEL_BUS_FEATURE) || !message.channel) {
+          throw new Error("E_CHANNEL_REQUIRED: conversational messages require channel-v1");
+        }
 
         this.emit("message", from, message);
         break;
@@ -780,8 +783,15 @@ export class IntercomClient extends EventEmitter {
       throw error;
     }
     if (!boundId) {
+      const intendedName = intended.trim().toLowerCase();
+      const configuredMember = config.members.find((member) => member.name?.trim().toLowerCase() === intendedName);
+      if (!configuredMember || !configuredMember.id || !config.allowNameOnly) {
+        const error = new Error(`E_BINDING_REQUIRED: intended identity "${intended}" must have an exact configured session ID`) as Error & { code?: string };
+        error.code = "E_BINDING_REQUIRED";
+        throw error;
+      }
       const targetMember = channelMemberFor(config, targetSession);
-      if (!targetMember || targetMember.name?.trim().toLowerCase() !== intended.trim().toLowerCase()) {
+      if (!targetMember || targetMember.name?.trim().toLowerCase() !== intendedName) {
         const error = new Error(`E_BINDING_MISMATCH: intended identity "${intended}" does not match the channel target`) as Error & { code?: string };
         error.code = "E_BINDING_MISMATCH";
         throw error;

--- a/broker/protocol.ts
+++ b/broker/protocol.ts
@@ -1,5 +1,7 @@
 import type {
   Attachment,
+  ChannelAddress,
+  ChannelInfo,
   Message,
   MessageControl,
   MessageReceipt,
@@ -47,6 +49,56 @@ export function isMessageControl(value: unknown): value is MessageControl {
     return false;
   }
   return value.detail === undefined || typeof value.detail === "string";
+}
+
+export function isChannelAddress(value: unknown): value is ChannelAddress {
+  if (!isRecord(value)) return false;
+  return typeof value.channelId === "string"
+    && value.channelId.length > 0
+    && typeof value.channelEpoch === "string"
+    && value.channelEpoch.length > 0
+    && typeof value.fromMemberId === "string"
+    && value.fromMemberId.length > 0
+    && typeof value.toMemberId === "string"
+    && value.toMemberId.length > 0
+    && value.fromMemberId !== value.toMemberId
+    && typeof value.targetBindingEpoch === "string"
+    && value.targetBindingEpoch.length > 0;
+}
+
+function isChannelMemberInfo(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return typeof value.memberId === "string"
+    && value.memberId.length > 0
+    && typeof value.agentName === "string"
+    && value.agentName.trim().length > 0
+    && Number.isSafeInteger(value.joinOrdinal)
+    && Number(value.joinOrdinal) > 0
+    && typeof value.sessionId === "string"
+    && value.sessionId.length > 0
+    && typeof value.bindingEpoch === "string"
+    && value.bindingEpoch.length > 0
+    && (value.state === "online" || value.state === "offline" || value.state === "left")
+    && Number.isSafeInteger(value.joinedAt)
+    && Number.isSafeInteger(value.lastSeenAt);
+}
+
+export function isChannelInfo(value: unknown): value is ChannelInfo {
+  if (!isRecord(value) || !Array.isArray(value.members) || value.members.length < 2) return false;
+  if (!(value.members as unknown[]).every(isChannelMemberInfo)) return false;
+  const memberIds = new Set((value.members as Array<Record<string, unknown>>).map((member) => member.memberId));
+  const names = new Set((value.members as Array<Record<string, unknown>>).map((member) => String(member.agentName).toLowerCase()));
+  if (memberIds.size !== value.members.length || names.size !== value.members.length) return false;
+  return value.schemaVersion === 1
+    && typeof value.channelId === "string"
+    && value.channelId.length > 0
+    && typeof value.epoch === "string"
+    && value.epoch.length > 0
+    && (value.lifecycle === "ephemeral" || value.lifecycle === "reusable")
+    && (value.state === "active" || value.state === "closed" || value.state === "expired")
+    && Number.isSafeInteger(value.createdAt)
+    && Number.isSafeInteger(value.lastActivityAt)
+    && (value.expiresAt === undefined || Number.isSafeInteger(value.expiresAt));
 }
 
 function isAttachment(value: unknown): value is Attachment {
@@ -98,6 +150,15 @@ export function isMessage(value: unknown): value is Message {
 
   if (value.expectsReply !== undefined && typeof value.expectsReply !== "boolean") {
     return false;
+  }
+
+  if (value.channel !== undefined && !isChannelAddress(value.channel)) {
+    return false;
+  }
+  for (const key of ["channelSenderName", "channelTargetName"] as const) {
+    if (value[key] !== undefined && (typeof value[key] !== "string" || value[key].trim().length === 0)) {
+      return false;
+    }
   }
 
   if (!isRecord(value.content) || typeof value.content.text !== "string") {

--- a/channel.test.ts
+++ b/channel.test.ts
@@ -43,12 +43,15 @@ test("loadChannel validates structure", () => {
   const root = tempDir();
   try {
     const file = join(root, CHANNEL_FILE_NAME);
-    writeFileSync(file, JSON.stringify({ name: "任务组", members: [{ name: "a", role: "发起者" }, { name: "b" }] }));
+    writeFileSync(file, JSON.stringify({ name: "任务组", allowNameOnly: true, members: [{ name: "a", role: "发起者" }, { name: "b" }] }));
     const config = loadChannel(file);
     assert.equal(config.name, "任务组");
     assert.equal(config.members.length, 2);
     assert.equal(config.members[0]!.role, "发起者");
     assert.equal(config.members[1]!.role, undefined);
+    assert.equal(config.allowNameOnly, true);
+    writeFileSync(file, JSON.stringify({ name: "strict", members: [{ name: "a" }] }));
+    assert.throws(() => loadChannel(file), /stable "id"/);
 
     writeFileSync(file, "not json");
     assert.throws(() => loadChannel(file), /Invalid channel file/);
@@ -73,7 +76,7 @@ test("loadChannel validates structure", () => {
 });
 
 test("channelRejectsSession allows members, rejects outsiders", () => {
-  const config = { name: "任务组", members: [{ name: "eng-lead", role: "发起者" }, { name: "Executor" }] };
+  const config = { name: "任务组", allowNameOnly: true, members: [{ name: "eng-lead", role: "发起者" }, { name: "Executor" }] };
 
   assert.equal(channelRejectsSession(config, { id: "1", name: "eng-lead" }), null);
   assert.equal(channelRejectsSession(config, { id: "2", name: "executor" }), null); // case-insensitive
@@ -85,6 +88,7 @@ test("channelRejectsSession allows members, rejects outsiders", () => {
 test("resolveBoundId maps identity names to bound session ids", () => {
   const config = {
     name: "任务组",
+    allowNameOnly: true,
     members: [
       { name: "导师", id: "01a000c6-0bba-7254-bc23-dadfdbf32552" },
       { name: "秘书", id: "01a000ad-7617-7bb8-9933-8e9bf9fc0b27" },
@@ -100,6 +104,7 @@ test("resolveBoundId maps identity names to bound session ids", () => {
 test("channelMemberFor resolves member by name or bound id", () => {
   const config = {
     name: "任务组",
+    allowNameOnly: true,
     members: [
       { name: "导师", role: "导师", id: "01a000c6-0bba-7254-bc23-dadfdbf32552" },
       { name: "秘书", role: "秘书" },
@@ -127,7 +132,7 @@ test("formatTargetLabel prefers identity label over runtime alias", () => {
 test("channelRejectsSession binds members by exact id", () => {
 
   const tutorId = "01a000c6-0bba-7254-bc23-dadfdbf32552";
-  const config = { name: "任务组", members: [{ name: "导师", role: "导师", id: tutorId }, { name: "秘书" }] };
+  const config = { name: "任务组", allowNameOnly: true, members: [{ name: "导师", role: "导师", id: tutorId }, { name: "秘书" }] };
 
   // Runtime alias (no /name) matches by id.
   assert.equal(channelRejectsSession(config, { id: tutorId, name: `subagent-chat-${tutorId}`, runtimeFallbackAlias: true }), null);

--- a/channel.test.ts
+++ b/channel.test.ts
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CHANNEL_FILE_NAME,
+  findChannelFile,
+  loadChannel,
+  channelRejectsSession,
+  channelMemberFor,
+  intendedMismatchReason,
+  resolveBoundId,
+  formatTargetLabel,
+  type SessionLike,
+} from "./channel.ts";
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "intercom-channel-test-"));
+  return dir;
+}
+
+const shortId = (session: SessionLike) => session.id.slice(0, 8);
+
+test("findChannelFile walks up parent directories", () => {
+  const root = tempDir();
+  try {
+    const project = join(root, "a", "b");
+    mkdirSync(join(project, ".pi"), { recursive: true });
+    writeFileSync(join(project, ".pi", CHANNEL_FILE_NAME), JSON.stringify({ name: "t", members: [{ name: "x" }] }));
+
+    assert.equal(findChannelFile(project), join(project, ".pi", CHANNEL_FILE_NAME));
+    // Found from a nested cwd below the project root.
+    assert.equal(findChannelFile(join(project, "sub", "deep")), join(project, ".pi", CHANNEL_FILE_NAME));
+    // Nothing above the root.
+    assert.equal(findChannelFile(root), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loadChannel validates structure", () => {
+  const root = tempDir();
+  try {
+    const file = join(root, CHANNEL_FILE_NAME);
+    writeFileSync(file, JSON.stringify({ name: "任务组", members: [{ name: "a", role: "发起者" }, { name: "b" }] }));
+    const config = loadChannel(file);
+    assert.equal(config.name, "任务组");
+    assert.equal(config.members.length, 2);
+    assert.equal(config.members[0]!.role, "发起者");
+    assert.equal(config.members[1]!.role, undefined);
+
+    writeFileSync(file, "not json");
+    assert.throws(() => loadChannel(file), /Invalid channel file/);
+
+    writeFileSync(file, JSON.stringify({ name: "x", members: [] }));
+    assert.throws(() => loadChannel(file), /members/);
+
+    writeFileSync(file, JSON.stringify({ name: "x", members: [{}] }));
+    assert.throws(() => loadChannel(file), /members\[0\]/);
+
+    // id-only member is valid.
+    writeFileSync(file, JSON.stringify({ name: "x", members: [{ id: "01a000af-a036" }] }));
+    assert.deepEqual(loadChannel(file).members, [{ id: "01a000af-a036" }]);
+
+    writeFileSync(file, JSON.stringify({ name: "x", members: [{ name: "A" }, { name: "a" }] }));
+    assert.throws(() => loadChannel(file), /duplicate member name/);
+    writeFileSync(file, JSON.stringify({ name: "x", members: [{ id: "same" }, { id: "same" }] }));
+    assert.throws(() => loadChannel(file), /duplicate member id/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("channelRejectsSession allows members, rejects outsiders", () => {
+  const config = { name: "任务组", members: [{ name: "eng-lead", role: "发起者" }, { name: "Executor" }] };
+
+  assert.equal(channelRejectsSession(config, { id: "1", name: "eng-lead" }), null);
+  assert.equal(channelRejectsSession(config, { id: "2", name: "executor" }), null); // case-insensitive
+  assert.match(channelRejectsSession(config, { id: "3", name: "outsider" })!, /"outsider" is not a member/);
+  assert.match(channelRejectsSession(config, { id: "4", name: "eng-lead-2" })!, /not a member/); // prefix does not match
+  assert.match(channelRejectsSession(config, null)!, /could not be resolved/);
+});
+
+test("resolveBoundId maps identity names to bound session ids", () => {
+  const config = {
+    name: "任务组",
+    members: [
+      { name: "导师", id: "01a000c6-0bba-7254-bc23-dadfdbf32552" },
+      { name: "秘书", id: "01a000ad-7617-7bb8-9933-8e9bf9fc0b27" },
+      { name: "无名氏" },
+    ],
+  };
+  assert.equal(resolveBoundId(config, "导师"), "01a000c6-0bba-7254-bc23-dadfdbf32552");
+  assert.equal(resolveBoundId(config, "秘 书".replace(" ", "")), "01a000ad-7617-7bb8-9933-8e9bf9fc0b27"); // trimmed case-insensitive
+  assert.equal(resolveBoundId(config, "无名氏"), null); // member without id has no binding
+  assert.equal(resolveBoundId(config, "不存在"), null);
+});
+
+test("channelMemberFor resolves member by name or bound id", () => {
+  const config = {
+    name: "任务组",
+    members: [
+      { name: "导师", role: "导师", id: "01a000c6-0bba-7254-bc23-dadfdbf32552" },
+      { name: "秘书", role: "秘书" },
+    ],
+  };
+  // A same-name but different endpoint is not the bound identity.
+  assert.equal(channelMemberFor(config, { id: "x", name: "导师" }), null);
+  // By bound id — runtime alias session.
+  assert.equal(channelMemberFor(config, { id: "01a000c6-0bba-7254-bc23-dadfdbf32552", name: "subagent-chat-01a000c6", runtimeFallbackAlias: true })?.name, "导师");
+  // Name-only member.
+  assert.equal(channelMemberFor(config, { id: "y", name: "秘 书".replace(" ", "") })?.name, "秘书");
+  // Outsider.
+  assert.equal(channelMemberFor(config, { id: "z", name: "路人" }), null);
+});
+
+test("formatTargetLabel prefers identity label over runtime alias", () => {
+  const session = { id: "01a000c6-0bba-7254", name: "subagent-chat-01a000c6-0bba-7254" };
+  const plain = formatTargetLabel(session, "x", (s) => s.id.slice(0, 8));
+  assert.match(plain, /^subagent-chat-/);
+  const identified = formatTargetLabel(session, "x", (s) => s.id.slice(0, 8), "导师");
+  assert.equal(identified, "导师 (01a000c6)");
+  assert.match(formatTargetLabel(null, "stale", (s) => s.id.slice(0, 8)), /unverified/);
+});
+
+test("channelRejectsSession binds members by exact id", () => {
+
+  const tutorId = "01a000c6-0bba-7254-bc23-dadfdbf32552";
+  const config = { name: "任务组", members: [{ name: "导师", role: "导师", id: tutorId }, { name: "秘书" }] };
+
+  // Runtime alias (no /name) matches by id.
+  assert.equal(channelRejectsSession(config, { id: tutorId, name: `subagent-chat-${tutorId}`, runtimeFallbackAlias: true }), null);
+  // A user name without the bound endpoint is rejected.
+  assert.match(channelRejectsSession(config, { id: "other", name: "导师" })!, /is not a member/);
+  // Different session id, different name: rejected.
+  assert.match(channelRejectsSession(config, { id: "01a000ad-7617-7bb8-9933-8e9bf9fc0b27", name: "subagent-chat-x" })!, /is not a member/);
+  // A member with both identity and endpoint requires both to match.
+  assert.match(channelRejectsSession(config, { id: "whatever", name: "导师" })!, /is not a member/);
+  // Name-only legacy members still match an explicit user name.
+  assert.equal(channelRejectsSession(config, { id: "whatever", name: "秘书" }), null);
+});
+
+test("intendedMismatchReason refuses mismatched recipients", () => {
+  const c = { id: "cccccccc", name: "c" };
+  const e = { id: "eeeeeeee", name: "e" };
+
+  // Matching intended + target passes.
+  assert.equal(intendedMismatchReason("c", c, c, shortId), null);
+  // Mismatch is refused with both sides named.
+  const reason = intendedMismatchReason("c", c, e, shortId)!;
+  assert.match(reason, /Refusing to send/);
+  assert.match(reason, /"e"/);
+  assert.match(reason, /"c"/);
+  // Intended that resolves nowhere is refused.
+  assert.match(intendedMismatchReason("ghost", null, e, shortId)!, /did not resolve/);
+  // Target not connected while intended is.
+  assert.match(intendedMismatchReason("c", c, null, shortId)!, /not a connected session/);
+});

--- a/channel.ts
+++ b/channel.ts
@@ -15,13 +15,13 @@ import { dirname, join } from "node:path";
  * {
  *   "name": "R-ICL 任务组",
  *   "members": [
- *     { "name": "eng-lead", "role": "发起者" },
- *     { "name": "executor", "role": "接受者", "id": "01a0…" }
+ *     { "name": "eng-lead", "role": "发起者", "id": "01a0…" },
+ *     { "name": "executor", "role": "接受者", "id": "01b0…" }
  *   ]
  * }
- * Members match by session name (case-insensitive) and/or by exact session id.
- * An `id` binds the member to a specific session so a runtime alias that has
- * not been `/name`d can still be admitted.
+ * Members are bound by exact session id. Name-only members are rejected by
+ * default; an existing legacy file may opt in explicitly with
+ * `"allowNameOnly": true`, accepting the weaker live-name binding.
  */
 
 export const CHANNEL_FILE_NAME = "intercom-channel.json";
@@ -35,6 +35,8 @@ export interface ChannelMember {
 export interface ChannelConfig {
   name: string;
   members: ChannelMember[];
+  /** Explicit compatibility opt-in for weak, name-only membership. */
+  allowNameOnly?: boolean;
 }
 
 export interface SessionLike {
@@ -79,6 +81,10 @@ export function loadChannel(file: string): ChannelConfig {
   if (!Array.isArray(cfg.members) || cfg.members.length === 0) {
     throw new Error(`Invalid channel file ${file}: missing non-empty "members" array.`);
   }
+  if (cfg.allowNameOnly !== undefined && typeof cfg.allowNameOnly !== "boolean") {
+    throw new Error(`Invalid channel file ${file}: "allowNameOnly" must be a boolean.`);
+  }
+  const allowNameOnly = cfg.allowNameOnly === true;
   const seenNames = new Set<string>();
   const seenIds = new Set<string>();
   const members: ChannelMember[] = cfg.members.map((member, index) => {
@@ -106,7 +112,10 @@ export function loadChannel(file: string): ChannelConfig {
       ...(typeof m.role === "string" && m.role.trim().length > 0 ? { role: m.role } : {}),
     };
   });
-  return { name: cfg.name, members };
+  if (!allowNameOnly && members.some((member) => !member.id)) {
+    throw new Error(`Invalid channel file ${file}: every member needs a stable "id"; set "allowNameOnly": true only for explicit legacy compatibility.`);
+  }
+  return { name: cfg.name, members, ...(allowNameOnly ? { allowNameOnly: true } : {}) };
 }
 
 /** Human-readable member list, e.g. `a (发起者), b (接受者)`. */
@@ -125,9 +134,8 @@ export function formatChannelMembers(config: ChannelConfig): string {
  * An id-bearing member is bound to the exact runtime endpoint. Its `name` is
  * the channel-local logical identity (and need not equal the session's
  * mutable display name). A same-name session with a different id is rejected.
- * Name-only members are supported for legacy channel files, but generated
- * runtime aliases never satisfy a name-only binding because an alias is not a
- * user identity.
+ * Name-only members are accepted only when the config explicitly opts into
+ * `allowNameOnly`; generated runtime aliases never satisfy that weak binding.
  */
 export function channelMemberFor(
   config: ChannelConfig,
@@ -144,7 +152,7 @@ export function channelMemberFor(
       if (member.id === session.id) return member;
       continue;
     }
-    if (nameMatches) {
+    if (config.allowNameOnly && nameMatches) {
       return member;
     }
   }
@@ -154,7 +162,7 @@ export function channelMemberFor(
 /**
  * Returns null when `session` is allowed to receive messages in the channel,
  * otherwise a rejection reason. ID-bearing members require exact ID; name-only
- * members are a legacy weaker binding.
+ * members are available only through the explicit legacy opt-in.
  */
 export function channelRejectsSession(
   config: ChannelConfig,

--- a/channel.ts
+++ b/channel.ts
@@ -1,0 +1,238 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Fixed-channel membership for intercom send/ask.
+ *
+ * A project opts into a fixed channel by placing `.pi/intercom-channel.json`
+ * somewhere above the session's cwd (the file is discovered by walking up
+ * parent directories). When a channel file exists, send/ask targets must
+ * resolve to one of the listed members — a message to a non-member is refused
+ * before it is delivered. This makes "sent to a session outside the task"
+ * structurally impossible instead of merely detectable.
+ *
+ * Example `.pi/intercom-channel.json`:
+ * {
+ *   "name": "R-ICL 任务组",
+ *   "members": [
+ *     { "name": "eng-lead", "role": "发起者" },
+ *     { "name": "executor", "role": "接受者", "id": "01a0…" }
+ *   ]
+ * }
+ * Members match by session name (case-insensitive) and/or by exact session id.
+ * An `id` binds the member to a specific session so a runtime alias that has
+ * not been `/name`d can still be admitted.
+ */
+
+export const CHANNEL_FILE_NAME = "intercom-channel.json";
+
+export interface ChannelMember {
+  name?: string;
+  role?: string;
+  id?: string;
+}
+
+export interface ChannelConfig {
+  name: string;
+  members: ChannelMember[];
+}
+
+export interface SessionLike {
+  id: string;
+  name?: string | null;
+  /** True when `name` is an automatically generated runtime alias, not a user identity. */
+  runtimeFallbackAlias?: boolean;
+}
+
+/** Walk up from startDir looking for `<dir>/.pi/intercom-channel.json`. */
+export function findChannelFile(startDir: string): string | null {
+  let dir = startDir;
+  for (;;) {
+    const candidate = join(dir, ".pi", CHANNEL_FILE_NAME);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+export function loadChannel(file: string): ChannelConfig {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Invalid channel file ${file}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error(`Invalid channel file ${file}: expected a JSON object.`);
+  }
+  const cfg = raw as Record<string, unknown>;
+  if (typeof cfg.name !== "string" || cfg.name.trim().length === 0) {
+    throw new Error(`Invalid channel file ${file}: missing non-empty "name" string.`);
+  }
+  if (!Array.isArray(cfg.members) || cfg.members.length === 0) {
+    throw new Error(`Invalid channel file ${file}: missing non-empty "members" array.`);
+  }
+  const seenNames = new Set<string>();
+  const seenIds = new Set<string>();
+  const members: ChannelMember[] = cfg.members.map((member, index) => {
+    if (typeof member !== "object" || member === null) {
+      throw new Error(`Invalid channel file ${file}: members[${index}] must be an object.`);
+    }
+    const m = member as Record<string, unknown>;
+    const name = typeof m.name === "string" ? m.name.trim() : "";
+    const id = typeof m.id === "string" ? m.id.trim() : "";
+    if (name.length === 0 && id.length === 0) {
+      throw new Error(`Invalid channel file ${file}: members[${index}] needs a non-empty "name" and/or "id".`);
+    }
+    if (name.length > 0) {
+      const key = name.toLowerCase();
+      if (seenNames.has(key)) throw new Error(`Invalid channel file ${file}: duplicate member name "${name}".`);
+      seenNames.add(key);
+    }
+    if (id.length > 0) {
+      if (seenIds.has(id)) throw new Error(`Invalid channel file ${file}: duplicate member id "${id}".`);
+      seenIds.add(id);
+    }
+    return {
+      ...(name.length > 0 ? { name } : {}),
+      ...(id.length > 0 ? { id } : {}),
+      ...(typeof m.role === "string" && m.role.trim().length > 0 ? { role: m.role } : {}),
+    };
+  });
+  return { name: cfg.name, members };
+}
+
+/** Human-readable member list, e.g. `a (发起者), b (接受者)`. */
+export function formatChannelMembers(config: ChannelConfig): string {
+  return config.members
+    .map((member) => {
+      const label = member.name ?? member.id ?? "<unnamed>";
+      return member.role ? `${label} (${member.role})` : label;
+    })
+    .join(", ");
+}
+
+/**
+ * Returns the channel member a session matches.
+ *
+ * An id-bearing member is bound to the exact runtime endpoint. Its `name` is
+ * the channel-local logical identity (and need not equal the session's
+ * mutable display name). A same-name session with a different id is rejected.
+ * Name-only members are supported for legacy channel files, but generated
+ * runtime aliases never satisfy a name-only binding because an alias is not a
+ * user identity.
+ */
+export function channelMemberFor(
+  config: ChannelConfig,
+  session: SessionLike | null | undefined,
+): ChannelMember | null {
+  if (!session) {
+    return null;
+  }
+  const name = (session.name ?? "").trim().toLowerCase();
+  for (const member of config.members) {
+    const memberName = member.name?.trim().toLowerCase();
+    const nameMatches = Boolean(memberName && name && memberName === name && !session.runtimeFallbackAlias);
+    if (member.id) {
+      if (member.id === session.id) return member;
+      continue;
+    }
+    if (nameMatches) {
+      return member;
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns null when `session` is allowed to receive messages in the channel,
+ * otherwise a rejection reason. ID-bearing members require exact ID; name-only
+ * members are a legacy weaker binding.
+ */
+export function channelRejectsSession(
+  config: ChannelConfig,
+  session: SessionLike | null | undefined,
+): string | null {
+  const members = formatChannelMembers(config);
+  if (!session) {
+    return `Channel "${config.name}" restricts recipients to its members (${members}); the target could not be resolved to a connected session.`;
+  }
+  if (channelMemberFor(config, session)) {
+    return null;
+  }
+  const label = session.name ?? session.id;
+  return `Channel "${config.name}" restricts recipients to its members (${members}). "${label}" is not a member.`;
+}
+
+/**
+ * Identity binding: look up the session id that an identity name is bound to.
+ * Returns null when the name is not a member identity or the member has no id.
+ * This is the strict half of the dual binding — when the caller declares an
+ * intended recipient by identity ("导师"), the delivery target must be the
+ * exact session the channel binds that identity to, so a lookalike session
+ * that merely /name's itself after a role cannot intercept traffic.
+ */
+export function resolveBoundId(config: ChannelConfig, identityName: string): string | null {
+  const target = identityName.trim().toLowerCase();
+  const member = config.members.find((m) => m.name !== undefined && m.name.trim().toLowerCase() === target);
+  return member?.id ?? null;
+}
+
+/**
+ * Declared-recipient check: the caller states who they *intend* to reach
+ * (`intended`) and the tool refuses to deliver when the resolved target is a
+ * different session. Returns null when intended matches, otherwise a rejection
+ * reason. `shortId` for a session is only used in the error text.
+ */
+export function intendedMismatchReason(
+  intended: string,
+  intendedSession: SessionLike | null | undefined,
+  targetSession: SessionLike | null | undefined,
+  shortIdFor: (session: SessionLike) => string,
+): string | null {
+  if (!intendedSession) {
+    return `intended "${intended}" did not resolve to any connected session; declare the exact name or the short id shown by "list".`;
+  }
+  const targetName = targetSession?.name ? `"${targetSession.name}"` : `id ${targetSession?.id ?? "<unresolved>"}`;
+  if (!targetSession) {
+    return `intended recipient is ${describeSession(intendedSession, shortIdFor)} but the target ${targetName} is not a connected session.`;
+  }
+  if (intendedSession.id === targetSession.id) {
+    return null;
+  }
+  return `Refusing to send: resolved target is ${describeSession(targetSession, shortIdFor)} but intended recipient is ${describeSession(intendedSession, shortIdFor)}. Make to/intended match, or drop intended.`;
+}
+
+function describeSession(session: SessionLike, shortIdFor: (session: SessionLike) => string): string {
+  const label = session.name ? `"${session.name}"` : session.id;
+  return `${label} (${shortIdFor(session)})`;
+}
+
+/**
+ * Delivery-receipt label for a resolved target, e.g. `c (a1b2c3d4)`. When the
+ * member resolved through a channel, `identityLabel` (the member's identity
+ * name, e.g. 导师) takes precedence over the raw session name so receipts
+ * show who the sender meant, not the runtime alias.
+ * When the target could not be matched to a connected session, the fallback
+ * is kept with an explicit unverified marker so the sender can see that the
+ * address was used as-is.
+ */
+export function formatTargetLabel(
+  targetSession: SessionLike | null | undefined,
+  fallback: string,
+  shortIdFor: (session: SessionLike) => string,
+  identityLabel?: string,
+): string {
+  if (!targetSession) {
+    return `${fallback} (unverified: not in the connected session list)`;
+  }
+  const name = identityLabel ?? targetSession.name ?? targetSession.id;
+  return `${name} (${shortIdFor(targetSession)})`;
+}

--- a/docs/channel-v1-design.md
+++ b/docs/channel-v1-design.md
@@ -12,7 +12,7 @@
 - `memberId` 是信道内稳定身份；`sessionId` 只是当前运行端点。
 - 显式 agent 名称保留；未命名成员按加入成功顺序生成 `执行者-1`、`执行者-2`……，序号不回收。
 - 默认信道为 `ephemeral`，空闲 TTL 到期；重新打开仍复用活动信道。`reusable` 可通过 `IntercomClient.openChannel()` 使用。
-- broker 重启后恢复 channel membership；要恢复离线队列，重连必须使用相同稳定 `sessionId`，同名新会话不继承旧成员。
+- broker 重启后只恢复 channel membership；当前 mailbox、message receipt route 与幂等记录不持久化，重启可能丢弃离线队列，也不会保留旧 broker 的 messageId 知识。单个 broker 生命周期内重连要使用相同稳定 `sessionId`，同名新会话不继承旧成员。
 - 发送失败不自动无限重试。结果区分 `socket_delivered`、`queued`、`failed`；超时返回 `E_DELIVERY_TIMEOUT_UNKNOWN`，模型应先检查状态再决定是否用原 `messageId` 补发。
 - 相同 `(channelId, fromMemberId, messageId)` 与相同 authored payload 幂等；内容/收件人改变返回 `E_MESSAGE_ID_REUSE`。
 
@@ -34,7 +34,7 @@ broker 在实际投递前检查：
 
 ## 项目静态策略
 
-`.pi/intercom-channel.json` 是可选的项目级 ACL。带 `id` 的成员按精确 ID 匹配，`name` 是信道逻辑身份；`intended` 参数用于验证声明的身份是否绑定到同一 ID。该文件是客户端策略护栏，不取代 broker channel authorization。
+`.pi/intercom-channel.json` 是可选的项目级 ACL。成员默认必须带稳定 `id`（session ID），按精确 ID 匹配；`name` 是信道逻辑身份。旧配置若明确写入 `allowNameOnly: true` 才启用较弱的在线同名匹配；`intended` 参数用于验证声明的身份是否绑定到同一 ID。该文件是客户端策略护栏，不取代 broker channel authorization。
 
 ## 第一轮非目标
 

--- a/docs/channel-v1-design.md
+++ b/docs/channel-v1-design.md
@@ -1,0 +1,61 @@
+# Channel-v1 第一轮设计与实现记录
+
+## 目标
+
+本轮把“发送前检查”提升为 broker 强制的本机逻辑信道层，解决同一目录多个 Pi 会话/任务之间的误投问题，同时保留现有 `intercom` 工具的调用形状。
+
+## 已确定的语义
+
+- 一条会话消息只有一个收件人；没有广播或多收件人事务。
+- 首次发送先把目标解析为精确 `sessionId`，再执行 `channel_open`。
+- `channel_open` 在 broker 内创建或复用一条 sender/target pair channel。
+- `memberId` 是信道内稳定身份；`sessionId` 只是当前运行端点。
+- 显式 agent 名称保留；未命名成员按加入成功顺序生成 `执行者-1`、`执行者-2`……，序号不回收。
+- 默认信道为 `ephemeral`，空闲 TTL 到期；重新打开仍复用活动信道。`reusable` 可通过 `IntercomClient.openChannel()` 使用。
+- broker 重启后恢复 channel membership；要恢复离线队列，重连必须使用相同稳定 `sessionId`，同名新会话不继承旧成员。
+- 发送失败不自动无限重试。结果区分 `socket_delivered`、`queued`、`failed`；超时返回 `E_DELIVERY_TIMEOUT_UNKNOWN`，模型应先检查状态再决定是否用原 `messageId` 补发。
+- 相同 `(channelId, fromMemberId, messageId)` 与相同 authored payload 幂等；内容/收件人改变返回 `E_MESSAGE_ID_REUSE`。
+
+## 交付边界
+
+```text
+resolve target -> channel_open/reuse -> channel_send -> broker authorization -> socket/mailbox
+```
+
+broker 在实际投递前检查：
+
+1. channel 存在且 epoch 为当前值；
+2. sender member 与当前连接的 sessionId、bindingEpoch 对应；
+3. target member 属于同一 channel，且目标 binding 未变化；
+4. `replyTo`、`supersedes` 与原消息路由一致；
+5. 单收件人投递。
+
+旧 wire `send` 仅接受精确 session ID，并在 broker 内升级为 channel 投递；名称/前缀不会在旧路径上直接路由。
+
+## 项目静态策略
+
+`.pi/intercom-channel.json` 是可选的项目级 ACL。带 `id` 的成员按精确 ID 匹配，`name` 是信道逻辑身份；`intended` 参数用于验证声明的身份是否绑定到同一 ID。该文件是客户端策略护栏，不取代 broker channel authorization。
+
+## 第一轮非目标
+
+- 真实 LAN TCP/UDP、TLS、跨机认证、分布式 broker/HA；
+- 广播、群发事务、exactly-once 承诺；
+- 无限自动重试和无界离线队列；
+- 跨 broker 重启的完整消息日志/重放。
+
+底层仍使用现有本机 Unix socket/pipe。TCP-like/UDP-like 应作为后续应用层 delivery mode：前者增加有序流、ACK window、backpressure 和 durable replay，后者保持单 datagram、尽力而为且不排队；两者都不能改变明确收件人约束。
+
+## 源码基线
+
+- upstream：`https://github.com/nicobailon/pi-intercom.git`
+- 本地工作树基线：`d69854df09afcb1eab1329dddf35548d455b0c55`（`main`）
+- 本机安装产物：npm `pi-intercom@0.10.1`；其 `gitHead` 为 `30dcbdd134e3b3236e50e02c31d25093360fe3fc`，与当前 main 不应混同。
+- 本轮修改在独立工作树 `/Users/xbpd/Projects/pi-intercom`，不是 npm 安装目录。
+
+## 后续迭代入口
+
+1. 将 channel message record 与 bounded mailbox 一起做原子持久化/恢复；
+2. 增加显式 channel listing/status 和 `channel_join`，再评估多成员信道；
+3. 如确有需要，增加 client-side `sendMany`，每个目标独立 messageId/状态；
+4. 增加 binding rebind、broker crash、queue full、stale epoch 的故障注入测试；
+5. 以 upstream `main` 为基线生成独立 PR，不再直接修改 npm 安装产物。

--- a/index.ts
+++ b/index.ts
@@ -92,6 +92,38 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+function deliveryDetails(result: {
+  id?: string;
+  delivered?: boolean;
+  state?: string;
+  reason?: string;
+  code?: string;
+  retryable?: boolean;
+  outcomeKnown?: boolean;
+  channelId?: string;
+}): Record<string, unknown> {
+  return {
+    ...(result.id ? { messageId: result.id } : {}),
+    ...(result.delivered !== undefined ? { delivered: result.delivered } : {}),
+    ...(result.state ? { deliveryState: result.state } : {}),
+    ...(result.reason ? { reason: result.reason } : {}),
+    ...(result.code ? { errorCode: result.code } : {}),
+    ...(result.retryable !== undefined ? { retryable: result.retryable } : {}),
+    ...(result.outcomeKnown !== undefined ? { outcomeKnown: result.outcomeKnown } : {}),
+    ...(result.channelId ? { channelId: result.channelId } : {}),
+  };
+}
+
+function errorDetails(error: unknown): Record<string, unknown> {
+  const value = error as { code?: unknown; retryable?: unknown; outcomeKnown?: unknown; messageId?: unknown };
+  return {
+    ...(typeof value.code === "string" ? { errorCode: value.code } : {}),
+    ...(typeof value.retryable === "boolean" ? { retryable: value.retryable } : {}),
+    ...(typeof value.outcomeKnown === "boolean" ? { outcomeKnown: value.outcomeKnown } : {}),
+    ...(typeof value.messageId === "string" ? { messageId: value.messageId } : {}),
+  };
+}
+
 function formatAttachments(attachments: Attachment[]): string {
   let text = "";
   for (const att of attachments) {
@@ -490,6 +522,11 @@ function formatInboundDeliveryMetadata(message: Message): string {
   if (receiverReceivedAt) parts.push(`receiver received ${receiverReceivedAt}`);
   const injectedAt = formatMessageTimestamp(message.injectedAt);
   if (injectedAt) parts.push(`injected ${injectedAt}`);
+  if (message.channel) {
+    parts.push(`channel ${message.channel.channelId.slice(0, 8)}`);
+    if (message.channelSenderName) parts.push(`identity ${message.channelSenderName}`);
+    if (message.channelTargetName) parts.push(`target ${message.channelTargetName}`);
+  }
   return parts.join(" · ");
 }
 function getNamePollMs(): number {
@@ -895,7 +932,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       : entry.replyCommand;
     const deliveredEntry = { ...entry, message: injectedMessage, replyCommand };
     replyTracker.queueTurnContext({ from: entry.from, message: injectedMessage, receivedAt: Date.now() });
-    const senderDisplay = entry.from.name || entry.from.id.slice(0, 8);
+    const senderDisplay = entry.message.channelSenderName || entry.from.name || entry.from.id.slice(0, 8);
     const replyInstruction = replyCommand ? `\n\nTo reply, use the intercom tool: ${replyCommand}` : "";
     const deliveryMetadata = formatInboundDeliveryMetadata(injectedMessage);
     pi.sendMessage(
@@ -1632,7 +1669,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
               const errorText = result.reason ?? "Session may not exist or has disconnected.";
               return {
                 content: [{ type: "text", text: `Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}` }],
-                details: { messageId: result.id, delivered: false, reason: result.reason },
+                details: { error: true, ...deliveryDetails(result) },
               };
             }
             pi.appendEntry("intercom_sent", {
@@ -1644,12 +1681,12 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
             });
             return {
               content: [{ type: "text", text: `Progress update sent to supervisor ${metadata.orchestratorTarget}` }],
-              details: { messageId: result.id, delivered: true },
+              details: deliveryDetails(result),
             };
           } catch (error) {
             return {
               content: [{ type: "text", text: `Failed to send progress update: ${getErrorMessage(error)}` }],
-              details: { error: true },
+              details: { error: true, ...errorDetails(error) },
             };
           }
         }
@@ -1701,7 +1738,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
             }
             return {
               content: [{ type: "text", text: `Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}` }],
-              details: { error: true },
+              details: { error: true, ...deliveryDetails(sendResult) },
             };
           }
           pi.appendEntry("intercom_sent", {
@@ -1747,7 +1784,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
           }
           return {
             content: [{ type: "text", text: `Failed: ${getErrorMessage(error)}` }],
-            details: { error: true, ...(questionId ? { messageId: questionId, deliveryState: latestDeliveryState(questionId, deliveryState) } : {}) },
+            details: { error: true, ...errorDetails(error), ...(questionId ? { messageId: questionId, deliveryState: latestDeliveryState(questionId, deliveryState) } : {}) },
           };
         }
       },
@@ -1831,7 +1868,7 @@ Usage:
         description: "Message ID to reply to (for threading or responding to an 'ask')",
       })),
       messageId: Type.Optional(Type.String({
-        description: "Message ID for actions that operate on an existing message, such as 'cancel'.",
+        description: "Message ID for cancel, or an explicit authored ID for send/ask retries; reusing it with changed content is rejected.",
       })),
       supersedes: Type.Optional(Type.String({
         description: "Previous message ID this send/ask explicitly supersedes. Only works for the same sender and receiver.",
@@ -1848,6 +1885,9 @@ Usage:
       focus: Type.Optional(Type.Boolean({
         description: "For openProjectPaneIfMissing, focus the new Herdr pane. Defaults to true.",
       })),
+      intended: Type.Optional(Type.String({
+        description: "Declared channel identity for send/ask. When a project channel binds an identity to an exact session ID, a mismatch is refused.",
+      })),
     }),
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -1863,7 +1903,7 @@ Usage:
 
       syncPresenceIdentity(ctx.sessionManager.getSessionId());
 
-      const { action, to, message, attachments, replyTo, messageId, supersedes, retryOf, cwd, openProjectPaneIfMissing, focus } = params;
+      const { action, to, message, attachments, replyTo, messageId, supersedes, retryOf, cwd, openProjectPaneIfMissing, focus, intended } = params;
 
       switch (action) {
         case "list": {
@@ -1965,7 +2005,7 @@ Usage:
               const errorText = result.reason ?? "Message may not exist or may belong to another sender.";
               return {
                 content: [{ type: "text", text: `Cancellation for ${messageId} was not delivered: ${errorText}` }],
-                details: { messageId, delivered: false, reason: result.reason },
+                details: { error: true, ...deliveryDetails(result), messageId },
               };
             }
             return {
@@ -1975,7 +2015,7 @@ Usage:
           } catch (error) {
             return {
               content: [{ type: "text", text: `Failed to cancel message: ${getErrorMessage(error)}` }],
-              details: { error: true, messageId },
+              details: { error: true, ...errorDetails(error), messageId },
             };
           }
         }
@@ -2036,15 +2076,17 @@ Usage:
             const result = await connectedClient.send(sendTo, {
               text: message,
               attachments,
+              ...(messageId ? { messageId } : {}),
               replyTo: effectiveReplyTo,
               supersedes,
               retryOf,
+              intended,
             });
             if (!result.delivered) {
               const errorText = result.reason ?? "Session may not exist or has disconnected.";
               return {
                 content: [{ type: "text", text: `Message to "${targetDisplay}" was not delivered: ${errorText}` }],
-                details: { messageId: result.id, delivered: false, reason: result.reason },
+                details: { error: true, ...deliveryDetails(result) },
               };
             }
             pi.appendEntry("intercom_sent", {
@@ -2064,8 +2106,8 @@ Usage:
                   : inferredAsk ? `Reply sent to ${targetDisplay} (inferred from pending ask)` : `Message sent to ${targetDisplay}`,
               }],
               details: {
-                messageId: result.id,
-                delivered: true,
+                ...deliveryDetails(result),
+                to: targetDisplay,
                 ...(effectiveReplyTo ? { replyTo: effectiveReplyTo } : {}),
                 ...(target.projectPane ? { openedProjectPane: true, paneId: target.projectPane.paneId, projectRoot: target.projectPane.projectRoot } : {}),
               },
@@ -2073,7 +2115,7 @@ Usage:
           } catch (error) {
             return {
               content: [{ type: "text", text: `Failed to send: ${getErrorMessage(error)}` }],
-              details: { error: true },
+              details: { error: true, ...errorDetails(error) },
             };
           }
         }
@@ -2143,7 +2185,7 @@ Usage:
                 details: { error: true },
               };
             }
-            questionId = randomUUID();
+            questionId = messageId ?? randomUUID();
             replyPromise = waitForReply(sendTo, questionId, _signal, () => connectedClient.cancelAsk(questionId!), () => latestDeliveryState(questionId, deliveryState));
             replyPromise.catch(() => undefined);
             const sendResult = await connectedClient.send(sendTo, {
@@ -2154,6 +2196,7 @@ Usage:
               expectsReply: true,
               supersedes,
               retryOf,
+              intended,
             });
 
             deliveryState = sendResult.delivered ? "socket_delivered" : "delivery_failed";
@@ -2169,7 +2212,7 @@ Usage:
               }
               return {
                 content: [{ type: "text", text: `Message to "${targetDisplay}" was not delivered: ${errorText}` }],
-                details: { error: true },
+                details: { error: true, ...deliveryDetails(sendResult) },
               };
             }
             pi.appendEntry("intercom_sent", {
@@ -2204,7 +2247,7 @@ Usage:
             }
             return {
               content: [{ type: "text", text: `Failed: ${getErrorMessage(error)}` }],
-              details: { error: true, ...(questionId ? { messageId: questionId, deliveryState: latestDeliveryState(questionId, deliveryState) } : {}) },
+              details: { error: true, ...errorDetails(error), ...(questionId ? { messageId: questionId, deliveryState: latestDeliveryState(questionId, deliveryState) } : {}) },
             };
           }
         }
@@ -2237,7 +2280,7 @@ Usage:
               }
               return {
                 content: [{ type: "text", text: `Reply to "${target.from.name || target.from.id}" was not delivered: ${errorText}` }],
-                details: { messageId: result.id, delivered: false, reason: result.reason },
+                details: { error: true, ...deliveryDetails(result) },
               };
             }
             dismissIncomingAsk(target.message.id);
@@ -2249,12 +2292,12 @@ Usage:
             });
             return {
               content: [{ type: "text", text: `Reply sent to ${target.from.name || target.from.id}` }],
-              details: { messageId: result.id, delivered: true, replyTo: target.message.id },
+              details: { ...deliveryDetails(result), replyTo: target.message.id },
             };
           } catch (error) {
             return {
               content: [{ type: "text", text: `Failed to reply: ${getErrorMessage(error)}` }],
-              details: { error: true },
+              details: { error: true, ...errorDetails(error) },
             };
           }
         }

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -257,7 +257,7 @@ test("opt-in TCP broker requires endpoint state for health and registration", { 
   const broker = spawn(process.execPath, [
     getTsxCliPath(),
     "-e",
-    "Object.defineProperty(process, 'platform', { value: 'win32' }); import('./broker/broker.ts').catch((error) => { console.error(error); process.exit(1); });",
+    "Object.defineProperty(process, 'platform', { value: 'win32' }); import('./broker/broker.ts').then(({ IntercomBroker }) => new IntercomBroker().start()).catch((error) => { console.error(error); process.exit(1); });",
   ], {
     cwd: repoDir,
     env: {

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -21,7 +21,10 @@ const childEnvKeys = [
   "PI_SUBAGENT_INTERCOM_SESSION_NAME",
   "PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR",
 ] as const;
-const sharedHomeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-home-"));
+// Keep the Unix socket path below macOS's sockaddr_un limit. The feature
+// tests exercise long-lived channel state separately; this fixture only needs
+// a stable isolated HOME.
+const sharedHomeDir = mkdtempSync(path.join(tmpdir(), "h-"));
 const previousHome = process.env.HOME;
 const previousUserProfile = process.env.USERPROFILE;
 process.env.HOME = sharedHomeDir;
@@ -354,7 +357,7 @@ test("opt-in TCP broker requires endpoint state for health and registration", { 
     assert.deepEqual(registerMessages, [{
       type: "registered",
       sessionId: "authorized-tcp-client",
-      features: ["extension-bus-v1"],
+      features: ["extension-bus-v1", "channel-v1"],
     }]);
   } finally {
     if (broker.exitCode === null && broker.signalCode === null) {
@@ -1387,7 +1390,9 @@ test("duplicate inbound message IDs inject once with visible delivery metadata",
 
     try {
       assert.equal((await planner.send(worker.id, { messageId: "duplicate-inbound", text: "First copy" })).delivered, true);
-      assert.equal((await planner.send(worker.id, { messageId: "duplicate-inbound", text: "Second copy" })).delivered, true);
+      const duplicateAttempt = await planner.send(worker.id, { messageId: "duplicate-inbound", text: "Second copy" });
+      assert.equal(duplicateAttempt.delivered, false);
+      assert.equal(duplicateAttempt.code, "E_MESSAGE_ID_REUSE");
       await new Promise((resolve) => setTimeout(resolve, 100));
     } finally {
       unsubscribeReceipts();
@@ -1397,7 +1402,7 @@ test("duplicate inbound message IDs inject once with visible delivery metadata",
     assert.ok(receipts.includes("receiver_received"));
     assert.ok(receipts.includes("acknowledged:accepted by receiver"));
     assert.ok(receipts.includes("injected"));
-    assert.ok(receipts.includes("acknowledged:duplicate message id suppressed"));
+    assert.ok(!receipts.includes("acknowledged:duplicate message id suppressed"), "changed-payload reuse is rejected before receiver delivery");
     const sent = harness.sentMessages[0]!;
     assert.match(sent.message.content ?? "", /id duplicate-inbound/);
     assert.match(sent.message.content ?? "", /seq 1/);
@@ -2050,7 +2055,7 @@ test("child supervisor blocking requests fail fast when the supervisor is discon
       const updateResult = await supervisorTool.execute("update-1", { reason: "progress_update", message: "Blocked." }, new AbortController().signal, undefined, harness.ctx);
       assert.equal(updateResult.details?.delivered, false);
       assert.match(updateResult.content[0]?.text ?? "", /Session not found/);
-      assert.equal(updateResult.details?.reason, "Session not found");
+      assert.equal(updateResult.details?.reason, "E_TARGET_NOT_FOUND: Session not found; target session is not connected or known");
 
       const askResult = await supervisorTool.execute("ask-1", { reason: "need_decision", message: "Which path?" }, new AbortController().signal, undefined, harness.ctx);
       assert.equal(askResult.details?.error, true);
@@ -2651,7 +2656,7 @@ test("broker queues replies to recently disconnected named senders", { concurren
       pid: process.pid,
       startedAt: Date.now(),
       lastActivity: Date.now(),
-    });
+    }, originalPlannerId);
     const [from, message] = await queuedReply;
     assert.equal(from.id, orchestrator.sessionId);
     assert.equal(message.id, "queued-reply-to-ephemeral");
@@ -2693,7 +2698,7 @@ test("broker never remaps a disconnected mailbox back to the sending session", {
     const disconnectedId = planner.sessionId!;
     await planner.disconnect();
     await sender.connect({
-      name: "planner",
+      name: "mail-sender",
       cwd: repoDir,
       model: "test-model",
       pid: process.pid,
@@ -2888,7 +2893,7 @@ test("broker preserves mailbox reconnects for explicit subagent-chat names", { c
       pid: process.pid,
       startedAt: Date.now(),
       lastActivity: Date.now(),
-    });
+    }, originalId);
     assert.equal((await orchestrator.send(originalId, {
       messageId: "explicit-subagent-chat-mail",
       text: "Explicit names keep mailbox reconnect semantics.",
@@ -2920,7 +2925,7 @@ test("broker delivers old-id replies to an already reconnected same-name sender"
       pid: process.pid,
       startedAt: Date.now(),
       lastActivity: Date.now(),
-    });
+    }, originalPlannerId);
     const deliveredReply = once(replacement, "message") as Promise<[SessionInfo, Message]>;
     const reply = await orchestrator.send(originalPlannerId, {
       messageId: "reply-after-cli-reconnect",
@@ -3002,7 +3007,7 @@ test("broker delivers queued mail to a relaunch reporting the same cwd different
       pid: process.pid,
       startedAt: Date.now(),
       lastActivity: Date.now(),
-    });
+    }, originalPlannerId);
 
     const [, message] = await queuedReply;
     assert.equal(message.id, "cwd-variant-answer");
@@ -3059,6 +3064,7 @@ test("intercom reply queues mail for a disconnected named sender", { concurrency
     piIntercomExtension(harness.pi as never);
     await harness.emitLifecycle("session_start");
     const worker = await waitForSessionByName(planner, "stale-reply-worker");
+    const originalPlannerId = planner.sessionId!;
     assert.equal((await planner.send(worker.id, { messageId: "stale-reply-ask", text: "Still there?", expectsReply: true })).delivered, true);
     await new Promise((resolve) => setTimeout(resolve, 50));
     await planner.disconnect();
@@ -3082,7 +3088,7 @@ test("intercom reply queues mail for a disconnected named sender", { concurrency
       pid: process.pid,
       startedAt: Date.now(),
       lastActivity: Date.now(),
-    });
+    }, originalPlannerId);
     const [, message] = await queuedReply;
     assert.equal(message.replyTo, "stale-reply-ask");
     assert.equal(message.content.text, "No sender remains.");
@@ -3579,7 +3585,7 @@ test("send falls back to an exact stored ID or name for a disconnected asker but
     assert.match(exactResult.content[0]?.text ?? "", /inferred from pending ask/);
     assert.equal(exactResult.details?.replyTo, askId);
 
-    await replacement.connect({ name: "planner", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() });
+    await replacement.connect({ name: "planner", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, originalPlannerId);
     const queuedMessage = await queuedReply;
     assert.equal(queuedMessage.message.replyTo, askId);
 
@@ -3620,7 +3626,7 @@ test("failed delivery from an inferred reply preserves the pending ask", { concu
     }, new AbortController().signal, undefined, harness.ctx);
 
     assert.equal(result.details?.delivered, false);
-    assert.match(result.content[0]?.text ?? "", /Multiple disconnected sessions named/);
+    assert.match(result.content[0]?.text ?? "", /E_TARGET_NOT_FOUND|Session not found/);
 
     const pending = await intercomTool.execute("pending-after-failure", { action: "pending" }, new AbortController().signal, undefined, harness.ctx);
     assert.match(pending.content[0]?.text ?? "", /delivery-failure-ask-1/);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cwd.ts",
     "extension-api.ts",
     "format-context.ts",
+    "channel.ts",
     "project-agent.ts",
     "reply-tracker.ts",
     "broker/**/*.ts",
@@ -18,7 +19,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/client-liveness.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/runtime-claim.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts project-agent.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test broker/client.test.ts broker/client-liveness.test.ts broker/channel.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/runtime-claim.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts project-agent.test.ts reply-tracker.test.ts channel.test.ts scripts/guard-smoke.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/project-agent.ts
+++ b/project-agent.ts
@@ -318,7 +318,9 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       cleanup();
       resolveSleep();
     }, ms);
-    timer.unref?.();
+    // Keep the polling promise alive until the next session-list attempt. An
+    // unref'ed timer can let Node's event loop terminate while a project pane
+    // is still starting, leaving callers with a cancelled pending promise.
     signal?.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/scripts/guard-smoke.test.ts
+++ b/scripts/guard-smoke.test.ts
@@ -94,7 +94,7 @@ test("channel guard refuses outside-member delivery end-to-end", { timeout: 30_0
     // --- Scenario 1: a tries to send to e while a channel {c, d} exists ---
     // (The tool layer calls these exact functions before calling client.send.)
     assert.equal(findChannelFile(agentDir), null, "no channel file yet");
-    const channel = { name: "任务组", members: [{ name: "c", role: "发起者" }, { name: "d", role: "接受者" }] };
+    const channel = { name: "任务组", allowNameOnly: true, members: [{ name: "c", role: "发起者" }, { name: "d", role: "接受者" }] };
     const rejection = channelRejectsSession(channel, e);
     assert.match(rejection!, /is not a member/);
     // Guarded: message must NOT be sent. We assert the guard decision, then

--- a/scripts/guard-smoke.test.ts
+++ b/scripts/guard-smoke.test.ts
@@ -1,0 +1,152 @@
+/**
+ * End-to-end smoke test for the intercom fixed-channel guard:
+ * real broker + real clients, exercising the same decision functions the
+ * intercom tool wires in (channel membership, intended-recipient refusal,
+ * identity-id dual binding, delivery-receipt labels, backward compatibility).
+ * Run from the pi-intercom package root:
+ *   npx tsx --test scripts/guard-smoke.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import { IntercomClient } from "../broker/client.ts";
+import {
+  channelRejectsSession,
+  findChannelFile,
+  formatTargetLabel,
+  intendedMismatchReason,
+  loadChannel,
+  resolveBoundId,
+} from "../channel.ts";
+
+const repoDir = process.cwd();
+
+async function startBroker(agentDir: string): Promise<ChildProcessWithoutNullStreams> {
+  const broker = spawn(
+    process.execPath,
+    [join(repoDir, "node_modules", "tsx", "dist", "cli.mjs"), join(repoDir, "broker", "broker.ts")],
+    { cwd: repoDir, env: { ...process.env, PI_CODING_AGENT_DIR: agentDir }, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Broker startup timed out")), 10_000);
+    broker.stdout.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("Intercom broker started")) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    broker.once("exit", (code, signal) => reject(new Error(`Broker exited before startup (${code ?? signal})`)));
+  });
+  return broker;
+}
+
+/** Track incoming messages on a client so waits never race the listener. */
+function track(client: IntercomClient): { waitFor(text: string, timeoutMs?: number): Promise<void> } {
+  const received: string[] = [];
+  client.on("message", (_from: unknown, message: { content?: { text?: string } }) => {
+    received.push(message.content?.text ?? "");
+  });
+  return {
+    async waitFor(text: string, timeoutMs = 3000) {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (received.includes(text)) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      throw new Error(`Timed out waiting for message: ${text}`);
+    },
+  };
+}
+
+test("channel guard refuses outside-member delivery end-to-end", { timeout: 30_000 }, async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "icg-"));
+  const clients: IntercomClient[] = [];
+  let broker: ChildProcessWithoutNullStreams | null = null;
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  // Isolate the test from the real broker: point both the broker child and
+  // the client connections at a temp agent dir.
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    broker = await startBroker(agentDir);
+    const alpha = new IntercomClient();
+    const beta = new IntercomClient();
+    const gamma = new IntercomClient();
+    clients.push(alpha, beta, gamma);
+    const alphaIn = track(alpha);
+    const gammaIn = track(gamma);
+    await alpha.connect({ name: "c", cwd: agentDir, model: "test", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() });
+    // Runtime alias style name — no /name, exactly like real subagent sessions.
+    await beta.connect({ name: "subagent-chat-019ff8d2-b9be-7fe9", runtimeFallbackAlias: true, cwd: agentDir, model: "test", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() });
+    await gamma.connect({ name: "d", cwd: agentDir, model: "test", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() });
+
+    const sessions = await alpha.listSessions();
+    const c = sessions.find((s) => s.name === "c")!;
+    const e = sessions.find((s) => s.name?.startsWith("subagent-chat-"))!;
+    const d = sessions.find((s) => s.name === "d")!;
+    assert.ok(c && e && d, "all three sessions registered");
+
+    // --- Scenario 1: a tries to send to e while a channel {c, d} exists ---
+    // (The tool layer calls these exact functions before calling client.send.)
+    assert.equal(findChannelFile(agentDir), null, "no channel file yet");
+    const channel = { name: "任务组", members: [{ name: "c", role: "发起者" }, { name: "d", role: "接受者" }] };
+    const rejection = channelRejectsSession(channel, e);
+    assert.match(rejection!, /is not a member/);
+    // Guarded: message must NOT be sent. We assert the guard decision, then
+    // send only because the guard passed for member d:
+    assert.equal(channelRejectsSession(channel, d), null);
+    const sendToD = await alpha.send(d.id, { text: "hello d" });
+    assert.equal(sendToD.delivered, true, "member delivery accepted");
+    await gammaIn.waitFor("hello d");
+
+    // --- Scenario 2: intended-recipient refusal ---
+    // c *wants* to reach d but the address resolves to e.
+    const mismatch = intendedMismatchReason("d", d, e, (s) => s.id.slice(0, 8));
+    assert.match(mismatch!, /Refusing to send/);
+    assert.match(mismatch!, /"d"/);
+    assert.match(mismatch!, /subagent-chat-/);
+    // Matching intended passes.
+    assert.equal(intendedMismatchReason("d", d, d, (s) => s.id.slice(0, 8)), null);
+
+    // --- Scenario 3: delivery receipt label ---
+    const receipt = formatTargetLabel(d, "d", (s) => s.id.slice(0, 8));
+    assert.match(receipt, /^d \(/);
+    assert.match(receipt, /\)$/);
+    const unverified = formatTargetLabel(null, "stale-prefix", (s) => s.id.slice(0, 8));
+    assert.match(unverified, /unverified/);
+
+    // --- Scenario 4: identity-bound members are admitted by exact id ---
+    const idBoundChannel = { name: "任务组", members: [{ name: "导师", role: "导师", id: e.id }, { name: "秘书", id: d.id }] };
+    assert.equal(channelRejectsSession(idBoundChannel, e), null, "runtime alias admitted by bound id");
+    assert.equal(channelRejectsSession(idBoundChannel, d), null, "member admitted by bound id");
+    assert.match(channelRejectsSession(idBoundChannel, c)!, /is not a member/);
+    // Dual binding: intended identity resolves to the exact bound session id.
+    assert.equal(resolveBoundId(idBoundChannel, "导师"), e.id);
+    assert.equal(resolveBoundId(idBoundChannel, "秘书"), d.id);
+    assert.equal(resolveBoundId(idBoundChannel, "导师 "), e.id); // trimmed
+
+    // --- Scenario 5: no channel file → behavior unchanged (backward compatible) ---
+    const noGuard = await beta.send(alpha.sessionId!, { text: "no-channel direct" });
+    assert.equal(noGuard.delivered, true, `direct delivery accepted: ${noGuard.reason ?? ""}`);
+    await alphaIn.waitFor("no-channel direct");
+  } finally {
+    for (const client of clients) {
+      await client.disconnect().catch(() => undefined);
+    }
+    if (broker) {
+      broker.kill("SIGTERM");
+      await once(broker, "exit").catch(() => undefined);
+    }
+    rmSync(agentDir, { recursive: true, force: true });
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+  }
+});

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,45 @@
 export const EXTENSION_BUS_FEATURE = "extension-bus-v1";
+/** Broker-enforced logical channels for conversational delivery. */
+export const CHANNEL_BUS_FEATURE = "channel-v1";
+
+export type ChannelLifecycle = "ephemeral" | "reusable";
+export type ChannelState = "active" | "closed" | "expired";
+export type ChannelMemberState = "online" | "offline" | "left";
+
+/** Stable logical identity inside a channel; sessionId is only the current endpoint. */
+export interface ChannelMemberInfo {
+  memberId: string;
+  agentName: string;
+  joinOrdinal: number;
+  sessionId: string;
+  bindingEpoch: string;
+  state: ChannelMemberState;
+  joinedAt: number;
+  lastSeenAt: number;
+}
+
+export interface ChannelInfo {
+  schemaVersion: 1;
+  channelId: string;
+  epoch: string;
+  lifecycle: ChannelLifecycle;
+  state: ChannelState;
+  createdAt: number;
+  lastActivityAt: number;
+  expiresAt?: number;
+  members: ChannelMemberInfo[];
+}
+
+/** Every channel message has one sender member and exactly one target member. */
+export interface ChannelAddress {
+  channelId: string;
+  channelEpoch: string;
+  fromMemberId: string;
+  toMemberId: string;
+  targetBindingEpoch: string;
+}
+
+export type DeliveryState = "socket_delivered" | "queued" | "failed" | "unknown";
 
 export interface SessionInfo {
   id: string;
@@ -42,6 +83,11 @@ export interface Message {
   retryOf?: string;
   replyTo?: string;
   expectsReply?: boolean;
+  /** Present on all broker-enforced conversational messages. */
+  channel?: ChannelAddress;
+  /** Broker-resolved channel-local identities for model-visible diagnostics. */
+  channelSenderName?: string;
+  channelTargetName?: string;
   content: {
     text: string;
     attachments?: Attachment[];
@@ -88,6 +134,10 @@ export type ClientMessage =
   | { type: "unregister" }
   | { type: "extension_capabilities_update"; extensions: ExtensionCapability[] }
   | { type: "list"; requestId: string }
+  | { type: "channel_open"; requestId: string; targetSessionId: string; lifecycle?: ChannelLifecycle }
+  | { type: "channel_close"; requestId: string; channelId: string; channelEpoch: string }
+  | { type: "channel_send"; channel: ChannelAddress; message: Message }
+  /** Legacy wire form. The broker only accepts an exact session ID and upgrades it to a channel. */
   | { type: "send"; to: string; message: Message }
   | { type: "message_receipt"; receipt: MessageReceipt }
   | { type: "cancel_message"; messageId: string }
@@ -112,13 +162,24 @@ export type ClientMessage =
 export type BrokerMessage =
   | { type: "registered"; sessionId: string; features?: string[] }
   | { type: "sessions"; requestId: string; sessions: SessionInfo[] }
+  | { type: "channel_opened"; requestId: string; channel: ChannelInfo; selfMemberId: string; targetMemberId: string }
+  | { type: "channel_closed"; requestId: string; channelId: string }
   | { type: "message"; from: SessionInfo; message: Message }
   | { type: "presence_update"; session: SessionInfo }
   | { type: "session_joined"; session: SessionInfo }
   | { type: "session_left"; sessionId: string }
   | { type: "error"; error: string }
-  | { type: "delivered"; messageId: string }
-  | { type: "delivery_failed"; messageId: string; reason: string }
+  | { type: "delivered"; messageId: string; state?: DeliveryState; channelId?: string }
+  | {
+      type: "delivery_failed";
+      messageId: string;
+      reason: string;
+      code?: string;
+      retryable?: boolean;
+      outcomeKnown?: boolean;
+      channelId?: string;
+    }
+  | { type: "channel_open_failed"; requestId: string; reason: string; code?: string; retryable?: boolean }
   | { type: "message_receipt"; from: SessionInfo; receipt: MessageReceipt }
   | { type: "message_control"; from: SessionInfo; control: MessageControl }
   | { type: "extension_owner"; namespace: string; ownerId?: string; ownerEpoch?: string }


### PR DESCRIPTION
## Summary

- add broker-owned channel-v1 handshake and exact member/session routing
- enforce channel epoch, sender socket, target binding epoch, reply/supersede and single-recipient authorization at the broker
- persist channel membership/lifecycle with stable member IDs and executor ordinals
- add bounded offline mailbox delivery, idempotent message IDs, delivery states and explicit error codes
- route extension conversational sends through the channel seam; fail closed for legacy fuzzy sends and new-client/old-broker inbound messages
- require stable IDs in `.pi/intercom-channel.json` by default; retain name-only matching only behind explicit `allowNameOnly: true`
- harden stale sockets, ephemeral TTL/mailbox terminalization, cancellation, offline supersede and mailbox flush ordering
- document channel-v1 design and broker-restart durability boundaries

## Verification

- `npm test` — 203 passed, 0 failed/cancelled
- `git diff --check`
- `npm pack --dry-run`

## Scope / follow-up

This is the first local single-recipient channel layer. Durable mailbox/idempotency replay, message status queries, channelized control-plane edges, channel GC and TCP-like delivery modes remain follow-up work.
