### PR TITLE
feat: bind intercom sends to endpoint epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ## [Unreleased]
 
 ### Added
+- Added endpoint-bound direct delivery with safe rebound retry and bounded same-message replay protection. Thanks to [@xiangbianpangde](https://github.com/xiangbianpangde) for #106.
 - Added local pending-ask observability records for delivered blocking asks. Thanks to [@bcanvural](https://github.com/bcanvural) for issue #104.
 - Added tmux pane IDs to the roster. Thanks to [@odfalik](https://github.com/odfalik) for issue #102 and PR #101.
 

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -18,8 +18,8 @@ import {
 } from "./paths.ts";
 import { getAskTimeoutMs } from "../config.ts";
 import { sameCwd } from "../cwd.ts";
-import { EXTENSION_BUS_FEATURE } from "../types.ts";
-import type { SessionInfo, Message, BrokerMessage, ExtensionCapability, MessageControl } from "../types.ts";
+import { EXACT_SEND_FEATURE, EXTENSION_BUS_FEATURE } from "../types.ts";
+import type { DeliveryState, SessionInfo, Message, BrokerMessage, ExtensionCapability, MessageControl } from "../types.ts";
 import { ExtensionStateManager } from "./extension-state.ts";
 import { assertNoLiveBroker } from "./runtime-claim.ts";
 
@@ -42,6 +42,8 @@ const MESSAGE_RECEIPT_ROUTE_RETENTION_MS = 60 * 60 * 1000;
 const DISCONNECTED_SESSION_RETENTION_MS = 24 * 60 * 60 * 1000;
 const MAILBOX_MESSAGE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const MAX_MAILBOX_MESSAGES = 256;
+const DELIVERY_RECORD_RETENTION_MS = 60 * 60 * 1000;
+const MAX_DELIVERY_RECORDS = 4096;
 
 function serializedPayloadSize(payload: unknown): number | null {
   try {
@@ -58,6 +60,16 @@ interface ConnectedSession {
   lastPresenceBroadcastAt: number;
   ownerOrder: number;
   extensions?: ExtensionCapability[];
+}
+
+interface DeliveryRecord {
+  fingerprint: string;
+  state: DeliveryState;
+  reason?: string;
+  code?: string;
+  retryable: boolean;
+  outcomeKnown: boolean;
+  createdAt: number;
 }
 
 interface NamespaceOwner {
@@ -143,6 +155,7 @@ class IntercomBroker {
   private messageReceiptRoutes = new Map<string, MessageReceiptRoute>();
   private disconnectedSessions = new Map<string, DisconnectedSession>();
   private mailboxMessages: MailboxMessage[] = [];
+  private deliveryRecords = new Map<string, DeliveryRecord>();
   private connections = new Set<net.Socket>();
   private unregisteredConnections = new Set<net.Socket>();
   private server: net.Server;
@@ -392,13 +405,13 @@ class IntercomBroker {
           break;
         }
         if (previous) {
-          this.clearAskEdgesForSession(id);
           this.clearMessageReceiptRoutesForSession(id);
           previous.socket.end();
         }
         setId(id);
         const info: SessionInfo = {
           id,
+          endpointEpoch: randomUUID(),
           ...(session.name !== undefined ? { name: session.name } : {}),
           ...(session.runtimeFallbackAlias !== undefined ? { runtimeFallbackAlias: session.runtimeFallbackAlias } : {}),
           cwd: session.cwd,
@@ -432,7 +445,7 @@ class IntercomBroker {
         writeMessage(socket, {
           type: "registered",
           sessionId: id,
-          features: [EXTENSION_BUS_FEATURE],
+          features: [EXTENSION_BUS_FEATURE, EXACT_SEND_FEATURE],
         });
         this.broadcast({ type: "session_joined", session: info }, id);
 
@@ -535,11 +548,7 @@ class IntercomBroker {
         const messageId = isMessage(message) ? message.id : "unknown";
 
         if (typeof clientMessage.to !== "string" || !isMessage(message)) {
-          writeMessage(socket, {
-            type: "delivery_failed",
-            messageId,
-            reason: "Invalid message format",
-          });
+          this.writeDeliveryFailure(socket, messageId, "Invalid message format", "E_INVALID_MESSAGE");
           break;
         }
 
@@ -548,53 +557,63 @@ class IntercomBroker {
         this.pruneMessageReceiptRoutes(brokerReceivedAt);
         const replyEdge = message.replyTo ? this.askEdges.get(message.replyTo) : undefined;
 
+        const hasTargetId = clientMessage.targetId !== undefined;
+        const hasTargetEpoch = clientMessage.targetEpoch !== undefined;
+        if (
+          hasTargetId !== hasTargetEpoch
+          || (hasTargetId && (typeof clientMessage.targetId !== "string" || clientMessage.targetId.length === 0))
+          || (hasTargetEpoch && (typeof clientMessage.targetEpoch !== "string" || clientMessage.targetEpoch.length === 0))
+        ) {
+          this.writeDeliveryFailure(socket, message.id, "Exact target requires an id and endpoint epoch", "E_INVALID_TARGET");
+          break;
+        }
+        if (hasTargetId && hasTargetEpoch) {
+          const targetId = clientMessage.targetId as string;
+          const targetEpoch = clientMessage.targetEpoch as string;
+          const fingerprint = this.deliveryFingerprint(message, targetId);
+          if (this.replayOrReject(socket, currentId, message.id, fingerprint)) {
+            break;
+          }
+          const exactTarget = this.sessions.get(targetId);
+          if (!exactTarget || exactTarget.info.endpointEpoch !== targetEpoch) {
+            this.recordDelivery(currentId, message.id, fingerprint, "failed", "Target endpoint changed before delivery", "E_TARGET_REBOUND", true);
+            this.writeDeliveryFailure(socket, message.id, "Target endpoint changed before delivery", "E_TARGET_REBOUND", true);
+            break;
+          }
+          clientMessage.to = targetId;
+        }
+
         const targets = this.findSessions(clientMessage.to);
         if (targets.length === 1) {
           if (message.replyTo && !replyEdge) {
-            writeMessage(socket, {
-              type: "delivery_failed",
-              messageId: message.id,
-              reason: "Reply target does not match a pending ask",
-            });
+            this.writeDeliveryFailure(socket, message.id, "Reply target does not match a pending ask", "E_REPLY_TARGET");
             break;
           }
           const fromSession = this.sessions.get(currentId);
           if (!fromSession || fromSession.socket !== socket) {
-            writeMessage(socket, {
-              type: "delivery_failed",
-              messageId: message.id,
-              reason: "Sender session not found",
-            });
+            this.writeDeliveryFailure(socket, message.id, "Sender session not found", "E_SENDER_NOT_FOUND");
             break;
           }
           const target = targets[0];
+          const fingerprint = this.deliveryFingerprint(message, target.info.id);
+          if (this.replayOrReject(socket, currentId, message.id, fingerprint)) {
+            break;
+          }
           if (message.supersedes) {
             const supersededRoute = this.messageReceiptRoutes.get(message.supersedes);
             if (!supersededRoute || supersededRoute.from !== currentId || supersededRoute.to !== target.info.id) {
-              writeMessage(socket, {
-                type: "delivery_failed",
-                messageId: message.id,
-                reason: "Supersede target does not match a previous message from this sender to this receiver",
-              });
+              this.writeDeliveryFailure(socket, message.id, "Supersede target does not match a previous message from this sender to this receiver", "E_SUPERSEDE_TARGET");
               break;
             }
           }
           if (replyEdge && (replyEdge.to !== currentId || replyEdge.from !== target.info.id)) {
-            writeMessage(socket, {
-              type: "delivery_failed",
-              messageId: message.id,
-              reason: "Reply target does not match the pending ask",
-            });
+            this.writeDeliveryFailure(socket, message.id, "Reply target does not match the pending ask", "E_REPLY_TARGET");
             break;
           }
           if (message.expectsReply) {
             const reverseEdge = Array.from(this.askEdges.entries()).find(([edgeMessageId, edge]) => edgeMessageId !== message.replyTo && edge.from === target.info.id && edge.to === currentId);
             if (reverseEdge) {
-              writeMessage(socket, {
-                type: "delivery_failed",
-                messageId: message.id,
-                reason: "Mutual ask refused: target session is already waiting for a reply from this session.",
-              });
+              this.writeDeliveryFailure(socket, message.id, "Mutual ask refused: target session is already waiting for a reply from this session.", "E_MUTUAL_ASK");
               break;
             }
             this.writePendingAskRecord(message, fromSession.info, target.info, brokerReceivedAt);
@@ -617,6 +636,7 @@ class IntercomBroker {
               from: fromSession.info,
               control,
             });
+            this.updateDeliveryRecord(currentId, message.supersedes, "failed", `Superseded by ${message.id}`, "E_DELIVERY_SUPERSEDED");
           }
           writeMessage(target.socket, {
             type: "message",
@@ -628,61 +648,42 @@ class IntercomBroker {
             this.removePendingAskRecord(message.replyTo);
           }
           this.messageReceiptRoutes.set(message.id, { from: currentId, to: target.info.id, createdAt: brokerReceivedAt });
-          writeMessage(socket, { type: "delivered", messageId: message.id });
+          this.recordDelivery(currentId, message.id, fingerprint, "socket_delivered");
+          this.writeDeliverySuccess(socket, message.id, "socket_delivered");
           break;
         }
 
         if (targets.length > 1) {
-          writeMessage(socket, {
-            type: "delivery_failed",
-            messageId: message.id,
-            reason: `Multiple sessions named \"${clientMessage.to}\" are connected. Use the session ID instead.`,
-          });
+          this.writeDeliveryFailure(socket, message.id, `Multiple sessions named \"${clientMessage.to}\" are connected. Use the session ID instead.`, "E_AMBIGUOUS_TARGET");
           break;
         }
 
         const disconnectedTargets = this.findDisconnectedSessions(clientMessage.to);
         if (disconnectedTargets.length === 1) {
           if (message.replyTo && !replyEdge) {
-            writeMessage(socket, {
-              type: "delivery_failed",
-              messageId: message.id,
-              reason: "Reply target does not match a pending ask",
-            });
+            this.writeDeliveryFailure(socket, message.id, "Reply target does not match a pending ask", "E_REPLY_TARGET");
             break;
           }
           const fromSession = this.sessions.get(currentId);
           if (!fromSession || fromSession.socket !== socket) {
-            writeMessage(socket, {
-              type: "delivery_failed",
-              messageId: message.id,
-              reason: "Sender session not found",
-            });
+            this.writeDeliveryFailure(socket, message.id, "Sender session not found", "E_SENDER_NOT_FOUND");
             break;
           }
           const target = disconnectedTargets[0]!.info;
+          const fingerprint = this.deliveryFingerprint(message, target.id);
+          if (this.replayOrReject(socket, currentId, message.id, fingerprint)) {
+            break;
+          }
           if (message.supersedes) {
-            writeMessage(socket, {
-              type: "delivery_failed",
-              messageId: message.id,
-              reason: "Supersede target is not connected",
-            });
+            this.writeDeliveryFailure(socket, message.id, "Supersede target is not connected", "E_SUPERSEDE_TARGET");
             break;
           }
           if (replyEdge && (replyEdge.to !== currentId || replyEdge.from !== target.id)) {
-            writeMessage(socket, {
-              type: "delivery_failed",
-              messageId: message.id,
-              reason: "Reply target does not match the pending ask",
-            });
+            this.writeDeliveryFailure(socket, message.id, "Reply target does not match the pending ask", "E_REPLY_TARGET");
             break;
           }
           if (message.expectsReply) {
-            writeMessage(socket, {
-              type: "delivery_failed",
-              messageId: message.id,
-              reason: "Target session is not currently connected; blocking asks are not queued",
-            });
+            this.writeDeliveryFailure(socket, message.id, "Target session is not currently connected; blocking asks are not queued", "E_TARGET_DISCONNECTED");
             break;
           }
           const liveMailboxTarget = this.findUniqueLiveSessionForDisconnectedSession(target, currentId);
@@ -705,24 +706,17 @@ class IntercomBroker {
             this.askEdges.delete(message.replyTo);
             this.removePendingAskRecord(message.replyTo);
           }
-          writeMessage(socket, { type: "delivered", messageId: message.id });
+          this.recordDelivery(currentId, message.id, fingerprint, liveMailboxTarget ? "socket_delivered" : "queued");
+          this.writeDeliverySuccess(socket, message.id, liveMailboxTarget ? "socket_delivered" : "queued");
           break;
         }
 
         if (disconnectedTargets.length > 1) {
-          writeMessage(socket, {
-            type: "delivery_failed",
-            messageId: message.id,
-            reason: `Multiple disconnected sessions named \"${clientMessage.to}\" can receive queued mail. Use the session ID instead.`,
-          });
+          this.writeDeliveryFailure(socket, message.id, `Multiple disconnected sessions named \"${clientMessage.to}\" can receive queued mail. Use the session ID instead.`, "E_AMBIGUOUS_TARGET");
           break;
         }
 
-        writeMessage(socket, {
-          type: "delivery_failed",
-          messageId: message.id,
-          reason: "Session not found",
-        });
+        this.writeDeliveryFailure(socket, message.id, "Session not found", "E_TARGET_NOT_FOUND");
         break;
       }
 
@@ -760,6 +754,7 @@ class IntercomBroker {
         const queuedIndex = this.mailboxMessages.findIndex(entry => entry.message.id === clientMessage.messageId && entry.from.id === currentId);
         if (queuedIndex >= 0 && sender?.socket === socket) {
           this.mailboxMessages.splice(queuedIndex, 1);
+          this.updateDeliveryRecord(currentId, clientMessage.messageId, "failed", "Sender cancelled the queued delivery", "E_DELIVERY_CANCELLED");
           const edge = this.askEdges.get(clientMessage.messageId);
           if (edge?.from === currentId) {
             this.askEdges.delete(clientMessage.messageId);
@@ -792,6 +787,7 @@ class IntercomBroker {
           this.askEdges.delete(clientMessage.messageId);
           this.removePendingAskRecord(clientMessage.messageId);
         }
+        this.updateDeliveryRecord(currentId, clientMessage.messageId, "failed", "Sender cancelled the delivery", "E_DELIVERY_CANCELLED");
         writeMessage(socket, { type: "delivered", messageId: clientMessage.messageId });
         break;
       }
@@ -935,6 +931,7 @@ class IntercomBroker {
           this.removePendingAskRecord(entry.message.id);
         }
         this.messageReceiptRoutes.delete(entry.message.id);
+        this.updateDeliveryRecord(entry.from.id, entry.message.id, "failed", "Mailbox delivery expired", "E_DELIVERY_EXPIRED");
         this.mailboxMessages.splice(index, 1);
       }
     }
@@ -950,6 +947,7 @@ class IntercomBroker {
         this.removePendingAskRecord(evicted.message.id);
       }
       this.messageReceiptRoutes.delete(evicted.message.id);
+      this.updateDeliveryRecord(evicted.from.id, evicted.message.id, "failed", "Mailbox capacity evicted the delivery", "E_DELIVERY_EVICTED");
     }
     this.mailboxMessages.push({
       from: { ...from },
@@ -957,6 +955,83 @@ class IntercomBroker {
       message: { ...message, brokerReceivedAt },
       queuedAt: brokerReceivedAt,
     });
+  }
+
+  private writeDeliverySuccess(socket: net.Socket, messageId: string, delivery: "socket_delivered" | "queued"): void {
+    writeMessage(socket, { type: "delivered", messageId, delivery, retryable: false, outcomeKnown: true });
+  }
+
+  private writeDeliveryFailure(socket: net.Socket, messageId: string, reason: string, code: string, retryable = false): void {
+    writeMessage(socket, { type: "delivery_failed", messageId, reason, delivery: "failed", code, retryable, outcomeKnown: true });
+  }
+
+  private deliveryFingerprint(message: Message, targetId: string): string {
+    return JSON.stringify({
+      targetId,
+      text: message.content.text,
+      attachments: message.content.attachments,
+      replyTo: message.replyTo,
+      expectsReply: message.expectsReply,
+      supersedes: message.supersedes,
+      retryOf: message.retryOf,
+    });
+  }
+
+  private deliveryRecordKey(fromSessionId: string, messageId: string): string {
+    return JSON.stringify([fromSessionId, messageId]);
+  }
+
+  private replayOrReject(socket: net.Socket, fromSessionId: string, messageId: string, fingerprint: string): boolean {
+    this.pruneDeliveryRecords();
+    const record = this.deliveryRecords.get(this.deliveryRecordKey(fromSessionId, messageId));
+    if (!record) return false;
+    if (record.fingerprint !== fingerprint) {
+      this.writeDeliveryFailure(socket, messageId, "Message id was reused with different authored content", "E_MESSAGE_ID_REUSE");
+      return true;
+    }
+    if (record.code === "E_TARGET_REBOUND" && record.retryable) {
+      return false;
+    }
+    if (record.state === "socket_delivered" || record.state === "queued") {
+      this.writeDeliverySuccess(socket, messageId, record.state);
+    } else {
+      this.writeDeliveryFailure(socket, messageId, record.reason ?? "Previous delivery failed", record.code ?? "E_DELIVERY_FAILED", record.retryable);
+    }
+    return true;
+  }
+
+  private recordDelivery(fromSessionId: string, messageId: string, fingerprint: string, state: DeliveryState, reason?: string, code?: string, retryable = false): void {
+    this.pruneDeliveryRecords();
+    while (this.deliveryRecords.size >= MAX_DELIVERY_RECORDS) {
+      const oldest = this.deliveryRecords.keys().next().value;
+      if (oldest === undefined) break;
+      this.deliveryRecords.delete(oldest);
+    }
+    this.deliveryRecords.set(this.deliveryRecordKey(fromSessionId, messageId), {
+      fingerprint,
+      state,
+      ...(reason ? { reason } : {}),
+      ...(code ? { code } : {}),
+      retryable,
+      outcomeKnown: true,
+      createdAt: Date.now(),
+    });
+  }
+
+  private pruneDeliveryRecords(now = Date.now()): void {
+    for (const [key, record] of this.deliveryRecords) {
+      if (now - record.createdAt > DELIVERY_RECORD_RETENTION_MS) this.deliveryRecords.delete(key);
+    }
+  }
+
+  private updateDeliveryRecord(fromSessionId: string, messageId: string, state: DeliveryState, reason?: string, code?: string): void {
+    const record = this.deliveryRecords.get(this.deliveryRecordKey(fromSessionId, messageId));
+    if (!record) return;
+    record.state = state;
+    record.reason = reason;
+    record.code = code;
+    record.retryable = false;
+    record.outcomeKnown = true;
   }
 
   private flushMailboxForSession(session: ConnectedSession, now = Date.now()): void {
@@ -1003,6 +1078,7 @@ class IntercomBroker {
         to: session.info.id,
         createdAt: entry.message.brokerReceivedAt ?? entry.queuedAt,
       });
+      this.updateDeliveryRecord(entry.from.id, entry.message.id, "socket_delivered");
     }
   }
 

--- a/broker/client.ts
+++ b/broker/client.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.ts";
 import { getBrokerConnectTarget, type BrokerConnectTarget } from "./paths.ts";
 import { isMessage, isMessageControl, isMessageReceipt, isSessionInfo } from "./protocol.ts";
-import { EXTENSION_BUS_FEATURE } from "../types.ts";
+import { EXACT_SEND_FEATURE, EXTENSION_BUS_FEATURE, type DeliveryDetails } from "../types.ts";
 import type {
   Attachment,
   BrokerMessage,
@@ -26,7 +26,7 @@ interface SendOptions {
   retryOf?: string;
 }
 
-interface SendResult {
+export interface SendResult extends DeliveryDetails {
   id: string;
   delivered: boolean;
   reason?: string;
@@ -366,8 +366,8 @@ export class IntercomClient extends EventEmitter {
       }
 
       case "delivered": {
-        const { messageId } = brokerMessage;
-        if (typeof messageId !== "string") {
+        const { messageId, delivery, retryable, outcomeKnown } = brokerMessage;
+        if (typeof messageId !== "string" || (delivery !== undefined && delivery !== "socket_delivered" && delivery !== "queued") || (retryable !== undefined && typeof retryable !== "boolean") || (outcomeKnown !== undefined && typeof outcomeKnown !== "boolean")) {
           throw new Error("Invalid delivered message");
         }
 
@@ -378,13 +378,13 @@ export class IntercomClient extends EventEmitter {
         }
 
         this.pendingSends.delete(messageId);
-        pending.resolve({ id: messageId, delivered: true });
+        pending.resolve({ id: messageId, delivered: true, delivery: delivery as "socket_delivered" | "queued" | undefined ?? "socket_delivered", retryable: retryable as boolean | undefined ?? false, outcomeKnown: outcomeKnown as boolean | undefined ?? true, ...(typeof brokerMessage.code === "string" ? { code: brokerMessage.code } : {}) });
         break;
       }
 
       case "delivery_failed": {
-        const { messageId, reason } = brokerMessage;
-        if (typeof messageId !== "string" || typeof reason !== "string") {
+        const { messageId, reason, delivery, retryable, outcomeKnown } = brokerMessage;
+        if (typeof messageId !== "string" || typeof reason !== "string" || (delivery !== undefined && delivery !== "failed" && delivery !== "unknown") || (retryable !== undefined && typeof retryable !== "boolean") || (outcomeKnown !== undefined && typeof outcomeKnown !== "boolean")) {
           throw new Error("Invalid delivery_failed message");
         }
 
@@ -395,7 +395,7 @@ export class IntercomClient extends EventEmitter {
         }
 
         this.pendingSends.delete(messageId);
-        pending.resolve({ id: messageId, delivered: false, reason });
+        pending.resolve({ id: messageId, delivered: false, reason, delivery: delivery as "failed" | "unknown" | undefined ?? "failed", retryable: retryable as boolean | undefined ?? false, outcomeKnown: outcomeKnown as boolean | undefined ?? true, ...(typeof brokerMessage.code === "string" ? { code: brokerMessage.code } : {}) });
         break;
       }
 
@@ -613,12 +613,12 @@ export class IntercomClient extends EventEmitter {
     });
   }
 
-  send(to: string, options: SendOptions): Promise<SendResult> {
+  async send(to: string, options: SendOptions): Promise<SendResult> {
     let socket: net.Socket;
     try {
       socket = this.requireActiveSocket();
     } catch (error) {
-      return Promise.reject(toError(error));
+      throw toError(error);
     }
     
     const messageId = options.messageId ?? randomUUID();
@@ -636,7 +636,7 @@ export class IntercomClient extends EventEmitter {
       },
     };
 
-    return new Promise((resolve, reject) => {
+    const sendOnce = (targetId?: string, targetEpoch?: string): Promise<SendResult> => new Promise((resolve, reject) => {
       const wrappedResolve = (result: SendResult) => {
         clearTimeout(timeout);
         resolve(result);
@@ -654,13 +654,34 @@ export class IntercomClient extends EventEmitter {
       this.pendingSends.set(messageId, { resolve: wrappedResolve, reject: wrappedReject });
 
       try {
-        writeMessage(socket, { type: "send", to, message });
+        writeMessage(socket, { type: "send", to, message, ...(targetId && targetEpoch ? { targetId, targetEpoch } : {}) });
       } catch (error) {
         clearTimeout(timeout);
         this.pendingSends.delete(messageId);
         reject(toError(error));
       }
     });
+
+    if (!this.supportsFeature(EXACT_SEND_FEATURE) || options.replyTo) {
+      return sendOnce();
+    }
+
+    const resolveTarget = async (): Promise<{ id: string; epoch: string } | null> => {
+      const sessions = await this.listSessions();
+      const byId = sessions.find((session) => session.id === to);
+      const byName = byId ? [] : sessions.filter((session) => session.name?.toLowerCase() === to.toLowerCase());
+      const byPrefix = byId || byName.length > 0 ? [] : sessions.filter((session) => session.id.startsWith(to));
+      const matches = byId ? [byId] : byName.length > 0 ? byName : byPrefix;
+      const target = matches.length === 1 ? matches[0]! : null;
+      return target?.endpointEpoch ? { id: target.id, epoch: target.endpointEpoch } : null;
+    };
+
+    const target = await resolveTarget();
+    if (!target) return sendOnce();
+    const result = await sendOnce(target.id, target.epoch);
+    if (result.code !== "E_TARGET_REBOUND") return result;
+    const reboundTarget = await resolveTarget();
+    return reboundTarget ? sendOnce(reboundTarget.id, reboundTarget.epoch) : result;
   }
 
   cancelMessage(messageId: string): Promise<SendResult> {

--- a/broker/protocol.ts
+++ b/broker/protocol.ts
@@ -124,6 +124,10 @@ export function isSessionInfo(value: unknown): value is SessionInfo {
     return false;
   }
 
+  if (value.endpointEpoch !== undefined && typeof value.endpointEpoch !== "string") {
+    return false;
+  }
+
   if (value.name !== undefined && typeof value.name !== "string") {
     return false;
   }

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import { StringEnum } from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
 import { Type } from "typebox";
 import { Text } from "@earendil-works/pi-tui";
-import { IntercomClient } from "./broker/client.ts";
+import { IntercomClient, type SendResult } from "./broker/client.ts";
 import { spawnBrokerIfNeeded } from "./broker/spawn.ts";
 import { SessionListOverlay } from "./ui/session-list.ts";
 import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
@@ -86,6 +86,18 @@ interface SupervisorInterviewReply {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function deliveryDetails(result: SendResult): Record<string, unknown> {
+  return {
+    messageId: result.id,
+    delivered: result.delivered,
+    delivery: result.delivery,
+    retryable: result.retryable,
+    outcomeKnown: result.outcomeKnown,
+    ...(result.code ? { code: result.code } : {}),
+    ...(result.reason ? { reason: result.reason } : {}),
+  };
 }
 
 function toError(error: unknown): Error {
@@ -1632,7 +1644,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
               const errorText = result.reason ?? "Session may not exist or has disconnected.";
               return {
                 content: [{ type: "text", text: `Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}` }],
-                details: { messageId: result.id, delivered: false, reason: result.reason },
+                details: deliveryDetails(result),
               };
             }
             pi.appendEntry("intercom_sent", {
@@ -2044,7 +2056,7 @@ Usage:
               const errorText = result.reason ?? "Session may not exist or has disconnected.";
               return {
                 content: [{ type: "text", text: `Message to "${targetDisplay}" was not delivered: ${errorText}` }],
-                details: { messageId: result.id, delivered: false, reason: result.reason },
+                details: deliveryDetails(result),
               };
             }
             pi.appendEntry("intercom_sent", {
@@ -2064,8 +2076,7 @@ Usage:
                   : inferredAsk ? `Reply sent to ${targetDisplay} (inferred from pending ask)` : `Message sent to ${targetDisplay}`,
               }],
               details: {
-                messageId: result.id,
-                delivered: true,
+                ...deliveryDetails(result),
                 ...(effectiveReplyTo ? { replyTo: effectiveReplyTo } : {}),
                 ...(target.projectPane ? { openedProjectPane: true, paneId: target.projectPane.paneId, projectRoot: target.projectPane.projectRoot } : {}),
               },
@@ -2156,7 +2167,7 @@ Usage:
               retryOf,
             });
 
-            deliveryState = sendResult.delivered ? "socket_delivered" : "delivery_failed";
+            deliveryState = sendResult.delivery;
             if (!sendResult.delivered) {
               const errorText = sendResult.reason ?? "Session may not exist or has disconnected.";
               rejectReplyWaiter(new Error(`Message to "${targetDisplay}" was not delivered: ${errorText}`));
@@ -2169,7 +2180,7 @@ Usage:
               }
               return {
                 content: [{ type: "text", text: `Message to "${targetDisplay}" was not delivered: ${errorText}` }],
-                details: { error: true },
+                details: { error: true, ...deliveryDetails(sendResult) },
               };
             }
             pi.appendEntry("intercom_sent", {
@@ -2237,7 +2248,7 @@ Usage:
               }
               return {
                 content: [{ type: "text", text: `Reply to "${target.from.name || target.from.id}" was not delivered: ${errorText}` }],
-                details: { messageId: result.id, delivered: false, reason: result.reason },
+                details: deliveryDetails(result),
               };
             }
             dismissIncomingAsk(target.message.id);
@@ -2249,7 +2260,7 @@ Usage:
             });
             return {
               content: [{ type: "text", text: `Reply sent to ${target.from.name || target.from.id}` }],
-              details: { messageId: result.id, delivered: true, replyTo: target.message.id },
+              details: { ...deliveryDetails(result), replyTo: target.message.id },
             };
           } catch (error) {
             return {

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -354,7 +354,7 @@ test("opt-in TCP broker requires endpoint state for health and registration", { 
     assert.deepEqual(registerMessages, [{
       type: "registered",
       sessionId: "authorized-tcp-client",
-      features: ["extension-bus-v1"],
+      features: ["extension-bus-v1", "exact-send-v1"],
     }]);
   } finally {
     if (broker.exitCode === null && broker.signalCode === null) {
@@ -575,6 +575,178 @@ test("broker accepts caller supplied stable IDs across reconnect", { concurrency
     await reconnected.disconnect();
   } finally {
     await worker.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("broker rotates endpoint epochs and replays same message ids without duplicate delivery", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const replacement = new IntercomClient();
+  const received: Message[] = [];
+  orchestrator.on("message", (_from: SessionInfo, message: Message) => received.push(message));
+
+  try {
+    const firstEndpoint = await waitForSessionByName(planner, "orchestrator");
+    assert.equal(typeof firstEndpoint.endpointEpoch, "string");
+
+    const messageId = "endpoint-epoch-replay";
+    const first = await planner.send(orchestrator.sessionId!, { text: "deliver once", messageId });
+    const replay = await planner.send(orchestrator.sessionId!, { text: "deliver once", messageId });
+    assert.deepEqual([first.delivery, replay.delivery], ["socket_delivered", "socket_delivered"]);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(received.filter((message) => message.id === messageId).length, 1);
+
+    await replacement.connect({
+      name: "orchestrator-replacement",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    }, orchestrator.sessionId!);
+    const replacedEndpoint = await waitForSessionId(planner, orchestrator.sessionId!);
+    assert.notEqual(replacedEndpoint.endpointEpoch, firstEndpoint.endpointEpoch);
+  } finally {
+    await replacement.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("delivery records keep colon-containing sender and message IDs distinct", { concurrency: false }, async () => {
+  const { orchestrator, cleanup } = await setupClients();
+  const first = new IntercomClient();
+  const second = new IntercomClient();
+  const received: Message[] = [];
+  orchestrator.on("message", (_from: SessionInfo, message: Message) => received.push(message));
+
+  try {
+    await first.connect({ name: "record-key-first", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, "a:b");
+    await second.connect({ name: "record-key-second", cwd: repoDir, model: "test-model", pid: process.pid, startedAt: Date.now(), lastActivity: Date.now() }, "a");
+
+    assert.equal((await first.send(orchestrator.sessionId!, { messageId: "c", text: "same fingerprint" })).delivered, true);
+    assert.equal((await second.send(orchestrator.sessionId!, { messageId: "b:c", text: "same fingerprint" })).delivered, true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.deepEqual(received.map((message) => message.id).sort(), ["b:c", "c"]);
+  } finally {
+    await first.disconnect().catch(() => undefined);
+    await second.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("client re-resolves a rebound exact target once with the same message id", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const replacement = new IntercomClient();
+  const replacementReceived = once(replacement, "message") as Promise<[SessionInfo, Message]>;
+  const listSessions = planner.listSessions.bind(planner);
+  let listCalls = 0;
+
+  try {
+    (planner as unknown as { listSessions: () => Promise<SessionInfo[]> }).listSessions = async () => {
+      const sessions = await listSessions();
+      listCalls += 1;
+      if (listCalls === 1) {
+        await replacement.connect({
+          name: "orchestrator-replacement",
+          cwd: repoDir,
+          model: "test-model",
+          pid: process.pid,
+          startedAt: Date.now(),
+          lastActivity: Date.now(),
+        }, orchestrator.sessionId!);
+      }
+      return sessions;
+    };
+
+    const result = await planner.send(orchestrator.sessionId!, { text: "retry after rebound", messageId: "endpoint-rebound-retry" });
+    assert.equal(result.delivered, true);
+    assert.equal(result.delivery, "socket_delivered");
+    const [, message] = await replacementReceived;
+    assert.equal(message.id, "endpoint-rebound-retry");
+    assert.equal(listCalls, 2);
+  } finally {
+    await replacement.disconnect().catch(() => undefined);
+    await cleanup();
+  }
+});
+
+test("broker rejects malformed exact target fields instead of falling back to name routing", { concurrency: false }, async () => {
+  const { orchestrator, cleanup } = await setupClients();
+  const raw = await connectRawRegistered("malformed-exact-sender", "malformed-exact-sender");
+  const { createMessageReader } = await import("./broker/framing.ts");
+
+  try {
+    const delivery = new Promise<Record<string, unknown>>((resolve, reject) => {
+      const reader = createMessageReader((received) => {
+        if (typeof received === "object" && received !== null && "type" in received && received.type === "delivery_failed") {
+          raw.socket.off("data", reader);
+          resolve(received as Record<string, unknown>);
+        }
+      }, reject);
+      raw.socket.on("data", reader);
+    });
+    raw.writeMessage(raw.socket, {
+      type: "send",
+      to: orchestrator.sessionId,
+      targetId: "",
+      targetEpoch: "",
+      message: {
+        id: "malformed-exact-target",
+        timestamp: Date.now(),
+        content: { text: "must not reach orchestrator" },
+      },
+    });
+    const result = await delivery;
+    assert.equal(result.code, "E_INVALID_TARGET");
+  } finally {
+    raw.socket.destroy();
+    await cleanup();
+  }
+});
+
+test("broker rejects changed message content after a rebound exact-target failure", { concurrency: false }, async () => {
+  const { planner, orchestrator, cleanup } = await setupClients();
+  const raw = await connectRawRegistered("rebound-reuse-sender", "rebound-reuse-sender");
+  const replacement = new IntercomClient();
+  const { createMessageReader } = await import("./broker/framing.ts");
+
+  try {
+    const targetId = orchestrator.sessionId!;
+    const oldTarget = await waitForSessionId(planner, targetId);
+    await replacement.connect({
+      name: "rebound-reuse-replacement",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+    }, targetId);
+    const receiveDelivery = () => new Promise<Record<string, unknown>>((resolve, reject) => {
+      const reader = createMessageReader((received) => {
+        if (typeof received === "object" && received !== null && "type" in received && (received.type === "delivered" || received.type === "delivery_failed")) {
+          raw.socket.off("data", reader);
+          resolve(received as Record<string, unknown>);
+        }
+      }, reject);
+      raw.socket.on("data", reader);
+    });
+    const send = (text: string) => raw.writeMessage(raw.socket, {
+      type: "send",
+      to: targetId,
+      targetId,
+      targetEpoch: oldTarget.endpointEpoch,
+      message: { id: "rebound-id-reuse", timestamp: Date.now(), content: { text } },
+    });
+
+    const firstDelivery = receiveDelivery();
+    send("first content");
+    assert.equal((await firstDelivery).code, "E_TARGET_REBOUND");
+    const secondDelivery = receiveDelivery();
+    send("changed content");
+    assert.equal((await secondDelivery).code, "E_MESSAGE_ID_REUSE");
+  } finally {
+    raw.socket.destroy();
+    await replacement.disconnect().catch(() => undefined);
     await cleanup();
   }
 });
@@ -832,7 +1004,7 @@ test("old stable-ID socket cannot mutate the replacement session", { concurrency
   }
 });
 
-test("stable-ID replacement clears old ask edges and ignores stale cancels", { concurrency: false }, async () => {
+test("stable-ID replacement preserves old ask edges and ignores stale cancels", { concurrency: false }, async () => {
   const { orchestrator, cleanup } = await setupClients();
   const first = await connectRawRegistered("replaceable-asker-id", "replaceable-asker-old");
   const replacement = new IntercomClient();
@@ -853,6 +1025,13 @@ test("stable-ID replacement clears old ask edges and ignores stale cancels", { c
       startedAt: Date.now(),
       lastActivity: Date.now(),
     }, "replaceable-asker-id");
+
+    const oldReply = once(replacement, "message") as Promise<[SessionInfo, Message]>;
+    assert.equal((await orchestrator.send("replaceable-asker-id", {
+      text: "Old ask answered after replacement.",
+      replyTo: "old-ask-edge",
+    })).delivered, true);
+    assert.equal((await oldReply)[1].replyTo, "old-ask-edge");
 
     const reverseAfterReplace = await orchestrator.send("replaceable-asker-id", {
       messageId: "reverse-after-replace",
@@ -940,6 +1119,9 @@ test("intercom tool prefers exact names over ID prefixes", { concurrency: false 
     ]);
     const result = await intercomTool.execute("send-exact-name", { action: "send", to: "orchestrator", message: "exact name wins" }, new AbortController().signal, undefined, harness.ctx);
     assert.notEqual(result.details?.error, true);
+    assert.equal(result.details?.delivery, "socket_delivered");
+    assert.equal(result.details?.retryable, false);
+    assert.equal(result.details?.outcomeKnown, true);
 
     const received = await exactNameReceived;
     assert.notEqual(received, null);
@@ -1371,7 +1553,7 @@ test("idle interactive sessions trigger a new turn immediately", { concurrency: 
 	}
 });
 
-test("duplicate inbound message IDs inject once with visible delivery metadata", { concurrency: false }, async () => {
+test("broker rejects changed duplicate message IDs and replays identical sends without reinjection", { concurrency: false }, async () => {
   const { default: piIntercomExtension } = await import("./index.ts");
   const { planner, cleanup } = await setupClients();
   const harness = createExtensionHarness("dedupe-worker", { hasUI: true });
@@ -1386,8 +1568,13 @@ test("duplicate inbound message IDs inject once with visible delivery metadata",
     });
 
     try {
-      assert.equal((await planner.send(worker.id, { messageId: "duplicate-inbound", text: "First copy" })).delivered, true);
-      assert.equal((await planner.send(worker.id, { messageId: "duplicate-inbound", text: "Second copy" })).delivered, true);
+      const first = await planner.send(worker.id, { messageId: "duplicate-inbound", text: "First copy" });
+      const changed = await planner.send(worker.id, { messageId: "duplicate-inbound", text: "Second copy" });
+      const replay = await planner.send(worker.id, { messageId: "duplicate-inbound", text: "First copy" });
+      assert.equal(first.delivered, true);
+      assert.equal(changed.delivered, false);
+      assert.equal(changed.code, "E_MESSAGE_ID_REUSE");
+      assert.equal(replay.delivered, true);
       await new Promise((resolve) => setTimeout(resolve, 100));
     } finally {
       unsubscribeReceipts();
@@ -1397,7 +1584,6 @@ test("duplicate inbound message IDs inject once with visible delivery metadata",
     assert.ok(receipts.includes("receiver_received"));
     assert.ok(receipts.includes("acknowledged:accepted by receiver"));
     assert.ok(receipts.includes("injected"));
-    assert.ok(receipts.includes("acknowledged:duplicate message id suppressed"));
     const sent = harness.sentMessages[0]!;
     assert.match(sent.message.content ?? "", /id duplicate-inbound/);
     assert.match(sent.message.content ?? "", /seq 1/);
@@ -3620,6 +3806,10 @@ test("failed delivery from an inferred reply preserves the pending ask", { concu
     }, new AbortController().signal, undefined, harness.ctx);
 
     assert.equal(result.details?.delivered, false);
+    assert.equal(result.details?.delivery, "failed");
+    assert.equal(result.details?.code, "E_AMBIGUOUS_TARGET");
+    assert.equal(result.details?.retryable, false);
+    assert.equal(result.details?.outcomeKnown, true);
     assert.match(result.content[0]?.text ?? "", /Multiple disconnected sessions named/);
 
     const pending = await intercomTool.execute("pending-after-failure", { action: "pending" }, new AbortController().signal, undefined, harness.ctx);

--- a/types.ts
+++ b/types.ts
@@ -1,7 +1,19 @@
 export const EXTENSION_BUS_FEATURE = "extension-bus-v1";
+export const EXACT_SEND_FEATURE = "exact-send-v1";
+
+export type DeliveryState = "socket_delivered" | "queued" | "failed" | "unknown";
+
+export interface DeliveryDetails {
+  delivery: DeliveryState;
+  code?: string;
+  retryable: boolean;
+  outcomeKnown: boolean;
+}
 
 export interface SessionInfo {
   id: string;
+  /** Broker-owned lifetime of this live endpoint. */
+  endpointEpoch?: string;
   name?: string;
   /** True only when the extension synthesized name for an unnamed runtime. */
   runtimeFallbackAlias?: boolean;
@@ -79,7 +91,7 @@ export interface ExtensionCapability {
   ownerEligible: boolean;
 }
 
-export type SessionRegistration = Omit<SessionInfo, "id" | "peerUid" | "trustedLocal"> & {
+export type SessionRegistration = Omit<SessionInfo, "id" | "endpointEpoch" | "peerUid" | "trustedLocal"> & {
   extensions?: ExtensionCapability[];
 };
 
@@ -88,7 +100,7 @@ export type ClientMessage =
   | { type: "unregister" }
   | { type: "extension_capabilities_update"; extensions: ExtensionCapability[] }
   | { type: "list"; requestId: string }
-  | { type: "send"; to: string; message: Message }
+  | { type: "send"; to: string; message: Message; targetId?: string; targetEpoch?: string }
   | { type: "message_receipt"; receipt: MessageReceipt }
   | { type: "cancel_message"; messageId: string }
   | { type: "cancel_ask"; messageId: string }
@@ -117,8 +129,8 @@ export type BrokerMessage =
   | { type: "session_joined"; session: SessionInfo }
   | { type: "session_left"; sessionId: string }
   | { type: "error"; error: string }
-  | { type: "delivered"; messageId: string }
-  | { type: "delivery_failed"; messageId: string; reason: string }
+  | ({ type: "delivered"; messageId: string } & DeliveryDetails)
+  | ({ type: "delivery_failed"; messageId: string; reason: string } & DeliveryDetails)
   | { type: "message_receipt"; from: SessionInfo; receipt: MessageReceipt }
   | { type: "message_control"; from: SessionInfo; control: MessageControl }
   | { type: "extension_owner"; namespace: string; ownerId?: string; ownerEpoch?: string }


### PR DESCRIPTION
## Summary

Adds broker-owned endpoint epochs for exact intercom sends.

New clients resolve a target to an exact session id and endpoint epoch before sending. The broker refuses stale endpoints, supports one safe re-resolve retry, and keeps bounded delivery records so same-message retries do not duplicate delivery or allow changed-content reuse.

Replies still route through pending ask edges, and explicit name+cwd mailbox recovery remains intact. Native `pi-subagents` supervisor-channel behavior is unchanged.

Thanks to [@xiangbianpangde](https://github.com/xiangbianpangde) for #106, which identified the routing safety problem that this replaces.

Closes #107.

## Validation

- `git diff --check`
- `env -u PI_INTERCOM_STABLE_ID -u PI_INTERCOM_SESSION_ID -u PI_SUBAGENT_ORCHESTRATOR_TARGET -u PI_SUBAGENT_ORCHESTRATOR_SESSION_ID -u PI_SUBAGENT_SUPERVISOR_CHANNEL_DIR npm test` passed 189/189
- Fresh review: `No issues found`
