### PR TITLE
feat: general 'send as current session' event for extensions

### DIFF
--- a/extension-api.ts
+++ b/extension-api.ts
@@ -3,6 +3,39 @@ import type { SessionInfo } from "./types.ts";
 export const INTERCOM_EXTENSION_REGISTER_EVENT = "intercom:extension-register";
 export const INTERCOM_EXTENSION_REGISTRY_READY_EVENT = "intercom:extension-registry-ready";
 
+/**
+ * General "send as the current session" channel.
+ *
+ * Any extension can emit INTERCOM_EXTENSION_SEND_EVENT on the pi event bus
+ * with { to, message, requestId? }. pi-intercom (running in the same process)
+ * forwards the message through the CURRENT session's own intercom client, so
+ * the broker records the message's `from` as this session — preserving sender
+ * identity and letting replies route back natively. If `requestId` is provided,
+ * pi-intercom emits INTERCOM_EXTENSION_SEND_RESULT_EVENT with the delivery
+ * outcome so the caller can confirm the message landed instead of assuming it.
+ *
+ * This is the right primitive for an extension that needs to deliver a message
+ * to another agent on the caller's behalf without the caller's own agent having
+ * to place the intercom send itself.
+ */
+export const INTERCOM_EXTENSION_SEND_EVENT = "intercom:extension-send";
+export const INTERCOM_EXTENSION_SEND_RESULT_EVENT = "intercom:extension-send-result";
+
+export interface IntercomExtensionSendRequest {
+  /** Target intercom session id or name. */
+  to: string;
+  /** Plain-text message body to deliver. */
+  message: string;
+  /** If provided, a matching result event is emitted on the pi event bus. */
+  requestId?: string;
+}
+
+export interface IntercomExtensionSendResult {
+  requestId?: string;
+  delivered: boolean;
+  reason?: string;
+}
+
 export interface IntercomExtensionOwner {
   sessionId: string;
   epoch: string;

--- a/index.ts
+++ b/index.ts
@@ -14,11 +14,14 @@ import type { Attachment, BrokerMessage, Message, MessageControl, MessageReceipt
 import {
   INTERCOM_EXTENSION_REGISTER_EVENT,
   INTERCOM_EXTENSION_REGISTRY_READY_EVENT,
+  INTERCOM_EXTENSION_SEND_EVENT,
+  INTERCOM_EXTENSION_SEND_RESULT_EVENT,
   type IntercomExtensionChannel,
   type IntercomExtensionEvent,
   type IntercomExtensionOwner,
   type IntercomExtensionRegistration,
   type IntercomExtensionState,
+  type IntercomExtensionSendRequest,
 } from "./extension-api.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
 import { resolve as resolvePath } from "node:path";
@@ -1408,6 +1411,50 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       acknowledge: true,
     });
   });
+
+  // ── General "send as the current session" channel ──────────────
+  //
+  // Any extension can emit INTERCOM_EXTENSION_SEND_EVENT with
+  // { to, message, requestId? } and pi-intercom forwards it through the
+  // current session's own intercom client, so the broker records `from` as
+  // this session (sender identity preserved, replies route back natively).
+  // When requestId is provided, a matching INTERCOM_EXTENSION_SEND_RESULT_EVENT
+  // is emitted so the caller can confirm delivery instead of assuming it.
+  // See extension-api.ts for the public contract.
+  const unsubscribeExtensionSend = pi.events.on(INTERCOM_EXTENSION_SEND_EVENT, (payload) => {
+    if (!payload || typeof payload !== "object") return;
+    const req = payload as Partial<IntercomExtensionSendRequest>;
+    if (typeof req.to !== "string" || typeof req.message !== "string" || req.to.length === 0) return;
+    const requestId = typeof req.requestId === "string" ? req.requestId : undefined;
+    const relayGeneration = runtimeGeneration;
+    const emitResult = (delivered: boolean, reason?: string) => {
+      if (!requestId) return;
+      pi.events.emit(INTERCOM_EXTENSION_SEND_RESULT_EVENT, {
+        requestId,
+        delivered,
+        ...(reason ? { reason } : {}),
+      });
+    };
+    void (async () => {
+      const relayStillLive = () => !runtimeStarted || Boolean(getLiveContext(runtimeContext, relayGeneration));
+      try {
+        const activeClient = await ensureConnected("background");
+        if (!relayStillLive()) return;
+        const target = (await resolveSessionTarget(activeClient, req.to)) ?? req.to;
+        if (!relayStillLive()) return;
+        if (currentSessionTargetMatches(req.to, target, activeClient)) {
+          emitResult(false, "target is the current session");
+          return;
+        }
+        const result = await activeClient.send(target, { text: req.message });
+        if (!relayStillLive()) return;
+        emitResult(result.delivered, result.delivered ? undefined : (result.reason ?? "delivery failed"));
+      } catch (error) {
+        if (!relayStillLive()) return;
+        emitResult(false, getErrorMessage(error));
+      }
+    })();
+  });
   pi.on("session_start", (_event, ctx) => {
     if (!config.enabled) {
       return;
@@ -1419,6 +1466,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     unsubscribeExtensionRegister();
     unsubscribeSubagentControlIntercom();
     unsubscribeSubagentResultIntercom();
+    unsubscribeExtensionSend();
     shuttingDown = true;
     disposed = true;
     runtimeGeneration += 1;


### PR DESCRIPTION
## Summary

This adds a small, general-purpose event channel that lets **any** pi extension send an intercom message **as the current session**, without that session's own agent having to place the `intercom send` itself. pi-intercom (running in the same process) forwards the message through the current session's own registered intercom client, so the broker records the message's `from` as this session — sender identity is preserved and replies route back to the caller natively. A matching result event carries the broker's delivery outcome, so the caller can confirm the message landed rather than assume it.

It generalizes the existing, pi-subagents-specific `subagent:result-intercom` / `subagent:control-intercom` relay into a primitive any extension can use.

## Why this exists

An extension that wants to deliver a message on a user's behalf today has only two options, both with real downsides:

1. **Tell the session's own agent to send.** The extension returns a result instructing the agent to call `intercom send` itself. This preserves sender identity (the agent's own client sends, so `from` is the session), but the delivery is now the agent's responsibility: the extension has already returned success before the send happens, so a later failed send is silently lost, and the extension has no way to report the real outcome.
2. **Connect to the broker directly as a short-lived proxy session.** The extension opens its own socket and sends. This delivers synchronously and can report the real outcome, but the message's `from` becomes that throwaway proxy session: replies no longer route back to the caller, and the extra registration competes for a broker session slot.

Neither is right. The first silently loses tasks; the second loses sender identity. What an extension actually needs is: *deliver now, as me, and tell me whether it landed.* That is what this channel provides.

## The contract

Two event names, exported from `extension-api.ts`:

- `INTERCOM_EXTENSION_SEND_EVENT` = `"intercom:extension-send"` — emit to send.
- `INTERCOM_EXTENSION_SEND_RESULT_EVENT` = `"intercom:extension-send-result"` — emitted back by pi-intercom when a `requestId` was supplied.

Request payload (`IntercomExtensionSendRequest`):

- `to: string` — target intercom session id or name (resolved the same way the `intercom` tool resolves it).
- `message: string` — plain-text body to deliver.
- `requestId?: string` — if provided, a matching result event is emitted. If omitted, the send is fire-and-forget from the caller's perspective (pi-intercom still sends it).

Result payload (`IntercomExtensionSendResult`):

- `requestId?: string` — matches the request.
- `delivered: boolean` — the broker's `delivered` ack.
- `reason?: string` — present when `delivered` is false (broker `delivery_failed` reason, an `error`, a self-target guard, or a connect/send failure).

Semantics:

- The send originates from the **current session's** own intercom client, so the broker sets `from` to this session. Replies route back to this session by id (or by name, as usual).
- Resolution and delivery mirror the `intercom` tool: name→id via `resolveSessionTarget`, then `activeClient.send(target, { text })`.
- A request targeting the current session itself is rejected with `delivered: false, reason: "target is the current session"` rather than looped back.
- One shot, no retry. A retry would risk delivering the message twice; the `delivered` ack is the confirmation, and a failure is reported honestly so the caller can surface it.
- The event is loose-coupled: consumers duplicate the event-name strings (the way pi-subagents already duplicates `subagent:result-intercom`) rather than importing pi-intercom, so there is no hard dependency.

## How it works

The extension emits on the in-process `pi.events` bus; pi-intercom's handler (registered alongside the existing subagent relays) does the work in the same process, using the current session's client.

```mermaid
sequenceDiagram
    autonumber
    participant Ext as Calling extension
    participant Bus as pi.events<br/>(in-process)
    participant H as pi-intercom handler
    participant C as IntercomClient<br/>(current session)
    participant B as intercom broker
    participant T as Target session

    Ext->>Bus: emit intercom:extension-send<br/>{to, message, requestId}
    Bus->>H: handler fires
    H->>C: ensureConnected("background")
    H->>C: resolveSessionTarget(to)
    H->>B: send(target, {text}) — from = current session
    B->>T: message (from = caller session)
    B-->>C: delivered | delivery_failed
    C-->>H: SendResult {delivered, reason}
    H->>Bus: emit intercom:extension-send-result<br/>{requestId, delivered, reason}
    Bus-->>Ext: result (awaited by requestId)
```

The pieces and where they live:

```mermaid
flowchart LR
    subgraph P["Caller session process"]
      Ext["Calling extension"]
      Bus[("pi.events bus")]
      H["pi-intercom handler<br/>(index.ts)"]
      C["IntercomClient<br/>registered as THIS session"]
    end
    B[("intercom broker")]
    T["Target session"]
    Ext -- "emit intercom:extension-send" --> Bus
    Bus -- "on()" --> H
    H -- "activeClient.send" --> C
    C -- "register/send (from = caller)" --> B
    B -- "message (from = caller)" --> T
    T -- "reply (by id/name)" --> B
    B -- "reply → caller session" --> C
    H -- "emit intercom:extension-send-result" --> Bus
    Bus -- "on()" --> Ext
```

## Relationship to existing code

The handler is a small, self-contained addition next to the existing `unsubscribeSubagentResultIntercom` registration. It reuses the same building blocks the subagent relay uses — `ensureConnected("background")`, `resolveSessionTarget`, `currentSessionTargetMatches`, `activeClient.send`, `getErrorMessage` — but does **not** touch the pi-subagents-specific paths: `relaySubagentIntercomPayload`, `deliverLocalSubagentRelayMessage`, and the `subagent:*` events are unchanged. Nothing about the broker wire protocol or the `IntercomClient.send` signature changes.

Conceptually, `subagent:result-intercom` is "pi-subagents asks pi-intercom to forward this result as the current session"; this PR simply opens that same move to any extension.

## Non-goals

- **No retry.** A failed send is reported, not retried, to avoid duplicate delivery. Confirming delivery is the caller's job (via the result event); recovering from a failure is the caller's job (re-send deliberately).
- **Not a replacement for the `intercom` tool.** Agent-mediated sends (the agent calls `intercom send`) remain fully supported and are still the right choice when the agent is the natural sender. This channel is for extensions that need to deliver on the caller's behalf *without* the agent in the loop.
- **No change to broker protocol, session registration, or the `send` signature.** This is purely an in-process event channel plus a handler that calls existing client methods.

## Testing

The existing suite passes on top of `main` (189 tests, 0 failed; 1 cancelled is the integration harness's teardown). The new handler mirrors the proven `relaySubagentIntercomPayload` path. Full end-to-end coverage of the event (extension emits → broker delivers → result event) needs a live pi process and is a good follow-up test; the contract types and event names are exported for that purpose.

## Status

Draft. Looking for feedback on:

- Whether the event-name/channel approach is the right shape vs. a more explicit inter-extension API surface.
- Whether `requestId`-less fire-and-forget is worth keeping, or whether the result event should always be emitted.
- Naming (`intercom:extension-send` / `intercom:extension-send-result`) — open to better names.
- Whether to also generalize the existing `subagent:*` relays onto this channel over time, or keep them separate.

— polar-newt-89 🤖