### PR TITLE
feat: add lazy intercom tool visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Added
+- Added opt-in `after-first-use` visibility for the generic `intercom` tool, keeping its model schema and prompt out of unused sessions until an inbound message, overlay send, or bundled skill load reveals it. Broker reception and the child-only `contact_supervisor` tool remain available while it is hidden.
+
 ## [0.11.0] - 2026-08-19
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Create `~/.pi/agent/intercom/config.json`:
   "brokerArgs": ["--no-install", "tsx"],
   "confirmSend": false,
   "inboundTrigger": "always",
+  "toolVisibility": "always",
   "enabled": true,
   "replyHint": true,
   "status": "researching"
@@ -409,6 +410,7 @@ Create `~/.pi/agent/intercom/config.json`:
 | `brokerArgs` | `["--no-install", "tsx"]` | Advanced trusted arguments passed to custom `brokerCommand` before the broker script path |
 | `confirmSend` | false | Show a confirmation dialog before ordinary or inferred sends from an interactive session with UI; caller-supplied `replyTo` skips it |
 | `inboundTrigger` | `"always"` | Auto-trigger policy for inbound broker messages: `"always"`, `"replies"`, or `"never"`. Local in-process subagent relay events still trigger the addressed session. |
+| `toolVisibility` | `"always"` | When the generic `intercom` tool enters the active model tool set: `"always"` or `"after-first-use"`. Lazy visibility reveals it after an inbound broker message, a successful overlay send, or loading the bundled skill. It does not hide the child-only `contact_supervisor` tool. |
 | `enabled` | true | Enable/disable intercom entirely |
 | `replyHint` | true | Include reply instruction in incoming messages |
 | `status` | — | Optional custom status suffix shown after the automatic lifecycle status, for example `thinking · researching` |
@@ -509,7 +511,7 @@ Runtime files live at `~/.pi/agent/intercom/` by default, or `$PI_CODING_AGENT_D
 - `broker.port.json` — Dynamic localhost TCP endpoint, only when Windows TCP transport is explicitly enabled
 - `config.json` — User configuration
 
-Supported `config.json` keys include `stableId` for restart-stable addressing, `status` for a custom status suffix, `inboundTrigger` (`always`, `replies`, or `never`), `replyHint`, `confirmSend`, and advanced broker launch overrides.
+Supported `config.json` keys include `stableId` for restart-stable addressing, `status` for a custom status suffix, `inboundTrigger` (`always`, `replies`, or `never`), `toolVisibility` (`always` or `after-first-use`), `replyHint`, `confirmSend`, and advanced broker launch overrides.
 
 ## Design Decisions
 

--- a/config.test.ts
+++ b/config.test.ts
@@ -60,6 +60,30 @@ test("loadConfig accepts inboundTrigger replies policy", async () => {
   }
 });
 
+test("loadConfig defaults intercom tool visibility to always", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
+  try {
+    await withAgentDir(root, () => {
+      assert.equal(loadConfig().toolVisibility, "always");
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig accepts lazy intercom tool visibility", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
+  try {
+    mkdirSync(join(root, "intercom"), { recursive: true });
+    writeFileSync(join(root, "intercom", "config.json"), JSON.stringify({ toolVisibility: "after-first-use" }));
+    await withAgentDir(root, () => {
+      assert.equal(loadConfig().toolVisibility, "after-first-use");
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("loadConfig accepts a restart-stable intercom id", async () => {
   const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
   try {
@@ -67,6 +91,23 @@ test("loadConfig accepts a restart-stable intercom id", async () => {
     writeFileSync(join(root, "intercom", "config.json"), JSON.stringify({ stableId: " pinned-worker " }));
     await withAgentDir(root, () => {
       assert.equal(loadConfig().stableId, "pinned-worker");
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig rejects invalid toolVisibility values", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-intercom-config-"));
+  try {
+    mkdirSync(join(root, "intercom"), { recursive: true });
+    writeFileSync(join(root, "intercom", "config.json"), JSON.stringify({ toolVisibility: "lazy" }));
+
+    await withAgentDir(root, () => {
+      assert.throws(
+        () => loadConfig(),
+        /Failed to load intercom config.*"toolVisibility" must be "always" or "after-first-use"/,
+      );
     });
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/config.ts
+++ b/config.ts
@@ -18,6 +18,7 @@ export function getAskTimeoutMs(): number {
 }
 
 export type InboundTriggerPolicy = "always" | "replies" | "never";
+export type IntercomToolVisibility = "always" | "after-first-use";
 
 export interface IntercomConfig {
   /** Broker command used to spawn the broker process (e.g. "npx" or "bun") */
@@ -31,6 +32,9 @@ export interface IntercomConfig {
 
   /** Controls whether inbound broker messages may automatically trigger a model turn */
   inboundTrigger: InboundTriggerPolicy;
+
+  /** Controls when the intercom tool enters the active model tool set */
+  toolVisibility: IntercomToolVisibility;
 
   /** Optional custom status suffix shown after automatic lifecycle status */
   status?: string;
@@ -54,6 +58,7 @@ const defaults: IntercomConfig = {
   brokerArgs: ["--no-install", "tsx"],
   confirmSend: false,
   inboundTrigger: "always",
+  toolVisibility: "always",
   enabled: true,
   replyHint: true,
 };
@@ -122,6 +127,16 @@ export function loadConfig(): IntercomConfig {
         throw new Error(`"inboundTrigger" must be "always", "replies", or "never"`);
       }
       config.inboundTrigger = parsedConfig.inboundTrigger;
+    }
+
+    if (Object.hasOwn(parsedConfig, "toolVisibility")) {
+      if (
+        parsedConfig.toolVisibility !== "always"
+        && parsedConfig.toolVisibility !== "after-first-use"
+      ) {
+        throw new Error(`"toolVisibility" must be "always" or "after-first-use"`);
+      }
+      config.toolVisibility = parsedConfig.toolVisibility;
     }
 
     if (Object.hasOwn(parsedConfig, "replyHint")) {

--- a/index.ts
+++ b/index.ts
@@ -21,11 +21,15 @@ import {
   type IntercomExtensionState,
 } from "./extension-api.ts";
 import { ReplyTracker } from "./reply-tracker.ts";
+import { realpathSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
 import { sameCwd } from "./cwd.ts";
 import { formatContextUsage } from "./format-context.ts";
 import { openProjectPane, resolveTargetInCwd, waitForProjectSession, type ProjectPaneLaunch } from "./project-agent.ts";
 
+const INTERCOM_TOOL_NAME = "intercom";
+const INTERCOM_SKILL_PATH = realpathSync(fileURLToPath(new URL("./skills/pi-intercom/SKILL.md", import.meta.url)));
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
 const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delivery";
@@ -86,6 +90,18 @@ interface SupervisorInterviewReply {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isIntercomSkillRead(input: unknown, cwd: string): boolean {
+  if (!input || typeof input !== "object") return false;
+  const inputPath = Reflect.get(input, "path");
+  if (typeof inputPath !== "string") return false;
+  const normalizedPath = inputPath.startsWith("@") ? inputPath.slice(1) : inputPath;
+  try {
+    return realpathSync(resolvePath(cwd, normalizedPath)) === INTERCOM_SKILL_PATH;
+  } catch {
+    return false;
+  }
 }
 
 function deliveryDetails(result: SendResult): Record<string, unknown> {
@@ -544,7 +560,24 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
   let runtimeGeneration = 0;
   let agentRunning = false;
   const activeTools = new Map<string, string>();
+  let intercomToolHiddenByPolicy = false;
   const replyTracker = new ReplyTracker();
+  function hideIntercomTool(): void {
+    if (config.toolVisibility !== "after-first-use") return;
+    const activeToolNames = pi.getActiveTools();
+    if (!activeToolNames.includes(INTERCOM_TOOL_NAME)) return;
+    pi.setActiveTools(activeToolNames.filter((name) => name !== INTERCOM_TOOL_NAME));
+    intercomToolHiddenByPolicy = true;
+  }
+  function activateIntercomTool(): void {
+    if (!intercomToolHiddenByPolicy) return;
+    const activeToolNames = pi.getActiveTools();
+    if (!activeToolNames.includes(INTERCOM_TOOL_NAME)) {
+      pi.setActiveTools([...activeToolNames, INTERCOM_TOOL_NAME]);
+    }
+    intercomToolHiddenByPolicy = false;
+  }
+
   const seenInboundMessages = new Map<string, number>();
   const latestOutboundReceipts = new Map<string, { status: MessageReceiptStatus; timestamp: number; detail?: string }>();
   function dismissIncomingAsk(messageId: string): void {
@@ -922,6 +955,10 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
         : { deliverAs: "steer" }
     );
   }
+  function sendIncomingBrokerMessage(entry: InboundMessageEntry, delivery: "trigger" | "steer", generation = runtimeGeneration): void {
+    activateIntercomTool();
+    sendIncomingMessage(entry, delivery, generation);
+  }
   function handleIncomingMessage(ctx: ExtensionContext, from: SessionInfo, message: Message): void {
     const messageGeneration = runtimeGeneration;
     const liveContext = getLiveContext(ctx, messageGeneration);
@@ -979,11 +1016,11 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
           }
           return;
         }
-        sendIncomingMessage(entry, "steer");
+        sendIncomingBrokerMessage(entry, "steer");
         return;
       }
       if (getLiveContext(liveContext, messageGeneration)) {
-        sendIncomingMessage(entry, "trigger", messageGeneration);
+        sendIncomingBrokerMessage(entry, "trigger", messageGeneration);
       }
     })();
   }
@@ -1270,6 +1307,7 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     });
   }
   function startSessionRuntime(ctx: ExtensionContext): void {
+    hideIntercomTool();
     const previousClient = client;
     shuttingDown = false;
     disposed = false;
@@ -1511,7 +1549,17 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
     return new InlineMessageComponent(details.from, details.message, theme, details.replyCommand, details.bodyText, !options.expanded);
   });
 
-  pi.on("tool_result", (event) => {
+  pi.on("input", (event) => {
+    if (/^\/skill:pi-intercom(?:\s|$)/u.test(event.text.trimStart())) {
+      activateIntercomTool();
+    }
+  });
+
+  pi.on("tool_result", (event, ctx) => {
+    if (event.toolName === "read" && event.isError !== true && isIntercomSkillRead(event.input, ctx.cwd)) {
+      activateIntercomTool();
+      return;
+    }
     if (event.toolName !== "intercom" && event.toolName !== "contact_supervisor") {
       return;
     }
@@ -1863,6 +1911,7 @@ Usage:
     }),
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      activateIntercomTool();
       let connectedClient: IntercomClient;
       try {
         connectedClient = await ensureConnected("tool");
@@ -2442,6 +2491,7 @@ Usage:
     ).catch(() => undefined);
 
     if (result?.sent && result.messageId && result.text && getLiveContext(ctx, overlayGeneration)) {
+      activateIntercomTool();
       pi.appendEntry("intercom_sent", {
         to: selectedSession.name || selectedSession.id,
         message: { text: result.text },

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { EventEmitter, once } from "node:events";
@@ -28,12 +28,25 @@ process.env.HOME = sharedHomeDir;
 process.env.USERPROFILE = sharedHomeDir;
 const { IntercomClient } = await import("./broker/client.ts");
 const { getTsxCliPath } = await import("./broker/spawn.ts");
-const { getAskTimeoutMs } = await import("./config.ts");
+const { getAskTimeoutMs, getConfigPath } = await import("./config.ts");
 process.on("exit", () => {
   process.env.HOME = previousHome;
   process.env.USERPROFILE = previousUserProfile;
   rmSync(sharedHomeDir, { recursive: true, force: true });
 });
+
+async function withIntercomConfig<T>(config: Record<string, unknown>, fn: () => T | Promise<T>): Promise<T> {
+  const configPath = getConfigPath();
+  const previous = existsSync(configPath) ? readFileSync(configPath, "utf-8") : undefined;
+  mkdirSync(path.dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config));
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) rmSync(configPath, { force: true });
+    else writeFileSync(configPath, previous);
+  }
+}
 
 async function waitForBrokerReady(broker: ChildProcess): Promise<void> {
   const stdout = broker.stdout;
@@ -146,13 +159,15 @@ function createExtensionHarness(sessionName: string | (() => string) = "child-wo
   mode?: "tui" | "rpc" | "json" | "print";
   ui?: unknown;
   sessionId?: string | (() => string);
+  activeTools?: string[];
 } = {}) {
   const events = new EventEmitter();
   const lifecycleHandlers = new Map<string, Array<(event: unknown, ctx: unknown) => unknown>>();
   const commands = new Map<string, (args: string, ctx: unknown) => unknown>();
   const tools: CapturedTool[] = [];
+  let activeToolNames = [...(options.activeTools ?? [])];
   const entries: Array<{ type: string; data: unknown }> = [];
-  const sentMessages: Array<{ message: { customType?: string; content?: string; details?: unknown }; options?: { triggerTurn?: boolean; deliverAs?: string } }> = [];
+  const sentMessages: Array<{ message: { customType?: string; content?: string; details?: unknown }; options?: { triggerTurn?: boolean; deliverAs?: string }; activeTools: string[] }> = [];
   const pi = {
     getSessionName: () => typeof sessionName === "function" ? sessionName() : sessionName,
     events: {
@@ -170,13 +185,16 @@ function createExtensionHarness(sessionName: string | (() => string) = "child-wo
     registerMessageRenderer: () => undefined,
     registerTool: (tool: CapturedTool) => {
       tools.push(tool);
+      if (!activeToolNames.includes(tool.name)) activeToolNames.push(tool.name);
     },
+    getActiveTools: () => [...activeToolNames],
+    setActiveTools: (names: string[]) => { activeToolNames = [...names]; },
     registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => unknown }) => {
       commands.set(name, command.handler);
     },
     registerShortcut: () => undefined,
     sendMessage: (message: { customType?: string; content?: string; details?: unknown }, options?: { triggerTurn?: boolean; deliverAs?: string }) => {
-      sentMessages.push({ message, options });
+      sentMessages.push({ message, options, activeTools: [...activeToolNames] });
     },
     appendEntry: (type: string, data: unknown) => entries.push({ type, data }),
   };
@@ -197,6 +215,7 @@ function createExtensionHarness(sessionName: string | (() => string) = "child-wo
     commands,
     entries,
     sentMessages,
+    getActiveTools: () => pi.getActiveTools(),
     async emitLifecycle(event: string, payload: unknown = {}, eventContext: unknown = ctx) {
       for (const handler of lifecycleHandlers.get(event) ?? []) {
         await handler(payload, eventContext);
@@ -1360,6 +1379,115 @@ test("intercom tool result hook marks failed details as errors", async () => {
     details: { delivered: true },
   });
   assert.deepEqual(okResults.filter(Boolean), []);
+});
+
+test("lazy tool visibility reveals intercom on bundled skill use only", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+
+  await withIntercomConfig({ toolVisibility: "after-first-use" }, () => withChildOrchestratorEnv({
+    orchestratorTarget: "orchestrator",
+    runId: "78f659a3",
+    agent: "worker",
+    index: "0",
+  }, async () => {
+    const harness = createExtensionHarness("lazy-skill-worker", { activeTools: ["read", "bash"] });
+    piIntercomExtension(harness.pi as never);
+
+    try {
+      await harness.emitLifecycle("session_start");
+      assert.deepEqual(harness.getActiveTools(), ["read", "bash", "contact_supervisor"]);
+
+      harness.pi.events.emit("subagent:control-intercom", {
+        to: "session-child-test",
+        message: "Local relay traffic should not reveal the generic tool.",
+      });
+      assert.equal(harness.sentMessages.at(-1)?.activeTools.includes("intercom"), false);
+      assert.equal(harness.getActiveTools().includes("intercom"), false);
+
+      await harness.emitLifecycle("tool_result", {
+        toolName: "read",
+        input: { path: path.join(repoDir, "README.md") },
+        isError: false,
+      });
+      await harness.emitLifecycle("tool_result", {
+        toolName: "read",
+        input: { path: path.join(repoDir, "skills", "pi-intercom", "SKILL.md") },
+        isError: true,
+      });
+      assert.equal(harness.getActiveTools().includes("intercom"), false);
+
+      await harness.emitLifecycle("tool_result", {
+        toolName: "read",
+        input: { path: path.join(repoDir, "skills", "pi-intercom", "SKILL.md") },
+        isError: false,
+      });
+      assert.deepEqual(harness.getActiveTools(), ["read", "bash", "contact_supervisor", "intercom"]);
+
+      await harness.emitLifecycle("session_start");
+      assert.equal(harness.getActiveTools().includes("intercom"), false);
+      await harness.emitLifecycle("input", { text: "  /skill:pi-intercom", source: "user" });
+      assert.equal(harness.getActiveTools().includes("intercom"), true);
+    } finally {
+      await harness.emitLifecycle("session_shutdown");
+    }
+  }));
+});
+
+test("lazy tool visibility reveals intercom before broker injection and after an overlay send", { concurrency: false }, async () => {
+  const { default: piIntercomExtension } = await import("./index.ts");
+
+  await withIntercomConfig({ toolVisibility: "after-first-use" }, async () => {
+    const { planner, cleanup } = await setupClients();
+    let selectedSession: SessionInfo | undefined;
+    let overlayStep = 0;
+    const overlayHarness = createExtensionHarness("lazy-overlay-worker", {
+      hasUI: true,
+      activeTools: ["read"],
+      ui: {
+        notify: () => undefined,
+        custom: async () => {
+          overlayStep += 1;
+          return overlayStep === 1
+            ? selectedSession
+            : { sent: true, messageId: "overlay-message", text: "Hello from the overlay" };
+        },
+      },
+    });
+    const inboundHarness = createExtensionHarness("lazy-inbound-worker", {
+      hasUI: true,
+      activeTools: ["read"],
+    });
+
+    try {
+      piIntercomExtension(overlayHarness.pi as never);
+      piIntercomExtension(inboundHarness.pi as never);
+      await overlayHarness.emitLifecycle("session_start");
+      await inboundHarness.emitLifecycle("session_start");
+      assert.equal(overlayHarness.getActiveTools().includes("intercom"), false);
+      assert.equal(inboundHarness.getActiveTools().includes("intercom"), false);
+
+      selectedSession = await waitForSessionByName(planner, "planner");
+      const inboundSession = await waitForSessionByName(planner, "lazy-inbound-worker");
+      const delivered = await planner.send(inboundSession.id, {
+        messageId: "lazy-inbound-message",
+        text: "Reveal intercom before injecting this message.",
+      });
+      assert.equal(delivered.delivered, true);
+      const deadline = Date.now() + 1000;
+      while (inboundHarness.sentMessages.length === 0 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      assert.equal(inboundHarness.sentMessages[0]?.activeTools.includes("intercom"), true);
+
+      await overlayHarness.commands.get("intercom")!("", overlayHarness.ctx);
+      assert.equal(overlayStep, 2);
+      assert.equal(overlayHarness.getActiveTools().includes("intercom"), true);
+    } finally {
+      await overlayHarness.emitLifecycle("session_shutdown");
+      await inboundHarness.emitLifecycle("session_shutdown");
+      await cleanup();
+    }
+  });
 });
 
 test("contact supervisor tool renders reason and reply state", async () => {


### PR DESCRIPTION
## Summary

Adds opt-in lazy visibility for the generic `intercom` tool:

```json
{
  "toolVisibility": "after-first-use"
}
```

The default remains `"always"`, so existing installations keep their current behavior.

In lazy mode, the extension removes only `intercom` from Pi's active tool set at session startup. This keeps its provider schema and prompt contribution out of sessions that never use intercom, while broker reception and the child-only `contact_supervisor` tool remain available.

The tool is restored for the current session runtime when:

- an inbound broker message is about to enter model context;
- the compose overlay successfully sends a message; or
- `/skill:pi-intercom` is submitted, or the bundled `SKILL.md` is read successfully.

The bundled skill stays discoverable so an agent can initiate the first outgoing use without carrying the full tool schema from startup. Local in-process subagent relay traffic does not reveal the generic tool. Activation also restores only a tool this policy removed, preserving external restrictive tool selections.

## Validation

- `npm test` — 194/194 passed
- isolated live Pi SDK probe — verified that both the tool and its prompt contribution are absent before use and restored on `/skill:pi-intercom`
- `npm pack --dry-run` — required runtime and skill files included
- `git diff --check`
