### PR TITLE
feat: report current Herdr session locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ The agent can list sessions and send messages using the `intercom` tool. Tool ca
 // List active sessions
 intercom({ action: "list" })
 // → **Current session:**
-// → • executor (20d43841) — ~/projects/api (claude-sonnet-4 · 42% ctx) [self, idle]
+// → • executor (20d43841) — ~/projects/api (claude-sonnet-4 · 42% ctx) · Herdr Platform [w5] / API [w5:t2] / pane w5:p4 [self, idle]
 // → **Other sessions:**
-// → • research (6332faab) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
+// → • research (6332faab) — ~/projects/api (claude-sonnet-4) · not under Herdr [same cwd, thinking]
 
 // List only peers in the same working directory
 intercom({ action: "list-cwd" })
@@ -378,7 +378,7 @@ Only registered in sessions where `pi-subagents` supplied the required child bri
 
 ### intercom actions
 
-**`list`** — Returns the current session plus other active intercom-connected sessions with name, short ID, working directory, model, and live status. Status is derived automatically from Pi lifecycle events: `idle`, `thinking`, or `tool:<name>`.
+**`list`** — Returns the current session plus other active intercom-connected sessions with name, short ID, working directory, model, live status, and explicit Herdr location. For Herdr-hosted sessions, the broker joins the process's stable Pi session identity against one fresh `herdr api snapshot` per list request and returns readable workspace/tab labels together with their opaque IDs and the diagnostic pane ID. Workspace and tab are not registration-time values and are not cached, so moving a pane is reflected by the next list. `herdrLocation.status` is `current`, `not_hosted`, or `unavailable`; unavailable results include a reason such as `pane_missing` or `herdr_unavailable` rather than inviting inference from cwd or session name. A Herdr command failure does not prevent the rest of the roster from being returned. When no connected session advertises Herdr hosting, `list` does not invoke Herdr and preserves the ordinary roster shape and rendering without location lines. `herdrPaneId` is the launch alias and may be stale after a move; consumers needing the current diagnostic pane ID must use `herdrLocation.paneId`. Pane IDs are diagnostic metadata, not intercom addressing handles. Status is derived automatically from Pi lifecycle events: `idle`, `thinking`, or `tool:<name>`.
 
 **`send`** — Sends a message to the specified session and returns immediately after delivery. If the destination has exactly one pending inbound ask, `send` infers the message is its answer and returns `Reply sent to <target> (inferred from pending ask)`. During a turn triggered by an inbound ask, a non-reply `send` to a different target is rejected so a guessed parent/root CWD cannot receive an accidental reply. Zero or multiple pending-ask matches remain unthreaded sends outside the active ask turn. Set `confirmSend: true` to confirm ordinary and inferred sends. A caller-supplied `replyTo` skips confirmation. `to` alone resolves globally across all live sessions. `cwd` alone targets the sole live peer in that directory. `to` plus `cwd` requires that peer to be in the directory. With `openProjectPaneIfMissing: true`, pi-intercom opens a visible Herdr project pane, starts Pi there, waits for that session to register, then delivers the message through normal intercom routing.
 

--- a/broker/broker.ts
+++ b/broker/broker.ts
@@ -22,6 +22,7 @@ import { EXACT_SEND_FEATURE, EXTENSION_BUS_FEATURE } from "../types.ts";
 import type { DeliveryState, SessionInfo, Message, BrokerMessage, ExtensionCapability, MessageControl } from "../types.ts";
 import { ExtensionStateManager } from "./extension-state.ts";
 import { assertNoLiveBroker } from "./runtime-claim.ts";
+import { resolveHerdrLocations } from "../herdr-location.ts";
 
 const INTERCOM_DIR = getIntercomDirPath();
 const LISTEN_TARGET = getBrokerListenTarget();
@@ -62,6 +63,9 @@ interface ConnectedSession {
   lastPresenceBroadcastAt: number;
   ownerOrder: number;
   extensions?: ExtensionCapability[];
+  /** Stable Pi session identity used only for live Herdr snapshot joins. This
+   * is a self-asserted local-client hint, not authenticated location evidence. */
+  herdrSessionPath?: string;
 }
 
 interface DeliveryRecord {
@@ -473,6 +477,7 @@ class IntercomBroker {
           lastActivity: session.lastActivity,
           ...(session.status !== undefined ? { status: session.status } : {}),
           ...(session.tmuxPane !== undefined ? { tmuxPane: session.tmuxPane } : {}),
+          ...(session.herdrPaneId !== undefined ? { herdrPaneId: session.herdrPaneId } : {}),
           trustedLocal: typeof LISTEN_TARGET === "string" && process.platform !== "win32",
         };
 
@@ -484,6 +489,7 @@ class IntercomBroker {
           lastPresenceBroadcastAt: Date.now(),
           ownerOrder: previous?.ownerOrder ?? this.nextOwnerOrder++,
           extensions,
+          ...(session.herdrSessionPath ? { herdrSessionPath: session.herdrSessionPath } : {}),
         };
         this.sessions.set(key, connectedSession);
         this.disconnectedSessions.delete(key);
@@ -596,7 +602,26 @@ class IntercomBroker {
         const sessions = Array.from(this.sessions.values())
           .filter(session => sameScope(session.scopeId, requester.scopeId))
           .map(s => s.info);
-        writeMessage(socket, { type: "sessions", requestId: clientMessage.requestId, sessions });
+        const requestId = clientMessage.requestId;
+        // Resolve all hosted panes from one bounded live snapshot. Never retain
+        // the result: moved panes must be re-resolved by the next list request.
+        const herdrSessionPaths = new Map(
+          Array.from(this.sessions.values())
+            .filter(session => sameScope(session.scopeId, requester.scopeId) && session.herdrSessionPath)
+            .map(session => [session.info.id, session.herdrSessionPath!] as const),
+        );
+        void resolveHerdrLocations(sessions, { sessionPaths: herdrSessionPaths })
+          .then((resolvedSessions) => writeMessage(socket, { type: "sessions", requestId, sessions: resolvedSessions }))
+          .catch((cause) => {
+            const detail = cause instanceof Error ? cause.message : String(cause);
+            const fallback = sessions.map((session) => ({
+              ...session,
+              herdrLocation: session.herdrPaneId
+                ? { status: "unavailable" as const, paneId: session.herdrPaneId, reason: "command_failed" as const, detail }
+                : { status: "not_hosted" as const },
+            }));
+            writeMessage(socket, { type: "sessions", requestId, sessions: fallback });
+          });
         break;
       }
 

--- a/broker/protocol.ts
+++ b/broker/protocol.ts
@@ -13,6 +13,27 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isHerdrLocation(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value.status === "not_hosted") return true;
+  if (value.status === "unavailable") {
+    return typeof value.paneId === "string"
+      && (value.reason === "herdr_unavailable"
+        || value.reason === "unsupported"
+        || value.reason === "command_failed"
+        || value.reason === "pane_missing"
+        || value.reason === "invalid_response")
+      && (value.detail === undefined || typeof value.detail === "string");
+  }
+  if (value.status !== "current" || !isRecord(value.workspace) || !isRecord(value.tab)) return false;
+  return typeof value.workspace.id === "string"
+    && typeof value.workspace.label === "string"
+    && typeof value.tab.id === "string"
+    && typeof value.tab.label === "string"
+    && typeof value.paneId === "string"
+    && typeof value.refreshedAt === "number";
+}
+
 function isMessageReceiptStatus(value: unknown): value is MessageReceiptStatus {
   return value === "receiver_received"
     || value === "queued"
@@ -168,6 +189,12 @@ export function isSessionInfo(value: unknown): value is SessionInfo {
   if (value.tmuxPane !== undefined && typeof value.tmuxPane !== "string") {
     return false;
   }
+  if (value.herdrPaneId !== undefined && typeof value.herdrPaneId !== "string") {
+    return false;
+  }
+  if (value.herdrLocation !== undefined && !isHerdrLocation(value.herdrLocation)) {
+    return false;
+  }
 
   return value.trustedLocal === undefined || typeof value.trustedLocal === "boolean";
 }
@@ -201,6 +228,12 @@ export function isSessionRegistration(value: unknown): value is SessionRegistrat
     return false;
   }
   if (value.tmuxPane !== undefined && typeof value.tmuxPane !== "string") {
+    return false;
+  }
+  if (value.herdrPaneId !== undefined && typeof value.herdrPaneId !== "string") {
+    return false;
+  }
+  if (value.herdrSessionPath !== undefined && typeof value.herdrSessionPath !== "string") {
     return false;
   }
 

--- a/herdr-location.test.ts
+++ b/herdr-location.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveHerdrLocations } from "./herdr-location.ts";
+import { createHerdrClient, type HerdrClient, type HerdrResult } from "./project-agent.ts";
+import type { SessionInfo } from "./types.ts";
+
+function session(id: string, herdrPaneId?: string): SessionInfo {
+  return {
+    id,
+    name: id,
+    cwd: "/repo",
+    model: "test",
+    pid: 1,
+    startedAt: 1,
+    lastActivity: 1,
+    ...(herdrPaneId ? { herdrPaneId } : {}),
+  };
+}
+
+function snapshot(workspaceId: string, workspaceLabel: string, tabId: string, tabLabel: string, paneId = "pane-1"): unknown {
+  return {
+    snapshot: {
+      panes: [
+        { pane_id: paneId, tab_id: tabId, workspace_id: workspaceId, agent_session: { kind: "path", source: "herdr:pi", value: "/sessions/hosted.jsonl" } },
+        { pane_id: "pane-2", tab_id: tabId, workspace_id: workspaceId },
+      ],
+      tabs: [{ tab_id: tabId, workspace_id: workspaceId, label: tabLabel }],
+      workspaces: [{ workspace_id: workspaceId, label: workspaceLabel }],
+    },
+  };
+}
+
+function client(results: HerdrResult<unknown>[]): HerdrClient & { calls: string[][] } {
+  const calls: string[][] = [];
+  return {
+    calls,
+    async run<T>(args: string[]): Promise<HerdrResult<T>> {
+      calls.push(args);
+      return results.shift() as HerdrResult<T>;
+    },
+  };
+}
+
+test("does not invoke Herdr or change roster shape when every session is non-Herdr", async () => {
+  const herdr = client([]);
+  const inputs = [session("shell-a"), session("shell-b")];
+  const resolved = await resolveHerdrLocations(inputs, { client: herdr });
+
+  assert.strictEqual(resolved, inputs);
+  assert.deepEqual(resolved, inputs);
+  assert.deepEqual(herdr.calls, []);
+  assert.equal(resolved.some((item) => "herdrLocation" in item), false);
+});
+
+test("resolves hosted and non-Herdr sessions from one current snapshot", async () => {
+  const herdr = client([{ ok: true, data: snapshot("workspace-1", "Platform", "tab-1", "API") }]);
+  const resolved = await resolveHerdrLocations([
+    session("hosted", "pane-1"),
+    session("second-hosted", "pane-2"),
+    session("shell"),
+  ], { client: herdr, now: () => 42 });
+
+  assert.deepEqual(herdr.calls, [["api", "snapshot"]]);
+  assert.deepEqual(resolved[0]!.herdrLocation, {
+    status: "current",
+    workspace: { id: "workspace-1", label: "Platform" },
+    tab: { id: "tab-1", label: "API" },
+    paneId: "pane-1",
+    refreshedAt: 42,
+  });
+  assert.equal(resolved[1]!.herdrLocation?.status, "current");
+  assert.deepEqual(resolved[2]!.herdrLocation, { status: "not_hosted" });
+});
+
+test("refreshes a moved pane instead of retaining its old tab or workspace", async () => {
+  const herdr = client([
+    { ok: true, data: snapshot("workspace-1", "Platform", "tab-1", "API", "pane-before") },
+    { ok: true, data: snapshot("workspace-2", "Research", "tab-2", "Review", "pane-after") },
+  ]);
+  const hosted = session("hosted", "launch-pane");
+  const sessionPaths = new Map([[hosted.id, "/sessions/hosted.jsonl"]]);
+
+  const first = await resolveHerdrLocations([hosted], { client: herdr, now: () => 10, sessionPaths });
+  const second = await resolveHerdrLocations([hosted], { client: herdr, now: () => 20, sessionPaths });
+
+  assert.equal(first[0]!.herdrLocation?.status === "current" && first[0]!.herdrLocation.workspace.id, "workspace-1");
+  assert.equal(first[0]!.herdrLocation?.status === "current" && first[0]!.herdrLocation.paneId, "pane-before");
+  assert.equal(second[0]!.herdrLocation?.status === "current" && second[0]!.herdrLocation.workspace.id, "workspace-2");
+  assert.equal(second[0]!.herdrLocation?.status === "current" && second[0]!.herdrLocation.tab.id, "tab-2");
+  assert.equal(second[0]!.herdrLocation?.status === "current" && second[0]!.herdrLocation.paneId, "pane-after");
+  assert.equal(herdr.calls.length, 2);
+});
+
+test("marks a registered pane missing from the live snapshot as unavailable", async () => {
+  const herdr = client([{ ok: true, data: snapshot("workspace-1", "Platform", "tab-1", "API", "other-pane") }]);
+  const [resolved] = await resolveHerdrLocations([session("stale", "gone-pane")], { client: herdr });
+
+  assert.deepEqual(resolved!.herdrLocation, {
+    status: "unavailable",
+    paneId: "gone-pane",
+    reason: "pane_missing",
+    detail: "The hosted Pi session is absent from the current Herdr snapshot.",
+  });
+});
+
+test("does not confidently choose between duplicate Pi session identities", async () => {
+  const data = snapshot("workspace-1", "Platform", "tab-1", "API") as {
+    snapshot: { panes: Array<Record<string, unknown>> };
+  };
+  data.snapshot.panes[1]!.agent_session = { kind: "path", source: "herdr:pi", value: "/sessions/hosted.jsonl" };
+  const herdr = client([{ ok: true, data }]);
+  const hosted = session("hosted", "launch-pane");
+  const [resolved] = await resolveHerdrLocations([hosted], {
+    client: herdr,
+    sessionPaths: new Map([[hosted.id, "/sessions/hosted.jsonl"]]),
+  });
+
+  assert.deepEqual(resolved!.herdrLocation, {
+    status: "unavailable",
+    paneId: "launch-pane",
+    reason: "invalid_response",
+    detail: "Multiple Herdr panes advertise the same Pi session identity.",
+  });
+});
+
+test("matches the live Herdr snapshot contract when running under Herdr", {
+  skip: !process.env.HERDR_ENV || !process.env.HERDR_PANE_ID,
+}, async () => {
+  const paneId = process.env.HERDR_PANE_ID!;
+  const liveClient = createHerdrClient();
+  const initial = await liveClient.run<{ snapshot?: { panes?: Array<{ pane_id?: string; agent_session?: { kind?: string; source?: string; value?: string } }> } }>(["api", "snapshot"]);
+  assert.equal(initial.ok, true, JSON.stringify(initial));
+  if (!initial.ok) return;
+  const livePane = initial.data.snapshot?.panes?.find((pane) => pane.pane_id === paneId);
+  const sessionPath = livePane?.agent_session?.kind === "path" && livePane.agent_session.source === "herdr:pi"
+    ? livePane.agent_session.value
+    : undefined;
+  assert.ok(sessionPath, JSON.stringify(livePane));
+  const liveSession = session("live", "obsolete-launch-alias");
+  const [resolved] = await resolveHerdrLocations([liveSession], {
+    client: liveClient,
+    sessionPaths: new Map([[liveSession.id, sessionPath!]]),
+  });
+  assert.equal(resolved!.herdrLocation?.status, "current", JSON.stringify(resolved!.herdrLocation));
+  if (resolved!.herdrLocation?.status === "current") {
+    assert.ok(resolved.herdrLocation.workspace.id);
+    assert.ok(resolved.herdrLocation.workspace.label);
+    assert.ok(resolved.herdrLocation.tab.id);
+    assert.ok(resolved.herdrLocation.tab.label);
+  }
+});
+
+test("preserves list data and marks location unavailable when the Herdr command fails", async () => {
+  const herdr = client([{ ok: false, error: { code: "HERDR_UNAVAILABLE", message: "missing binary" } }]);
+  const inputs = [session("hosted", "pane-1"), session("shell")];
+  const resolved = await resolveHerdrLocations(inputs, { client: herdr });
+
+  assert.equal(resolved.length, 2);
+  assert.deepEqual(resolved[0]!.herdrLocation, {
+    status: "unavailable",
+    paneId: "pane-1",
+    reason: "herdr_unavailable",
+    detail: "missing binary",
+  });
+  assert.deepEqual(resolved[1]!.herdrLocation, { status: "not_hosted" });
+});

--- a/herdr-location.ts
+++ b/herdr-location.ts
@@ -1,0 +1,137 @@
+import type { HerdrClient } from "./project-agent.ts";
+import { createHerdrClient } from "./project-agent.ts";
+import type { HerdrLocation, SessionInfo } from "./types.ts";
+
+type RecordValue = Record<string, unknown>;
+
+let activeSnapshot: Promise<Awaited<ReturnType<HerdrClient["run"]>>> | undefined;
+
+function readCurrentSnapshot(client: HerdrClient): Promise<Awaited<ReturnType<HerdrClient["run"]>>> {
+  if (activeSnapshot) return activeSnapshot;
+  activeSnapshot = client.run(["api", "snapshot"], { timeoutMs: 3_000 });
+  void activeSnapshot.finally(() => { activeSnapshot = undefined; });
+  return activeSnapshot;
+}
+
+function record(value: unknown): RecordValue | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as RecordValue : undefined;
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const item = record(value)?.[key];
+  return typeof item === "string" && item.length > 0 ? item : undefined;
+}
+
+function recordsField(value: unknown, key: string): RecordValue[] | undefined {
+  const items = record(value)?.[key];
+  return Array.isArray(items) && items.every((item) => record(item) !== undefined)
+    ? items as RecordValue[]
+    : undefined;
+}
+
+function unavailable(paneId: string, reason: Extract<HerdrLocation, { status: "unavailable" }>['reason'], detail?: string): HerdrLocation {
+  return { status: "unavailable", paneId, reason, ...(detail ? { detail } : {}) };
+}
+
+/**
+ * Resolve every Herdr-hosted session against one live Herdr snapshot. The
+ * registration-time pane id is only a stable join key; workspace and tab are
+ * always taken from this snapshot and are never cached.
+ */
+export async function resolveHerdrLocations(
+  sessions: SessionInfo[],
+  options: { client?: HerdrClient; now?: () => number; sessionPaths?: ReadonlyMap<string, string> } = {},
+): Promise<SessionInfo[]> {
+  const hosted = sessions.filter((session) => session.herdrPaneId);
+  if (hosted.length === 0) {
+    // Preserve the upstream roster byte-for-byte in installations where Herdr
+    // is not in use: no subprocess and no additive rendering/state.
+    return sessions;
+  }
+
+  const client = options.client ?? createHerdrClient();
+  // Injected clients remain isolated for deterministic tests. Production calls
+  // share only an already-in-flight snapshot, collapsing concurrent list bursts
+  // without caching a result for a later request.
+  const snapshotResult = await (options.client
+    ? client.run(["api", "snapshot"], { timeoutMs: 3_000 })
+    : readCurrentSnapshot(client));
+  if (snapshotResult.ok === false) {
+    const reason = snapshotResult.error.code === "HERDR_UNAVAILABLE"
+      ? "herdr_unavailable"
+      : snapshotResult.error.code === "HERDR_UNSUPPORTED_VERSION"
+        ? "unsupported"
+        : "command_failed";
+    return sessions.map((session) => session.herdrPaneId
+      ? { ...session, herdrLocation: unavailable(session.herdrPaneId, reason, snapshotResult.error.message) }
+      : { ...session, herdrLocation: { status: "not_hosted" } });
+  }
+
+  const envelope = record(snapshotResult.data);
+  const snapshot = record(envelope?.snapshot) ?? envelope;
+  const panes = recordsField(snapshot, "panes");
+  const tabs = recordsField(snapshot, "tabs");
+  const workspaces = recordsField(snapshot, "workspaces");
+  if (!panes || !tabs || !workspaces) {
+    return sessions.map((session) => session.herdrPaneId
+      ? { ...session, herdrLocation: unavailable(session.herdrPaneId, "invalid_response", "Herdr snapshot omitted panes, tabs, or workspaces.") }
+      : { ...session, herdrLocation: { status: "not_hosted" } });
+  }
+
+  const refreshedAt = (options.now ?? Date.now)();
+  const keyed = (items: RecordValue[], key: string): Array<[string, RecordValue]> => items.flatMap((item) => {
+    const id = stringField(item, key);
+    return id ? [[id, item]] : [];
+  });
+  const panesById = new Map(keyed(panes, "pane_id"));
+  const panesBySessionPath = new Map<string, RecordValue | null>();
+  for (const pane of panes) {
+    const agentSession = record(pane.agent_session);
+    const sessionPath = agentSession
+      && stringField(agentSession, "kind") === "path"
+      && stringField(agentSession, "source") === "herdr:pi"
+      ? stringField(agentSession, "value")
+      : undefined;
+    if (!sessionPath) continue;
+    panesBySessionPath.set(sessionPath, panesBySessionPath.has(sessionPath) ? null : pane);
+  }
+  const tabsById = new Map(keyed(tabs, "tab_id"));
+  const workspacesById = new Map(keyed(workspaces, "workspace_id"));
+
+  return sessions.map((session): SessionInfo => {
+    const paneId = session.herdrPaneId;
+    if (!paneId) return { ...session, herdrLocation: { status: "not_hosted" } };
+    // Pane ids are workspace-qualified launch aliases and change when a pane is
+    // moved. New clients register the Pi session file, which Herdr carries with
+    // the terminal across moves. Older clients fall back to a direct pane-id
+    // lookup and explicitly become unavailable after a move.
+    const sessionPath = options.sessionPaths?.get(session.id);
+    const pane = sessionPath
+      ? panesBySessionPath.get(sessionPath)
+      : panesById.get(paneId);
+    if (pane === null) {
+      return { ...session, herdrLocation: unavailable(paneId, "invalid_response", "Multiple Herdr panes advertise the same Pi session identity.") };
+    }
+    if (!pane) return { ...session, herdrLocation: unavailable(paneId, "pane_missing", "The hosted Pi session is absent from the current Herdr snapshot.") };
+    const currentPaneId = stringField(pane, "pane_id");
+    const tabId = stringField(pane, "tab_id");
+    const workspaceId = stringField(pane, "workspace_id");
+    const tab = tabId ? tabsById.get(tabId) : undefined;
+    const workspace = workspaceId ? workspacesById.get(workspaceId) : undefined;
+    const tabLabel = stringField(tab, "label");
+    const workspaceLabel = stringField(workspace, "label");
+    if (!currentPaneId || !tabId || !workspaceId || !tabLabel || !workspaceLabel) {
+      return { ...session, herdrLocation: unavailable(paneId, "invalid_response", "Herdr snapshot could not resolve the pane's current labeled tab and workspace.") };
+    }
+    return {
+      ...session,
+      herdrLocation: {
+        status: "current",
+        workspace: { id: workspaceId, label: workspaceLabel },
+        tab: { id: tabId, label: tabLabel },
+        paneId: currentPaneId,
+        refreshedAt,
+      },
+    };
+  });
+}

--- a/index.ts
+++ b/index.ts
@@ -517,6 +517,14 @@ function currentTmuxPane(): string | undefined {
   const pane = process.env.TMUX_PANE?.trim();
   return pane ? pane : undefined;
 }
+// Herdr exports a launch-time pane alias to hosted processes. Its visible,
+// workspace-qualified id can change when the pane moves, so registration also
+// carries the stable Pi session file and the broker resolves both against a
+// fresh snapshot. Workspace and tab ids are intentionally never registered.
+function currentHerdrPane(): string | undefined {
+  const pane = process.env.HERDR_PANE_ID?.trim();
+  return pane ? pane : undefined;
+}
 function formatIntercomContactSnippet(sessionId: string): string {
   return `Use pi-intercom: intercom({ action: "send", to: "${sessionId}", message: "..." })`;
 }
@@ -528,13 +536,22 @@ function formatSessionLabel(session: SessionInfo, duplicates: Set<string>): stri
     ? `${session.name} (${session.id.slice(0, 8)})`
     : session.name;
 }
+function formatHerdrLocation(session: SessionInfo): string {
+  const location = session.herdrLocation;
+  if (!location) return "";
+  if (location.status === "not_hosted") return "not under Herdr";
+  if (location.status === "unavailable") return `Herdr location unavailable: ${location.reason} (pane ${location.paneId})`;
+  return `Herdr ${location.workspace.label} [${location.workspace.id}] / ${location.tab.label} [${location.tab.id}] / pane ${location.paneId}`;
+}
 function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: boolean, idPrefix: string): string {
   const name = session.name || "Unnamed session";
   const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
   const pane = session.tmuxPane ? ` · tmux ${session.tmuxPane}` : "";
-  return `• ${name} (${idPrefix}) — ${session.cwd} (${session.model}${formatContextUsage(session)}${pane})${suffix}`;
+  const herdrLocation = formatHerdrLocation(session);
+  const herdr = herdrLocation ? ` · ${herdrLocation}` : "";
+  return `• ${name} (${idPrefix}) — ${session.cwd} (${session.model}${formatContextUsage(session)}${pane})${herdr}${suffix}`;
 }
 function previewText(value: unknown, maxLength = 72): string | undefined {
   if (typeof value !== "string") {
@@ -869,6 +886,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
 
     const identity = buildPresenceIdentity(pi, currentIntercomSessionId ?? currentSessionId);
     const tmuxPane = currentTmuxPane();
+    const herdrPaneId = currentHerdrPane();
+    const herdrSessionPath = herdrPaneId ? liveContext.sessionManager.getSessionFile() : undefined;
     return {
       ...identity,
       cwd: liveContext.cwd,
@@ -878,6 +897,8 @@ export default function piIntercomExtension(pi: ExtensionAPI) {
       lastActivity: Date.now(),
       status: currentStatus(),
       ...(tmuxPane ? { tmuxPane } : {}),
+      ...(herdrPaneId ? { herdrPaneId } : {}),
+      ...(herdrSessionPath ? { herdrSessionPath } : {}),
       ...(localExtensions.size > 0
         ? {
             extensions: currentExtensionCapabilities(),

--- a/intercom.integration.test.ts
+++ b/intercom.integration.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { EventEmitter, once } from "node:events";
@@ -30,14 +30,20 @@ const childEnvKeys = [
 const sharedHomeDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-home-"));
 const previousHome = process.env.HOME;
 const previousUserProfile = process.env.USERPROFILE;
+const previousHerdrPaneId = process.env.HERDR_PANE_ID;
 process.env.HOME = sharedHomeDir;
 process.env.USERPROFILE = sharedHomeDir;
+// Synthetic extension harnesses are not running in the parent test runner's
+// Herdr pane. Individual Herdr integration cases register an explicit pane id.
+delete process.env.HERDR_PANE_ID;
 const { IntercomClient } = await import("./broker/client.ts");
 const { getTsxCliPath } = await import("./broker/spawn.ts");
 const { getAskTimeoutMs, getConfigPath } = await import("./config.ts");
 process.on("exit", () => {
   process.env.HOME = previousHome;
   process.env.USERPROFILE = previousUserProfile;
+  if (previousHerdrPaneId === undefined) delete process.env.HERDR_PANE_ID;
+  else process.env.HERDR_PANE_ID = previousHerdrPaneId;
   rmSync(sharedHomeDir, { recursive: true, force: true });
 });
 
@@ -905,6 +911,94 @@ test("broker rejects changed message content after a rebound exact-target failur
     raw.socket.destroy();
     await replacement.disconnect().catch(() => undefined);
     await cleanup();
+  }
+});
+
+test("all-non-Herdr rosters preserve upstream structured and text output without invoking Herdr", { concurrency: false }, async () => {
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-no-herdr-"));
+  const marker = path.join(fixtureDir, "invoked");
+  const fixtureBin = path.join(fixtureDir, "herdr-must-not-run");
+  writeFileSync(fixtureBin, `#!/bin/sh\ntouch ${JSON.stringify(marker)}\nexit 99\n`);
+  chmodSync(fixtureBin, 0o755);
+  const previousHerdrBin = process.env.HERDR_BIN;
+  process.env.HERDR_BIN = fixtureBin;
+  let setup: Awaited<ReturnType<typeof setupClients>>;
+  try {
+    setup = await setupClients();
+  } finally {
+    if (previousHerdrBin === undefined) delete process.env.HERDR_BIN;
+    else process.env.HERDR_BIN = previousHerdrBin;
+  }
+  const harness = createExtensionHarness("plain-worker", { sessionId: "plain-worker-session" });
+
+  try {
+    const structured = await setup.planner.listSessions();
+    assert.equal(structured.every((session) => !("herdrLocation" in session)), true);
+    assert.equal(existsSync(marker), false);
+
+    const { default: piIntercomExtension } = await import("./index.ts");
+    piIntercomExtension(harness.pi as never);
+    await harness.emitLifecycle("session_start");
+    await waitForSessionByName(setup.planner, "plain-worker");
+    const intercomTool = harness.tools.find((tool) => tool.name === "intercom")!;
+    const result = await intercomTool.execute("plain-list", { action: "list" }, new AbortController().signal, undefined, harness.ctx);
+    const text = result.content.map((part) => part.text).join("\n");
+    assert.match(text, /Current session:/);
+    assert.match(text, /Other sessions:/);
+    assert.doesNotMatch(text, /Herdr|not under/);
+    assert.equal(existsSync(marker), false);
+  } finally {
+    await harness.emitLifecycle("session_shutdown");
+    await setup.cleanup();
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("broker resolves a registered Herdr pane through one live snapshot", { concurrency: false }, async () => {
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), "pi-intercom-herdr-"));
+  const fixtureBin = path.join(fixtureDir, "herdr-fixture");
+  writeFileSync(fixtureBin, `#!/usr/bin/env node
+console.log(JSON.stringify({ result: { snapshot: {
+  panes: [{ pane_id: "pane-current", tab_id: "tab-current", workspace_id: "workspace-current", agent_session: { kind: "path", source: "herdr:pi", value: "/sessions/worker.jsonl" } }],
+  tabs: [{ tab_id: "tab-current", workspace_id: "workspace-current", label: "Review" }],
+  workspaces: [{ workspace_id: "workspace-current", label: "Research" }]
+} } }));
+`);
+  chmodSync(fixtureBin, 0o755);
+  const previousHerdrBin = process.env.HERDR_BIN;
+  process.env.HERDR_BIN = fixtureBin;
+  let setup: Awaited<ReturnType<typeof setupClients>>;
+  try {
+    setup = await setupClients();
+  } finally {
+    if (previousHerdrBin === undefined) delete process.env.HERDR_BIN;
+    else process.env.HERDR_BIN = previousHerdrBin;
+  }
+  const worker = new IntercomClient();
+
+  try {
+    await worker.connect({
+      name: "herdr-worker",
+      cwd: repoDir,
+      model: "test-model",
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+      herdrPaneId: "pane-at-launch",
+      herdrSessionPath: "/sessions/worker.jsonl",
+    });
+    const session = await waitForSessionByName(setup.planner, "herdr-worker");
+    assert.deepEqual(session.herdrLocation && { ...session.herdrLocation, refreshedAt: 0 }, {
+      status: "current",
+      workspace: { id: "workspace-current", label: "Research" },
+      tab: { id: "tab-current", label: "Review" },
+      paneId: "pane-current",
+      refreshedAt: 0,
+    });
+  } finally {
+    await worker.disconnect().catch(() => undefined);
+    await setup.cleanup();
+    rmSync(fixtureDir, { recursive: true, force: true });
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cwd.ts",
     "extension-api.ts",
     "format-context.ts",
+    "herdr-location.ts",
     "project-agent.ts",
     "reply-tracker.ts",
     "broker/**/*.ts",
@@ -18,7 +19,7 @@
     "skills/**/*"
   ],
   "scripts": {
-    "test": "tsx --test broker/client.test.ts broker/client-liveness.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/runtime-claim.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts project-agent.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
+    "test": "tsx --test herdr-location.test.ts broker/client.test.ts broker/client-liveness.test.ts broker/extension.test.ts broker/framing.test.ts broker/paths.test.ts broker/runtime-claim.test.ts broker/spawn.test.ts config.test.ts cwd.test.ts format-context.test.ts project-agent.test.ts reply-tracker.test.ts intercom.integration.test.ts test/inline-message.test.ts test/overlay-width.test.ts"
   },
   "keywords": [
     "pi-package"

--- a/project-agent.ts
+++ b/project-agent.ts
@@ -65,7 +65,7 @@ function normalizeCode(raw: unknown): HerdrErrorCode {
   return "VALIDATION_ERROR";
 }
 
-function createHerdrClient(options: { bin?: string; spawn?: SpawnHerdr } = {}): HerdrClient {
+export function createHerdrClient(options: { bin?: string; spawn?: SpawnHerdr } = {}): HerdrClient {
   const bin = options.bin ?? process.env.HERDR_BIN ?? "herdr";
   const spawnImpl = options.spawn ?? spawn;
   return {

--- a/skills/pi-intercom/SKILL.md
+++ b/skills/pi-intercom/SKILL.md
@@ -71,7 +71,8 @@ Before sending, verify who's connected:
 
 ```typescript
 intercom({ action: "list" })
-// → Shows all connected sessions with names, cwd, models, and live status (`idle`, `thinking`, `tool:<name>`)
+// → Shows all connected sessions with names, cwd, models, live status, and
+//   current Herdr workspace/tab/pane (or explicit not-hosted/unavailable state)
 ```
 
 ### Pattern 3: Reply Naturally
@@ -235,7 +236,7 @@ new visible project panes should go through the supervisor.
 | `ask` | Blocks until reply (10 min default, configurable with `PI_INTERCOM_ASK_TIMEOUT_MS`) | You need an answer to continue |
 | `reply` | Responds to the active or pending inbound ask | You were asked something and need to answer naturally |
 | `pending` | Lists unresolved inbound asks | You need to see who is waiting before replying |
-| `list` | Returns all sessions with live status | You need to discover targets or choose an idle peer |
+| `list` | Returns all sessions with live status and freshly resolved Herdr location | You need to discover targets or choose an idle peer |
 | `status` | Returns your connection state | Troubleshooting |
 
 ## Visible Peer Sessions
@@ -273,6 +274,10 @@ if (result.isError && result.content[0].text.includes("Already waiting")) {
 - **Explicit replies skip confirmation**: A caller-supplied `replyTo` skips the dialog
 
 ## Best Practices
+
+### Treat list location as authoritative
+
+For a Herdr-hosted session, `list` displays readable workspace and tab labels plus stable opaque IDs and a diagnostic pane ID. The workspace/tab values come from a fresh bounded Herdr snapshot for that list request, joined by the Pi session identity that remains stable when Herdr changes the workspace-qualified pane ID, so use them instead of inferring location from cwd or session name. `not under Herdr` means the session did not register a Herdr pane. `Herdr location unavailable` means it did register one, but the current snapshot failed or no longer contained that pane. Use `herdrLocation.paneId`, not the launch-time `herdrPaneId`, when current diagnostic pane metadata is needed. Do not use pane IDs as intercom addressing handles; target the session name or intercom session ID. If no connected session is Herdr-hosted, `list` does not call Herdr or add location lines.
 
 ### Use `ask` for blocking workflows
 

--- a/types.ts
+++ b/types.ts
@@ -10,6 +10,23 @@ export interface DeliveryDetails {
   outcomeKnown: boolean;
 }
 
+export type HerdrLocation =
+  | {
+      status: "current";
+      workspace: { id: string; label: string };
+      tab: { id: string; label: string };
+      paneId: string;
+      /** Time when the broker requested the live Herdr snapshot. */
+      refreshedAt: number;
+    }
+  | { status: "not_hosted" }
+  | {
+      status: "unavailable";
+      paneId: string;
+      reason: "herdr_unavailable" | "unsupported" | "command_failed" | "pane_missing" | "invalid_response";
+      detail?: string;
+    };
+
 export interface SessionInfo {
   id: string;
   /** Broker-owned lifetime of this live endpoint. */
@@ -40,6 +57,11 @@ export interface SessionInfo {
    *  name, which is mutable — so a peer can live-resolve the current window
    *  from it via tmux when it needs to introspect or drive that pane. */
   tmuxPane?: string;
+  /** Launch-time Herdr pane alias. It may differ from the current pane id after a move. */
+  herdrPaneId?: string;
+  /** Present on list responses. `current` is freshly resolved for that request;
+   *  other states explicitly distinguish non-Herdr sessions from failures. */
+  herdrLocation?: HerdrLocation;
 }
 
 export interface Message {
@@ -99,8 +121,10 @@ export interface ExtensionCapability {
   ownerEligible: boolean;
 }
 
-export type SessionRegistration = Omit<SessionInfo, "id" | "endpointEpoch" | "peerUid" | "trustedLocal"> & {
+export type SessionRegistration = Omit<SessionInfo, "id" | "endpointEpoch" | "peerUid" | "trustedLocal" | "herdrLocation"> & {
   extensions?: ExtensionCapability[];
+  /** Broker-only join hint; never returned in the public roster. */
+  herdrSessionPath?: string;
 };
 
 export type ClientMessage =

--- a/ui/session-list.ts
+++ b/ui/session-list.ts
@@ -33,6 +33,14 @@ function shortSessionId(sessionId: string): string {
   return sessionId.slice(0, 8);
 }
 
+function herdrLocationText(session: SessionInfo): string | undefined {
+  const location = session.herdrLocation;
+  if (!location) return undefined;
+  if (location.status === "not_hosted") return "not under Herdr";
+  if (location.status === "unavailable") return `Herdr unavailable (${location.reason}, pane ${location.paneId})`;
+  return `${location.workspace.label} [${location.workspace.id}] / ${location.tab.label} [${location.tab.id}] / ${location.paneId}`;
+}
+
 function sessionTitle(session: SessionInfo, options?: { self?: boolean; sameCwd?: boolean }): string {
   const name = session.name || "Unnamed session";
   const tags = [options?.self ? "self" : undefined, options?.sameCwd ? "same cwd" : undefined]
@@ -121,6 +129,8 @@ export class SessionListOverlay implements Component {
     lines.push(row());
     lines.push(row(`  ${this.theme.fg("dim", sessionTitle(this.currentSession, { self: true }))}`));
     lines.push(row(`  ${this.theme.fg("dim", `${middleTruncate(this.currentSession.cwd, Math.max(8, contentWidth - 4))} • ${this.currentSession.model}`)}`));
+    const currentHerdrLocation = herdrLocationText(this.currentSession);
+    if (currentHerdrLocation) lines.push(row(`  ${this.theme.fg("dim", currentHerdrLocation)}`));
     lines.push(row());
     lines.push(border(`├${"─".repeat(contentWidth)}┤`));
     lines.push(row(this.theme.bold(" Other Sessions")));
@@ -145,6 +155,8 @@ export class SessionListOverlay implements Component {
 
         lines.push(row(`${prefix}${isSelected ? this.theme.fg("accent", title) : title}`));
         lines.push(row(`  ${this.theme.fg("dim", pathText)}`));
+        const sessionHerdrLocation = herdrLocationText(session);
+        if (sessionHerdrLocation) lines.push(row(`  ${this.theme.fg("dim", sessionHerdrLocation)}`));
         if (index < endIndex - 1) {
           lines.push(row());
         }


### PR DESCRIPTION
## Summary

Add optional, current Herdr topology to `intercom({ action: "list" })` so agents do not have to infer a peer's workspace or tab from its name/cwd.

For Herdr-hosted peers, list results include:

- current workspace label + ID
- current tab label + ID
- current pane ID
- refresh timestamp

The resolver reads one fresh bounded `herdr api snapshot` per list burst and joins panes by the Pi session path reported at registration. This survives Herdr pane moves, where the workspace-qualified pane ID changes while the process keeps its launch-time environment.

## Compatibility

This is inactive for ordinary non-Herdr users:

- when no peer advertises Herdr hosting, list returns the original roster unchanged
- no Herdr process is invoked
- no Herdr fields or text lines are added
- mixed rosters explicitly distinguish Herdr-hosted and non-hosted peers
- missing panes, duplicate session claims, schema drift, unavailable binaries, and command failures degrade to explicit unavailable location metadata without failing the roster

The session-path hint remains broker-private and is not exposed in public `SessionInfo` output. Pane location is display/diagnostic metadata, not an addressing or authentication primitive.

## Validation

- `npm test` — **212/212 passing**
- `git diff --check` — passing
- `npm pack --dry-run` — passing; new runtime module included
- live Herdr contract test executed against `herdr api snapshot`
- real move proof: a disposable pane moved between workspaces; its stable terminal/session identity resolved the new workspace, tab, and pane
- all-non-Herdr integration uses a sentinel `HERDR_BIN`; structured and text list calls leave the sentinel untouched and preserve the original output shape

The implementation was independently reviewed twice after the v0.13.0 rebase and move/non-Herdr fixes.
